### PR TITLE
feat(credits): pause a running turn when its user runs out of credits

### DIFF
--- a/migrations/versions/033_in_flight_credits.py
+++ b/migrations/versions/033_in_flight_credits.py
@@ -109,19 +109,17 @@ def upgrade() -> None:
     # is additive and every reader tolerates a missing index or an unvalidated
     # constraint.
     with op.get_context().autocommit_block():
-        # Drop the 5s cap for the concurrent work. CREATE INDEX CONCURRENTLY
-        # spends most of its life in two waits for transactions that can still
-        # see the table, and those are lock waits, so lock_timeout aborts them:
-        # on a table taking continuous writes a 5s cap fails the build almost
-        # every time and leaves an INVALID index behind. The statements below
-        # take no lock worth bounding — CONCURRENTLY and VALIDATE both yield to
-        # readers and writers — so the cap buys nothing here and costs the
-        # migration.
-        op.execute("SET lock_timeout = 0")
-        # NOT VALID skips the scan (SHARE UPDATE EXCLUSIVE, no heap validation);
-        # the VALIDATE that follows scans without blocking readers or writers.
-        # Every existing row holds the column default, so validation cannot
-        # fail — the pair is only about which lock the scan runs under.
+        # The cap stays on for the constraint DDL. NOT VALID skips the heap
+        # SCAN, not the LOCK: ADD CONSTRAINT ... CHECK takes ACCESS EXCLUSIVE
+        # either way, and so does the DROP above it — the reduced-lock ALTER
+        # forms are ADD FOREIGN KEY and VALIDATE, not this one. Skipping the
+        # scan makes the hold brief but does nothing about the WAIT, and an
+        # ACCESS EXCLUSIVE queued behind one long transaction parks every
+        # reader and writer of a hot run table behind it for as long as that
+        # transaction lives. Both tables are done here, before either scan
+        # below, so the exclusive work is over early rather than interleaved
+        # with a validation that can run for minutes.
+        op.execute("SET lock_timeout = '5s'")
         for table in ("conversation_responses", "subagent_runs"):
             constraint = f"ck_{table}_in_flight_credits_nonneg"
             op.execute(
@@ -137,7 +135,22 @@ def upgrade() -> None:
                     CHECK (in_flight_credits >= 0) NOT VALID
                 """
             )
-            op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {constraint}")
+
+        # Only now drop the cap, for the two kinds of statement that need it
+        # dropped. CREATE INDEX CONCURRENTLY spends most of its life in two
+        # waits for transactions that can still see the table, and those are
+        # lock waits, so lock_timeout aborts them: on a table taking continuous
+        # writes a 5s cap fails the build almost every time and leaves an
+        # INVALID index behind. VALIDATE takes SHARE UPDATE EXCLUSIVE and scans
+        # without blocking readers or writers, so it has nothing worth bounding
+        # either. Every existing row holds the column default, so validation
+        # cannot fail.
+        op.execute("SET lock_timeout = 0")
+        for table in ("conversation_responses", "subagent_runs"):
+            op.execute(
+                f"ALTER TABLE {table} "
+                f"VALIDATE CONSTRAINT ck_{table}_in_flight_credits_nonneg"
+            )
 
         # Drop before create, always. IF NOT EXISTS matches on NAME alone, so
         # on its own it adopts whatever index already wears the name: a failed

--- a/migrations/versions/033_in_flight_credits.py
+++ b/migrations/versions/033_in_flight_credits.py
@@ -1,0 +1,214 @@
+"""In-flight credit ledger columns on runs.
+
+A run's platform-credit spend is only visible today after finalize writes its
+usage row; between admission and settle the spend is dark. These columns let a
+live run heartbeat its own cumulative spend onto its own ledger row, and let a
+reader aggregate "unsettled in-flight spend per user" in one snapshot:
+
+- ``in_flight_credits``: monotone cumulative platform credits for this run,
+  written as an absolute value by the run's own heartbeat. Never incremented.
+- ``user_id``: denormalized so the per-user aggregate needs no join at read
+  time. Nullable on purpose: rows inserted by pre-gate code omit it, and the
+  aggregate never sees those rows (they stay at zero in-flight credits), so a
+  backfill would rewrite a large hot table for nothing. Contraction to
+  NOT NULL, if ever, follows the 017/018 expand/contract precedent.
+- ``usage_settled_at``: stamped in the same transaction as the run's usage
+  insert (or a recovery path's degraded settle). A row counts toward in-flight
+  spend until this is set, regardless of run status: terminal and
+  billing-settled are separate states, because a subagent run turns terminal
+  in one CAS while its usage is collected later.
+
+Those four semantics are a contract rather than incidental. These columns are
+read outside this service to split spend that is already billed from spend that
+is not, so changing the monotone write, the settle transaction, the nullability
+of ``user_id`` or the status-independence of the in-flight window all change
+what that split means.
+
+The partial indexes match the only read shape: SUM per user over unsettled
+rows that have actually heartbeated. Filtering on ``in_flight_credits > 0``
+keeps every pre-gate row and every old-worker row (which never heartbeats)
+out of the index and out of the aggregate, which is what makes the no-backfill
+rollout safe under a rolling deploy.
+
+``user_id IS NOT NULL`` is part of the predicate for a different reason: the
+aggregate reads per user, so an owner-less row with real spend on it is
+invisible to every reader while still costing index space. Excluding it makes
+that set cheap to ask about directly (``in_flight_credits > 0 AND user_id IS
+NULL``) instead of leaving it to hide inside a scan nobody runs.
+
+One further index covers the complement: settled rows that carried spend,
+keyed by ``parent_run_id``. Reconciling a turn family against what has already
+been billed asks the opposite question of the aggregate above -- which of this
+parent's children are done -- and neither index above can answer it, since both
+are keyed on ``user_id`` and their predicate excludes exactly the rows it
+needs. ``user_id`` rides in the INCLUDE so a reader can check a row's owner
+without leaving the index.
+
+Revision ID: 033
+Revises: 032
+
+NOTE (numbering): merge order is the rule — this is the next id free on main's
+head at the time it landed, not the id it was written under. A branch that
+renumbers behind it has to repoint its ``down_revision`` as well, which is the
+line that actually matters; the filename prefix is cosmetic. Alembic refuses to
+run on two heads rather than picking one, so skipping that step cannot land
+quietly.
+
+That safety net does NOT cover a database already stamped with an id this file
+used earlier: the version table holds one string, so only one head is visible
+and the upgrade walks straight past whatever else claimed that id. Any database
+stamped 031 or 032 by an earlier form of this file must be checked against
+that id's own DDL by hand before it is upgraded — the stamp is not evidence
+that this file's DDL ran.
+"""
+
+from alembic import op
+
+revision = "033"
+down_revision = "032"
+branch_labels = None
+depends_on = None
+
+# One name per index, so the drop and the create below can never disagree.
+_RESPONSES_INDEX = "ix_responses_in_flight_by_user"
+_SUBAGENT_INDEX = "ix_subagent_runs_in_flight_by_user"
+_SUBAGENT_SETTLED_INDEX = "ix_subagent_runs_settled_by_parent"
+
+
+def upgrade() -> None:
+    # Bounds how long we WAIT for the lock, not how long we hold it — which is
+    # why the column adds below are kept to metadata-only work. A statement
+    # that has to rewrite or scan the heap would hold ACCESS EXCLUSIVE for the
+    # whole scan no matter what this is set to.
+    # NUMERIC unconstrained, and no inline CHECK: a column-level CHECK on ADD
+    # COLUMN defeats the fast-default path and forces a validating scan of the
+    # whole heap under ACCESS EXCLUSIVE. The constraint is added separately
+    # below as NOT VALID and validated outside the lock.
+    #
+    # Each table gets its own autocommit block, which is what actually makes
+    # good on "one table's lock is never held across the other's work" —
+    # sharing the migration's transaction holds ACCESS EXCLUSIVE on
+    # conversation_responses until COMMIT, and so right through the second
+    # ALTER's wait for subagent_runs, blocking every read and write to the
+    # hottest table in the schema for up to the whole lock_timeout.
+    for table in ("conversation_responses", "subagent_runs"):
+        with op.get_context().autocommit_block():
+            op.execute("SET lock_timeout = '5s'")
+            op.execute(
+                f"""
+                ALTER TABLE {table}
+                    ADD COLUMN IF NOT EXISTS in_flight_credits NUMERIC NOT NULL DEFAULT 0,
+                    ADD COLUMN IF NOT EXISTS user_id VARCHAR(255),
+                    ADD COLUMN IF NOT EXISTS usage_settled_at TIMESTAMPTZ
+                """
+            )
+
+    # Everything below runs outside the migration's transaction: CONCURRENTLY
+    # requires it, and VALIDATE CONSTRAINT wants its own so its SHARE UPDATE
+    # EXCLUSIVE is released promptly. Safe here because every statement above
+    # is additive and every reader tolerates a missing index or an unvalidated
+    # constraint.
+    with op.get_context().autocommit_block():
+        # Drop the 5s cap for the concurrent work. CREATE INDEX CONCURRENTLY
+        # spends most of its life in two waits for transactions that can still
+        # see the table, and those are lock waits, so lock_timeout aborts them:
+        # on a table taking continuous writes a 5s cap fails the build almost
+        # every time and leaves an INVALID index behind. The statements below
+        # take no lock worth bounding — CONCURRENTLY and VALIDATE both yield to
+        # readers and writers — so the cap buys nothing here and costs the
+        # migration.
+        op.execute("SET lock_timeout = 0")
+        # NOT VALID skips the scan (SHARE UPDATE EXCLUSIVE, no heap validation);
+        # the VALIDATE that follows scans without blocking readers or writers.
+        # Every existing row holds the column default, so validation cannot
+        # fail — the pair is only about which lock the scan runs under.
+        for table in ("conversation_responses", "subagent_runs"):
+            constraint = f"ck_{table}_in_flight_credits_nonneg"
+            op.execute(
+                f"""
+                ALTER TABLE {table}
+                    DROP CONSTRAINT IF EXISTS {constraint}
+                """
+            )
+            op.execute(
+                f"""
+                ALTER TABLE {table}
+                    ADD CONSTRAINT {constraint}
+                    CHECK (in_flight_credits >= 0) NOT VALID
+                """
+            )
+            op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {constraint}")
+
+        # Drop before create, always. IF NOT EXISTS matches on NAME alone, so
+        # on its own it adopts whatever index already wears the name: a failed
+        # CONCURRENTLY build leaves an INVALID one that Postgres keeps
+        # maintaining on every write, and an earlier revision of this file
+        # leaves a narrower one that cannot serve the reader the INCLUDE was
+        # widened for. Both skip silently and neither shows up in
+        # alembic_version. Dropping first makes the definition below the only
+        # one that can survive this migration.
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_RESPONSES_INDEX}")
+        op.execute(
+            f"""
+            CREATE INDEX CONCURRENTLY {_RESPONSES_INDEX}
+                ON conversation_responses (user_id)
+                INCLUDE (in_flight_credits)
+                WHERE usage_settled_at IS NULL AND in_flight_credits > 0
+                  AND user_id IS NOT NULL
+            """
+        )
+        # parent_run_id rides along so a reader can resolve a subagent row to
+        # the turn that leased for it without leaving the index.
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_SUBAGENT_INDEX}")
+        op.execute(
+            f"""
+            CREATE INDEX CONCURRENTLY {_SUBAGENT_INDEX}
+                ON subagent_runs (user_id)
+                INCLUDE (in_flight_credits, parent_run_id)
+                WHERE usage_settled_at IS NULL AND in_flight_credits > 0
+                  AND user_id IS NOT NULL
+            """
+        )
+        # The settled complement of the index above, keyed by the parent rather
+        # than the owner. No predicate here overlaps the two above, so this is
+        # an additional index rather than a wider one: a reader reconciling a
+        # family against already-billed spend needs precisely the rows they
+        # exclude, and needs them by parent.
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_SUBAGENT_SETTLED_INDEX}")
+        op.execute(
+            f"""
+            CREATE INDEX CONCURRENTLY {_SUBAGENT_SETTLED_INDEX}
+                ON subagent_runs (parent_run_id)
+                INCLUDE (in_flight_credits, user_id)
+                WHERE usage_settled_at IS NOT NULL AND in_flight_credits > 0
+            """
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET lock_timeout = 0")  # same reason as upgrade()
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_SUBAGENT_SETTLED_INDEX}")
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_SUBAGENT_INDEX}")
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_RESPONSES_INDEX}")
+
+    # Own block per table, for the same reason as upgrade(): a DROP COLUMN
+    # takes ACCESS EXCLUSIVE too, and one shared transaction would hold the
+    # first table's lock across the second's wait.
+    for table in ("subagent_runs", "conversation_responses"):
+        with op.get_context().autocommit_block():
+            op.execute("SET lock_timeout = '5s'")
+            op.execute(
+                f"""
+                ALTER TABLE {table}
+                    DROP CONSTRAINT IF EXISTS ck_{table}_in_flight_credits_nonneg
+                """
+            )
+            op.execute(
+                f"""
+                ALTER TABLE {table}
+                    DROP COLUMN IF EXISTS usage_settled_at,
+                    DROP COLUMN IF EXISTS user_id,
+                    DROP COLUMN IF EXISTS in_flight_credits
+                """
+            )

--- a/scripts/e2e/credit_family_pass.py
+++ b/scripts/e2e/credit_family_pass.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Live pass: one reservation per turn, against the real lease service.
+
+    docker exec -e PYTHONPATH=/app:/app/src <backend> \\
+        /app/.venv/bin/python scripts/e2e/credit_family_pass.py <user_id>
+
+
+Exercises the exact shape that broke — a parent lane and a subagent lane on a
+small balance — and asserts the child never asks for its own reservation, the
+family total is what gets reported, and the lease survives the parent's close
+until the last child leaves. Releases the lease on every exit path, so a
+failed run does not leave one standing for its whole TTL.
+"""
+
+import asyncio
+import sys
+import uuid
+
+from ptc_agent.agent.middleware.credit_gate import CreditGateState, CreditLease
+from src.server.services.credit_gate_port import PlatformCreditGatePort
+
+if len(sys.argv) != 2:
+    sys.exit("usage: credit_family_pass.py <user_id>")
+USER_ID = sys.argv[1]
+# Real UUIDs: a run ref IS a run's conversation_response_id, and the lease
+# service parses it as one. A readable fixture string gets a 422 here, which
+# the gate correctly fails open on — and a fail-open pass proves nothing.
+RUN_REF = str(uuid.uuid4())
+CHILD_REF = str(uuid.uuid4())
+
+
+class Meter:
+    def __init__(self, usd):
+        self.usd = usd
+
+    def platform_usd_total(self):
+        return self.usd
+
+
+class SpyPort(PlatformCreditGatePort):
+    """The real port, with every acquire/release recorded."""
+
+    def __init__(self):
+        self.acquires = []
+        self.releases = []
+        self.heartbeats = []
+
+    async def acquire(self, user_id, run_ref, spent_credits, rate_multiplier=1.0,
+                      byok=False):
+        verdict = await super().acquire(
+            user_id, run_ref, spent_credits, rate_multiplier, byok
+        )
+        self.acquires.append((run_ref, spent_credits, rate_multiplier, byok, verdict))
+        return verdict
+
+    async def release(self, user_id, run_ref, generation=None):
+        self.releases.append((run_ref, generation))
+        return await super().release(user_id, run_ref, generation)
+
+    async def heartbeat(self, kind, run_ref, credits):
+        # Recorded, not performed. The ledger heartbeat writes to this
+        # service's own run rows through a pool only the app lifespan opens,
+        # and these refs have no row anyway — the lease is what this pass is
+        # here to prove.
+        self.heartbeats.append((kind, run_ref, credits))
+        return True
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{'  ' + detail if detail else ''}")
+    return ok
+
+
+async def main():
+    port = SpyPort()
+    lease = CreditLease(user_id=USER_ID, run_ref=RUN_REF, port=port)
+    parent = CreditGateState(
+        run_ref=RUN_REF, kind="run", port=port, lease=lease, tracker=Meter(0.002)
+    )
+    ok = True
+    try:
+        await parent.start()
+        await asyncio.sleep(3.0)  # let the lease's first acquire land
+
+        granted = [v for *_, v in port.acquires if v and v.granted]
+        ok &= check(
+            "lease granted to the parent",
+            bool(granted) and lease.ceiling_credits > 0,
+            f"ceiling={lease.ceiling_credits}",
+        )
+        ok &= check("parent not denied", lease.denial is None)
+
+        child = parent.spawn_child(
+            run_ref=CHILD_REF, tracker=Meter(0.004), tool_tracker=None
+        )
+        await child.start()
+        await asyncio.sleep(4.0)
+
+        child_asks = [r for r, *_ in port.acquires if r == CHILD_REF]
+        ok &= check(
+            "child never asks for its own reservation",
+            child_asks == [],
+            f"child acquires={child_asks}",
+        )
+        ok &= check(
+            "child is not denied against its own parent",
+            lease.denial is None and child.lease is lease,
+        )
+
+        fam, p, c = lease.spend(), parent.spend(), child.spend()
+        ok &= check(
+            "family spend sums both lanes",
+            abs(fam - (p + c)) < 1e-9 and c > 0,
+            f"family={fam:.4f} parent={p:.4f} child={c:.4f}",
+        )
+        # Force a renewal: under the ceiling the lease would not re-ask on its
+        # own, and a check that never triggers one proves nothing.
+        before = len(port.acquires)
+        lease._lease_deadline = 0.0
+        await asyncio.sleep(3.0)
+        renewed = port.acquires[before:]
+        ok &= check(
+            "a renewal happens and reports the family total, under the turn's ref",
+            bool(renewed)
+            and all(r == RUN_REF for r, *_ in renewed)
+            and abs(renewed[-1][1] - fam) < 1e-6,
+            f"renewals={[(r, round(s, 4)) for r, s, *_ in renewed]} family={fam:.4f}",
+        )
+
+        await parent.aclose()
+        ok &= check(
+            "parent close does not release while a child is live",
+            port.releases == [],
+            f"releases={port.releases}",
+        )
+
+        await child.aclose()
+        ok &= check(
+            "the last lane out releases",
+            [r for r, _ in port.releases] == [RUN_REF],
+            f"releases={port.releases}",
+        )
+        # The fence, against the live service rather than a stub: a release
+        # that carries no generation is unconditional, which is the race it
+        # exists to close.
+        ok &= check(
+            "the release is fenced on the grant it retires",
+            bool(port.releases) and port.releases[-1][1] is not None,
+            f"generation={port.releases[-1][1] if port.releases else None}",
+        )
+    finally:
+        # Never leave a reservation standing, whatever happened above. Unfenced
+        # on purpose: this is the backstop, and by here there is no grant left
+        # worth protecting.
+        await port.release(USER_ID, RUN_REF)
+    print("\n" + ("ALL CHECKS PASSED" if ok else "SOME CHECKS FAILED"))
+    return 0 if ok else 1
+
+
+sys.exit(asyncio.run(main()))

--- a/src/llms/pricing_utils.py
+++ b/src/llms/pricing_utils.py
@@ -336,17 +336,26 @@ def find_model_pricing(model_name: str, provider: Optional[str] = None) -> Optio
 PRICE_TIER_BANDS = [(8.0, 5), (4.0, 4), (1.5, 3), (0.5, 2), (0.0, 1)]
 
 
-def _representative_rate(pricing: Dict[str, Any], flat_key: str, tier_key: str) -> Optional[float]:
+def _representative_rate(
+    pricing: Dict[str, Any],
+    flat_key: str,
+    tier_key: str,
+    tier_field: str = 'rate',
+) -> Optional[float]:
     """A single $/1M rate for tiering: the flat rate, else the base (first) tier.
 
     Base tier is deliberate: it's the standard-context rate nearly all requests
     pay; long-context surcharge tiers are excluded from the headline cost dot.
+
+    ``tier_field`` names the rate to read inside a tier, because a tiered card
+    carries its cache rates as siblings of ``rate`` rather than as tiers of
+    their own.
     """
     if pricing.get(flat_key) is not None:
         return pricing[flat_key]
     tiers = pricing.get(tier_key)
     if tiers:
-        return tiers[0].get('rate')
+        return tiers[0].get(tier_field)
     return None
 
 
@@ -369,6 +378,100 @@ def get_price_tier(model_name: str, provider: Optional[str] = None) -> Optional[
         if blended >= lo:
             return tier
     return 1
+
+
+# The token mix a typical platform-billed call bills at, measured over 30 days
+# of production traffic. Two of them, because the split is a property of the
+# provider's cache architecture rather than of the model: an implicit-cache
+# provider is never charged for a cache write, so those tokens are absent from
+# its bill entirely, while explicit breakpoints put roughly a quarter of every
+# prompt on a rate twelve times the read rate. Weights are
+# (fresh input, cache read, cache write, output).
+_MIX_IMPLICIT_CACHE = (0.17, 0.81, 0.00, 0.02)
+_MIX_EXPLICIT_CACHE = (0.00, 0.73, 0.23, 0.04)
+
+# Providers whose caching is keyed at explicit breakpoints, so a cache write is
+# a real line on the bill. Mirrors ``provider_cache.breakpoint_marker``, which
+# keys Anthropic reads that way unconditionally; OpenAI's opt-in models run in
+# implicit mode and are billed no differently from the rest.
+_EXPLICIT_CACHE_PROVIDERS = frozenset({"anthropic", "claude-oauth"})
+
+# What one call bills at, per 1M tokens, on the model carrying most of our
+# traffic. A constant rather than a live lookup on that model: a vendor price
+# cut should carry every chunk down with it, and a ratio taken against a moving
+# baseline would cancel out exactly the change a chunk needs to follow.
+_BASELINE_BLENDED_RATE = 0.34
+
+
+def blended_rate(
+    model_name: str,
+    billing_type: str = "platform",
+    at: Optional[datetime] = None,
+) -> Optional[float]:
+    """What a typical call on this model bills at, in $/1M tokens.
+
+    Weights the card's four rates by the measured production token mix, which
+    answers a different question from the headline input rate: traffic here runs
+    about 80% cache reads at a tenth of the input rate, so input alone overstates
+    a cheap model and understates one whose output rate is 6x its input.
+
+    Resolves a scheduled card (peak/off-peak) against ``at``, defaulting to now,
+    because a model on hourly pricing genuinely costs twice as much some hours.
+    """
+    provider, pricing_id = resolve_pricing_identity(model_name, billing_type)
+    pricing = find_model_pricing(pricing_id, provider)
+    if not pricing:
+        return None
+    if has_schedule(pricing):
+        pricing = resolve_schedule(pricing, at or datetime.now(timezone.utc))[0]
+    r_in = _representative_rate(pricing, 'input', 'input_tiers')
+    r_out = _representative_rate(pricing, 'output', 'output_tiers')
+    if r_in is None or r_out is None:
+        return None
+    # A card publishing no read discount charges reads as input, and one
+    # publishing no write rate bills a write as ordinary input. Both fall back
+    # to the higher figure, which sizes a budget generously rather than short.
+    r_read = _representative_rate(pricing, 'cached_input', 'input_tiers', 'cached_input')
+    r_write = _representative_rate(pricing, 'cache_5m', 'input_tiers', 'cache_5m')
+    if r_write is None:
+        # Falls through on absence, not on zero: a card that publishes a free
+        # cache write means it, and ``or`` would bill it at the input rate.
+        r_write = _representative_rate(pricing, 'cache_1h', 'input_tiers', 'cache_1h')
+    rates = (
+        r_in,
+        r_in if r_read is None else r_read,
+        r_in if r_write is None else r_write,
+        r_out,
+    )
+    mix = (
+        _MIX_EXPLICIT_CACHE
+        if provider in _EXPLICIT_CACHE_PROVIDERS
+        else _MIX_IMPLICIT_CACHE
+    )
+    return sum(rate * weight for rate, weight in zip(rates, mix))
+
+
+def chunk_multiplier(
+    model_name: str,
+    billing_type: str = "platform",
+    at: Optional[datetime] = None,
+) -> Optional[float]:
+    """How much one call on this model costs against the baseline model.
+
+    Sizes the credit lease: a run reserves this many times the baseline chunk
+    before it has to re-check, so a pricier model gets headroom matching what a
+    single model boundary actually spends. Snapped to a coarse ladder so a cent
+    of manifest drift cannot restate every reservation, and to the nearest step
+    rather than up, because the figure doubles as a plain statement of relative
+    cost and only reads honestly as one if it rounds both ways. None when the
+    model has no rates, which leaves the caller on its own default.
+    """
+    rate = blended_rate(model_name, billing_type, at)
+    if rate is None or rate <= 0:
+        return None
+    raw = rate / _BASELINE_BLENDED_RATE
+    return round(raw, 1) if raw < 1 else round(raw * 2) / 2
+
 
 
 def calculate_tiered_cost(tokens: int, tiers: List[Dict[str, Any]]) -> float:

--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -38,6 +38,7 @@ from ptc_agent.agent.middleware import (
     MultimodalMiddleware,
     create_plan_mode_interrupt_config,
     CodeValidationMiddleware,
+    CreditGateMiddleware,
     EmptyToolCallRetryMiddleware,
     LeakDetectionMiddleware,
     ProtectedPathMiddleware,
@@ -600,6 +601,10 @@ class PTCAgent:
         )
         shared_middleware.extend(
             [
+                # First so a stop fires before any per-boundary work below;
+                # shared placement gives subagent lanes the same gate. Inert
+                # unless the server installed a gate state for the lane.
+                CreditGateMiddleware(),
                 ToolArgumentParsingMiddleware(),
                 ProtectedPathMiddleware(
                     denied_directories=self.config.filesystem.denied_directories,

--- a/src/ptc_agent/agent/flash/agent.py
+++ b/src/ptc_agent/agent/flash/agent.py
@@ -13,6 +13,7 @@ from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 
 from ptc_agent.agent.middleware import (
+    CreditGateMiddleware,
     EmptyToolCallRetryMiddleware,
     ToolArgumentParsingMiddleware,
     ToolErrorHandlingMiddleware,
@@ -220,6 +221,8 @@ class FlashAgent:
 
         # Minimal shared middleware stack
         shared_middleware: list[Any] = [
+            # Inert unless the server installed a gate state for this run.
+            CreditGateMiddleware(),
             ToolArgumentParsingMiddleware(),
             ToolErrorHandlingMiddleware(),
             leak_detection,

--- a/src/ptc_agent/agent/middleware/__init__.py
+++ b/src/ptc_agent/agent/middleware/__init__.py
@@ -26,6 +26,11 @@ from .plan_mode import (
 # Ask user middleware
 from .ask_user import AskUserMiddleware
 
+# Runtime credit gate (model-boundary spend enforcement). Only the middleware
+# is re-exported: the lease, the lane state and the ContextVar are the gate's
+# own wiring and their callers import them from the module directly.
+from .credit_gate import CreditGateMiddleware
+
 # Tool middleware (argument parsing, error handling, result normalization, leak detection, code validation, empty call retry)
 from .tool import (
     CodeValidationMiddleware,
@@ -141,6 +146,7 @@ __all__ = [
     "create_plan_mode_interrupt_config",
     # Ask user
     "AskUserMiddleware",
+    "CreditGateMiddleware",
     # Multimodal middleware (for read_file image/PDF support)
     "MultimodalMiddleware",
     # Tool middleware

--- a/src/ptc_agent/agent/middleware/background_subagent/outcomes.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/outcomes.py
@@ -1,0 +1,96 @@
+"""One run's terminal outcome: its status, its reason, and their spelling.
+
+Three writers publish this independently and have to agree: the ledger CAS
+writes the durable row, the token forwarder writes the wire frame the frontend
+classifies on, and the task's in-memory result feeds the agent-facing
+aggregate. Deriving it separately per writer is how a credit stop came to read
+"Stopped" on one surface and "Failed" on another, so it is derived once here
+and each writer projects the value rather than recomputing it.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from ptc_agent.agent.middleware.background_subagent.registry import (
+    TransportLostError,
+)
+from ptc_agent.agent.middleware.credit_gate import CreditStopError
+from src.server.contracts.status import CREDIT_STOP_ERROR_TYPE
+
+# Declared spellings for the two terminals something downstream matches on: the
+# retention contract greps "transport_lost", and the credit resume query and the
+# pause card both match CREDIT_STOP_ERROR_TYPE. A class name would make either
+# of them a rename away from silently never matching.
+_TRANSPORT_LOST = "transport_lost"
+
+_TORN_STREAM_MESSAGE = (
+    "transport_lost: the task's Redis event stream tore mid-run "
+    "(spill failure or quota); the replay archive is incomplete"
+)
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """How a run ended, in the one vocabulary every writer publishes."""
+
+    status: str
+    error: str
+    error_type: str
+
+    @classmethod
+    def from_exception(cls, e: BaseException) -> "Outcome":
+        return cls(
+            status=_settle_status(e), error=str(e), error_type=_error_type(e)
+        )
+
+    @classmethod
+    def torn_stream(cls) -> "Outcome":
+        """A handler that finished while its event stream was already lost.
+        An error rather than a stop: the run worked, the record of it did not."""
+        return cls(
+            status="error", error=_TORN_STREAM_MESSAGE, error_type=_TRANSPORT_LOST
+        )
+
+    def as_failure(self) -> dict[str, Any]:
+        """The ledger row's failure payload."""
+        return {"error": self.error, "error_type": self.error_type}
+
+    def as_result(self) -> dict[str, Any]:
+        """The writer's return payload.
+
+        Carries ``status`` so the in-memory outcome lands on the same terminal
+        the ledger row gets: ``success: False`` alone reads as a failure, which
+        is wrong for a stop that was neutral by design.
+        """
+        return {"success": False, **self.as_failure(), "status": self.status}
+
+
+def _error_type(e: BaseException) -> str:
+    if isinstance(e, TransportLostError):
+        return _TRANSPORT_LOST
+    if isinstance(e, CreditStopError):
+        return CREDIT_STOP_ERROR_TYPE
+    return type(e).__name__
+
+
+def is_credit_stop(result: Any) -> bool:
+    """Whether a settled task stopped on budget rather than being killed.
+
+    The terminal spelling is a cancel on every surface by design, so the error
+    type is the only thing separating a stop whose checkpoint is intact from
+    one the user ended deliberately.
+    """
+    return (
+        isinstance(result, dict) and result.get("error_type") == CREDIT_STOP_ERROR_TYPE
+    )
+
+
+def _settle_status(e: BaseException) -> str:
+    """A credit stop settles terminal-neutral, like a cancel and unlike a
+    failure: the turn ran out of budget, nothing malfunctioned. Status is the
+    only outcome field that reaches every surface, so this is what makes the
+    chip, the nav row and the summary line all read "Stopped". It keeps its
+    failure payload either way, and the ``credit_stop`` type is what offers the
+    task back for resume.
+    """
+    return "cancelled" if isinstance(e, CreditStopError) else "error"

--- a/src/ptc_agent/agent/middleware/background_subagent/registry.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/registry.py
@@ -86,14 +86,20 @@ class TaskWriterLive(Exception):
 
 def take_task_usage(
     tasks: list[BackgroundTask], response_id: str
-) -> list[tuple[BackgroundTask, list, dict]]:
+) -> list[tuple[BackgroundTask, list, dict, str | None]]:
     """Snapshot-and-clear the usage records ``response_id`` still owns.
 
     Module-level so a torn-down thread with no registry left to lock can run
     the same body: it has no awaits, so it is atomic either way, and the lock
     only orders it against concurrent registry mutation.
+
+    ``task_run_id`` is snapshotted with the records for the same reason they
+    are cleared together: a resume remints it, and the caller reads it only
+    after several awaits. Settling the reminted id would mark the *live* run
+    billed on its predecessor's usage alone, after which its heartbeats bounce
+    off the settle guard and its spend is never seen again.
     """
-    taken: list[tuple[BackgroundTask, list, dict]] = []
+    taken: list[tuple[BackgroundTask, list, dict, str | None]] = []
     for task in tasks:
         if task.collector_response_id != response_id:
             continue
@@ -102,7 +108,7 @@ def take_task_usage(
         records, tool_usage = task.per_call_records, task.tool_usage
         task.per_call_records = []
         task.tool_usage = {}
-        taken.append((task, records, tool_usage))
+        taken.append((task, records, tool_usage, task.task_run_id or None))
     return taken
 
 
@@ -369,7 +375,7 @@ class BackgroundTaskRegistry:
 
     async def take_owned_usage(
         self, tasks: list[BackgroundTask], response_id: str
-    ) -> list[tuple[BackgroundTask, list, dict]]:
+    ) -> list[tuple[BackgroundTask, list, dict, str | None]]:
         """Take the usage records this collector already owns, under the lock.
 
         The billing sibling of the claim family: ownership is checked rather

--- a/src/ptc_agent/agent/middleware/background_subagent/run_executor.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/run_executor.py
@@ -9,8 +9,9 @@ namespace-owner handles, never itself.
 
 import asyncio
 import time
-from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, Optional
 
 import structlog
 from langchain_core.messages import ToolMessage
@@ -20,6 +21,11 @@ from langgraph.types import Command
 from ptc_agent.agent.middleware.background_subagent.context import (
     current_background_token_tracker,
 )
+from ptc_agent.agent.middleware.credit_gate import (
+    CreditGateState,
+    current_credit_gate,
+)
+from ptc_agent.agent.middleware.background_subagent.outcomes import Outcome
 from ptc_agent.agent.middleware.background_subagent.redis_stream import (
     parse_steering_payload,
     steering_queue_key,
@@ -27,7 +33,6 @@ from ptc_agent.agent.middleware.background_subagent.redis_stream import (
 from ptc_agent.agent.middleware.background_subagent.registry import (
     BackgroundTask,
     BackgroundTaskRegistry,
-    TransportLostError,
 )
 
 if TYPE_CHECKING:
@@ -180,20 +185,45 @@ async def _return_unconsumed_steering(
         )
 
 
-def _transport_lost_failure() -> dict[str, Any]:
-    return {
-        "error": (
-            "transport_lost: the task's Redis event stream tore mid-run "
-            "(spill failure or quota); the replay archive is incomplete"
-        ),
-        "error_type": "transport_lost",
-    }
+@asynccontextmanager
+async def _child_credit_lane(
+    task: BackgroundTask,
+    tracker: "PerCallTokenTracker",
+    tool_tracker: Any,
+    label: str,
+) -> AsyncIterator[Optional[CreditGateState]]:
+    """This child's credit lane: its own run ref, metering and ledger heartbeat,
+    sharing the turn's lease (inherited via context copy at task creation, so a
+    resumed task joins whichever turn resumed it).
 
-
-def _error_type(e: BaseException) -> str:
-    # One spelling for the retention contract's torn-transport terminal —
-    # consumers grep "transport_lost", never the class name.
-    return "transport_lost" if isinstance(e, TransportLostError) else type(e).__name__
+    The ContextVar is set on every path, including to None, so a lane that
+    cannot be opened runs ungated rather than under its parent's state.
+    """
+    parent_gate = current_credit_gate.get()
+    gate: Optional[CreditGateState] = None
+    if parent_gate is not None and task.task_run_id:
+        gate = parent_gate.spawn_child(
+            run_ref=task.task_run_id,
+            tracker=tracker,
+            tool_tracker=tool_tracker,
+        )
+        await gate.start()
+    elif parent_gate is not None:
+        # Degraded admission left this task without a ledger row, so it has
+        # nowhere to heartbeat and never joins the lease: it runs ungated, and
+        # its spend does not reach the family total the parent is measured
+        # against. Not fatal, but silent is how a hole like this stays open.
+        logger.warning(
+            "%s has no ledger row; running without a credit lane",
+            label,
+            display_id=task.display_id,
+        )
+    current_credit_gate.set(gate)
+    try:
+        yield gate
+    finally:
+        if gate is not None:
+            await gate.aclose()
 
 
 async def _run_background_task(
@@ -219,7 +249,8 @@ async def _run_background_task(
     async def run_handler() -> ToolMessage | Command:
         current_background_token_tracker.set(tracker)
         set_tool_tracker(tool_tracker)
-        return await handler(request)
+        async with _child_credit_lane(task, tracker, tool_tracker, label):
+            return await handler(request)
 
     handler_task: asyncio.Task[ToolMessage | Command] = asyncio.create_task(
         run_handler()
@@ -262,14 +293,14 @@ async def _run_background_task(
             # must not settle "completed" — the replay archive has holes the
             # consumer can't detect. The abort loop usually raises first;
             # this covers a tear on the final events.
-            ledger_status = "error"
-            ledger_failure = _transport_lost_failure()
+            torn = Outcome.torn_stream()
+            ledger_status, ledger_failure = torn.status, torn.as_failure()
             logger.error(
                 "%s finished with a torn event stream; finalizing transport_lost",
                 label,
                 display_id=task.display_id,
             )
-            return {"success": False, **_transport_lost_failure()}
+            return torn.as_result()
         logger.debug(
             "%s completed",
             label,
@@ -288,30 +319,30 @@ async def _run_background_task(
             result = await handler_task
             ledger_status, ledger_failure = "completed", None
             if task.redis_write_failed and not task.cancelled:
-                ledger_status = "error"
-                ledger_failure = _transport_lost_failure()
-                return {"success": False, **_transport_lost_failure()}
+                torn = Outcome.torn_stream()
+                ledger_status, ledger_failure = torn.status, torn.as_failure()
+                return torn.as_result()
             return {"success": True, "result": result}
         except Exception as e:
-            ledger_status = "error"
-            ledger_failure = {"error": str(e), "error_type": _error_type(e)}
+            outcome = Outcome.from_exception(e)
+            ledger_status, ledger_failure = outcome.status, outcome.as_failure()
             logger.error(
                 "%s failed after cancellation",
                 label,
                 display_id=task.display_id,
                 error=str(e),
             )
-            return {"success": False, "error": str(e), "error_type": _error_type(e)}
+            return outcome.as_result()
     except Exception as e:
-        ledger_status = "error"
-        ledger_failure = {"error": str(e), "error_type": _error_type(e)}
+        outcome = Outcome.from_exception(e)
+        ledger_status, ledger_failure = outcome.status, outcome.as_failure()
         logger.error(
             "%s failed",
             label,
             display_id=task.display_id,
             error=str(e),
         )
-        return {"success": False, "error": str(e), "error_type": _error_type(e)}
+        return outcome.as_result()
     finally:
         # A double-cancel can exit while the shielded handler still runs; in
         # that case keep the fence (the guard's teardown unlock_all reclaims
@@ -363,7 +394,7 @@ async def _settle_terminal_run(
     # survivor. Meta must mirror the row, not the local request.
     terminal_status = (
         "cancelled"
-        if task.cancelled
+        if task.cancelled or ledger_status == "cancelled"
         else ("completed" if ledger_status == "completed" else "error")
     )
     run_finalized = False

--- a/src/ptc_agent/agent/middleware/background_subagent/task.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/task.py
@@ -25,6 +25,12 @@ the task pending, and ``never_started`` has none either — a run that never
 spawned either has no row or already settled its own as ``error``.
 """
 
+# The same values as a set, for the one caller that has to ask whether a
+# string a writer handed it is one of them.
+_TERMINAL_STATUSES = frozenset(
+    ("completed", "error", "cancelled", "timeout", "never_started")
+)
+
 WORKFLOW_SUBAGENT_TYPE = "workflow"
 """The ``subagent_type`` a workflow run's task carries.
 
@@ -216,7 +222,16 @@ class BackgroundTask:
             return self.result
         self.result = result
         failed = isinstance(result, dict) and result.get("success") is False
-        self.terminal_status = "error" if failed else "completed"
+        # A writer that settled on a specific terminal says so in its payload.
+        # ``success: False`` alone reads as a failure, which is wrong for a
+        # stop that was neutral by design: the ledger row for a credit stop
+        # says "cancelled", and an in-memory "error" here would contradict
+        # every other surface and steer the model off the resumable path.
+        declared = result.get("status") if isinstance(result, dict) else None
+        if failed and declared in _TERMINAL_STATUSES:
+            self.terminal_status = declared
+        else:
+            self.terminal_status = "error" if failed else "completed"
         self.last_updated_at = time.time()
         return result
 

--- a/src/ptc_agent/agent/middleware/background_subagent/task_actions.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/task_actions.py
@@ -25,6 +25,7 @@ from ptc_agent.agent.middleware.background_subagent.registry import (
 from ptc_agent.agent.middleware.background_subagent.task import (
     WORKFLOW_SUBAGENT_TYPE,
 )
+from ptc_agent.agent.middleware.background_subagent.outcomes import is_credit_stop
 from ptc_agent.agent.middleware.background_subagent.spawn import (
     SpawnSetupError,
     SpawnStoppedError,
@@ -352,7 +353,11 @@ async def _handle_resume(
     # The agent just looked at this task — bump last_checked_at.
     task.last_checked_at = time.time()
 
-    if task.cancelled:
+    # A credit stop spells itself as a cancel everywhere else on purpose, but
+    # it is the one kind of stop whose checkpoint is meant to be re-entered:
+    # the resume reminder lists exactly these tasks and tells the model to
+    # resume them.
+    if task.cancelled and not is_credit_stop(task.result):
         return ToolMessage(
             content=f"Error: Task-{target_task_id} was cancelled and cannot be resumed.",
             tool_call_id=tool_call_id,

--- a/src/ptc_agent/agent/middleware/background_subagent/token_forwarder.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/token_forwarder.py
@@ -9,6 +9,7 @@ from langchain_core.messages import BaseMessage
 from ptc_agent.agent.middleware.background_subagent.registry import (
     BackgroundTaskRegistry,
 )
+from ptc_agent.agent.middleware.background_subagent.outcomes import Outcome
 from src.llms.content_utils import extract_reasoning_summary_index
 from src.server.utils.content_normalizer import normalize_text_content
 
@@ -247,7 +248,9 @@ class _SubagentTokenForwarder:
         try:
             await self.registry.append_captured_event(
                 self.tool_call_id,
-                self._error_record(str(exc) or repr(exc), type(exc).__name__),
+                self._error_record(
+                    str(exc) or repr(exc), Outcome.from_exception(exc).error_type
+                ),
             )
         except Exception:
             logger.warning(

--- a/src/ptc_agent/agent/middleware/background_subagent/tools.py
+++ b/src/ptc_agent/agent/middleware/background_subagent/tools.py
@@ -16,6 +16,7 @@ from langgraph.config import get_config
 # Module-attribute binding to keep utils.build_message_checker the single patch
 # point shared with orchestrator.py.
 from ptc_agent.agent.middleware.background_subagent import utils
+from ptc_agent.agent.middleware.background_subagent.outcomes import is_credit_stop
 from ptc_agent.agent.middleware.background_subagent.utils import config_own_run_id
 from src.server.contracts.status import REPORT_BACK_STATUSES
 
@@ -64,6 +65,20 @@ def _stop_notice(task: BackgroundTask) -> str:
     )
 
 
+def _credit_stop_notice(task: BackgroundTask) -> str:
+    """A stop the budget caused, not the user — so the advice inverts.
+
+    ``_stop_notice``'s "do not re-dispatch, the stop was deliberate" would
+    steer the model off the one path this stop is designed to leave open.
+    """
+    return (
+        f"**{task.display_id}** ({task.subagent_type}) stopped when the turn "
+        f"ran out of credits; no result was produced. Its prior work is "
+        f'preserved — resume it with Task(action="resume", task_id=...) if '
+        f"the work is still needed."
+    )
+
+
 def _never_started_notice(task: BackgroundTask) -> str:
     """A task the infrastructure refused before it ever ran — the opposite
     advice from ``_stop_notice``, which is why they must not share a status."""
@@ -79,6 +94,8 @@ def _terminal_notice(task: BackgroundTask) -> str | None:
     """The fixed reply for a settled task that produced no result, or None
     when the task has a real result to render."""
     if task.terminal_status == "cancelled":
+        if is_credit_stop(task.result):
+            return _credit_stop_notice(task)
         return _stop_notice(task)
     if task.terminal_status == "timeout":
         return _timeout_notice(task)
@@ -200,8 +217,23 @@ async def _compose_missing_reply(registry, task_id: str, run: dict | None) -> st
             f"the user before re-dispatching it."
         )
     if status == "cancelled":
-        # Deliberately silent on *why*: the ledger spells a timeout kill
-        # 'cancelled' too, so claiming the stop was intentional here would
+        # The one *why* the ledger can prove, and the one that changes the
+        # advice: a credit stop leaves the checkpoint intact and resumable, so
+        # the generic text below would talk the model out of the single path
+        # this stop exists to leave open. The local notice already branches
+        # here; without the same branch the advice would be correct only when
+        # the request happened to land on the worker still holding the task in
+        # memory, which multi-worker makes a coin flip.
+        failure = run.get("failure") if isinstance(run, dict) else None
+        if is_credit_stop(failure):
+            return (
+                f"Task-{task_id} stopped when the turn ran out of credits; no "
+                f"result was produced. Its prior work is preserved — resume it "
+                f'with Task(action="resume", task_id="{task_id}") if the work '
+                f"is still needed."
+            )
+        # Otherwise deliberately silent on *why*: the ledger spells a timeout
+        # kill 'cancelled' too, so claiming the stop was intentional here would
         # tell the agent not to retry a task that merely ran long. The live
         # task carries its own terminal_status and says which it was.
         return (

--- a/src/ptc_agent/agent/middleware/credit_gate.py
+++ b/src/ptc_agent/agent/middleware/credit_gate.py
@@ -1,0 +1,651 @@
+"""Runtime credit gate — per-model-boundary spend check against a turn ceiling.
+
+The quota check otherwise runs once at admission and never again until
+finalize, so a long turn can spend unbounded platform credits mid-run. This
+middleware closes that window: each turn meters its own platform spend (LLM
+records priced at record time + per-use infrastructure credits) and compares
+it, at every model boundary, against a ceiling granted by the quota service.
+The comparison is own-spend vs own-ceiling: a turn measures what it has spent
+against what it was granted, never against a shared "remaining" figure that
+every other turn is drawing down at the same time.
+
+**One reservation per turn, not per lane.** A turn is one billable unit: the
+main run and every subagent it spawns spend from the same budget, so they
+share one lease. Splitting the reservation per lane is what made a subagent
+unrunnable on a small balance: asking under its own ref put a child in
+competition with its own parent for the one budget they both spend from.
+Hence the two objects here:
+
+- :class:`CreditLease` — one per turn family. Owns the reservation: the
+  acquire loop, the ceiling, the verdict, and the members spending under it.
+- :class:`CreditGateState` — one per lane. Owns that lane's metering and its
+  own ledger heartbeat, and defers the stop decision to the lease.
+
+The ledger stays per-run (a subagent's spend lands on its own row); only the
+reservation is shared. Membership is refcounted and the last member out
+releases, because subagent writers routinely outlive the main run: the
+parent's stream ends while children are still working, so a parent-owned
+release would leave them spending against nothing.
+
+Enforcement is deliberately one verdict behind (accepted overshoot: one
+model boundary): the gate never blocks a call waiting on the network. The
+lease's refresher extends the reservation asynchronously and each lane
+flushes its own spend heartbeat; the gate only enforces what the refresher
+last learned. Mid-run, inability to check NEVER stops a turn — refresh
+failures and unreachable services fail open with spend still metered and
+heartbeated. The only stop is a healthy service answering "insufficient
+credits":
+
+- The main run pauses via ``interrupt()`` (a resumable HITL checkpoint,
+  relaying the service's denial message verbatim). The resume arrives as a
+  new POST with its own lease, so nothing here re-checks on the way back:
+  admission refuses a still-short account before any model call is paid for.
+- A subagent run raises :class:`CreditStopError` instead, settling terminal
+  through the normal writer path with the stop reason in its failure
+  payload; its checkpoint survives, so the parent can resume it later via
+  ``Task(action="resume")``.
+
+Everything turn-local hangs off the lane state reached through a ContextVar —
+the middleware instance itself is stateless because compiled subagent graphs
+share middleware instances across lanes. Deployments with no quota service
+never set the ContextVar, so the whole gate is inert.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import contextvars
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Literal, Optional
+
+from langchain.agents.middleware.types import AgentMiddleware, AgentState
+from langgraph.runtime import Runtime
+from langgraph.types import interrupt
+
+from src.config.env import USD_TO_CREDITS_RATE
+from src.server.contracts.status import INTERRUPT_REASON_CREDIT_PAUSE
+from src.utils.tracking.infrastructure_costs import calculate_infrastructure_credits
+
+logger = logging.getLogger(__name__)
+
+# Heartbeat flush triggers: elapsed time OR credits accrued since the last
+# flush, whichever first. Each lane polls its own meter cheaply and only
+# touches the DB when a trigger fires.
+_FLUSH_INTERVAL_SECONDS = 10.0
+# Written in USD because that is the unit it was reasoned about in: 50 credits
+# reads like a threshold and is five cents, which any real model call clears,
+# so the "or" arm fired on essentially every poll and the interval above never
+# got to be the floor it was meant to be.
+_FLUSH_CREDIT_DELTA = 1.0 * USD_TO_CREDITS_RATE
+_POLL_SECONDS = 2.0
+# Extend the lease when it is this close to expiry even if spend hasn't
+# reached the ceiling — a lease that lapses mid-turn no longer covers the
+# run, and the gate would go on enforcing a grant it does not hold.
+# Public because the startup wiring check compares the service's granted TTL
+# against it: a TTL at or below this margin puts every lease inside the renew
+# window at the moment it is granted, which is a re-acquire loop wearing the
+# costume of a working gate.
+LEASE_RENEW_MARGIN_SECONDS = 120.0
+# Consecutive "row no longer open" heartbeats before a lane accepts its run
+# has settled elsewhere and stops its own heartbeat (backstop for any
+# teardown path that missed aclose()).
+_DEAD_ROW_STOPS = 3
+# After an acquire that produced no verdict (unreachable / 5xx), wait this
+# long before asking again — fail-open must not turn into a hot retry loop.
+_ACQUIRE_RETRY_BACKOFF_SECONDS = 15.0
+# Floor between two acquires that DID get an answer. A grant whose TTL is short
+# or unreadable leaves the deadline permanently inside the renew margin, and a
+# lane sitting at its ceiling re-asks on the same condition every poll: either
+# way a healthy service gets asked every _POLL_SECONDS for the whole turn.
+_ACQUIRE_MIN_SPACING_SECONDS = 5.0
+# Last resort only. The quota service authors the denial copy and we relay it
+# verbatim; this stands in for the one case where a denial arrives with none,
+# so neither stop surface is left without an explanation.
+_DEFAULT_STOP_MESSAGE = "Stopped by the credit gate."
+
+
+class CreditStopError(Exception):
+    """A subagent run stopped by the credit gate (healthy-service denial).
+
+    Reaches the background writer's generic exception handler, so the run
+    settles terminal with ``error_type: credit_stop``
+    (:data:`~src.server.contracts.status.CREDIT_STOP_ERROR_TYPE`) in its
+    failure payload — the marker the parent's resume-time injection looks for.
+    """
+
+
+@dataclass(frozen=True)
+class LeaseVerdict:
+    """One answered acquire, normalized by the port.
+
+    The port is the only producer and this class is the only consumer, so the
+    fields are guaranteed rather than defended: a body the port could not read
+    becomes ``None`` in place of a verdict, which the gate treats as "keep
+    enforcing the last one I trusted".
+    """
+
+    granted: bool
+    ceiling_credits: float = 0.0
+    ttl_seconds: float = 0.0
+    generation: Optional[int] = None
+    quota: Optional[dict] = None
+
+
+class _GateLoop:
+    """Shared lifecycle for this module's two background loops.
+
+    Both the lease's refresher and a lane's heartbeat are one cancellable
+    task that polls, must never let a tick's failure kill the loop, and tear
+    down exactly once even when the teardown itself is being cancelled. Only
+    the tick differs, so only the tick lives in the subclasses.
+    """
+
+    _refresher: Optional[asyncio.Task]
+    _closed: bool
+
+    async def _poll_forever(self, tick: Any, label: str) -> None:
+        while not self._closed:
+            await asyncio.sleep(_POLL_SECONDS)
+            try:
+                await tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "[CreditGate] %s tick failed", label, exc_info=True
+                )
+
+    async def _stop_refresher(self) -> bool:
+        """Cancel and await the loop. False when teardown already ran, which
+        is the caller's cue to skip the rest of its own teardown."""
+        if self._closed and self._refresher is None:
+            return False
+        self._closed = True
+        refresher, self._refresher = self._refresher, None
+        if refresher is not None:
+            refresher.cancel()
+            with contextlib.suppress(BaseException):
+                await asyncio.shield(refresher)
+        return True
+
+
+@dataclass(eq=False)
+class CreditLease(_GateLoop):
+    """One turn's reservation, shared by the main run and its subagents.
+
+    Identity is the main run's ref, which is what the quota service reserves
+    against. Members join as their lanes start and leave as they finish;
+    spend from a departed member is retained in ``_retired_credits`` so the
+    family total never drops. The last member out releases — subagent
+    writers outlive the main run, so "the parent finished" is not the same
+    question as "this turn is done spending".
+
+    ``port`` is duck-typed (the server injects it; its absence is the OSS
+    shape and disables the gate entirely):
+
+    - ``await port.acquire(user_id, run_ref, spent_credits, rate_multiplier,
+      byok)`` → :class:`LeaseVerdict`, or None for "no verdict" (unreachable
+      / 5xx — fail open).
+    - ``await port.release(user_id, run_ref, generation)`` → best-effort
+      lease retirement, fenced on the generation of the grant being retired.
+    """
+
+    user_id: str
+    run_ref: str
+    port: Any
+
+    # Whether this turn runs on a credential the user pays for themselves.
+    # Relayed, never branched on here: which pools apply to an own key is the
+    # quota service's rule, and admission already asks it the same question.
+    # Dropping it is what let a lease answer a turn admission had allowed.
+    is_byok: bool = False
+    ceiling_credits: float = 0.0
+    denial: Optional[dict] = None
+    # The service's own version of this reservation, echoed back on release so
+    # it only applies to the grant this lease actually holds. None until a
+    # verdict carries one, which leaves that release unconditional.
+    grant_generation: Optional[int] = None
+    _lease_deadline: float = 0.0  # monotonic; 0 = no live lease
+    _members: set["CreditGateState"] = field(default_factory=set)
+    _retired_credits: float = 0.0
+    _refresher: Optional[asyncio.Task] = None
+    _closed: bool = False
+    _next_acquire_at: float = 0.0
+    # Makes one membership transition atomic. A lane can arrive after the last
+    # one left — a subagent's first step is scheduled independently of its
+    # spawn, so it can land past the parent's teardown — and interleaving that
+    # arrival with the departure is what leaves a lease closed with members in
+    # it, or open with none.
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    # -- membership --------------------------------------------------------
+
+    async def join(self, member: "CreditGateState") -> None:
+        """Attach a lane and make sure the refresher is running, reopening the
+        lease if the last lane already left."""
+        async with self._lock:
+            self._closed = False
+            self._members.add(member)
+            self._start_refresher()
+
+    async def leave(self, member: "CreditGateState") -> None:
+        """Retire a lane, keeping its spend in the family total, and release
+        the reservation once the last member is gone."""
+        async with self._lock:
+            if member in self._members:
+                self._members.discard(member)
+                self._retired_credits += member.spend()
+            if self._members or not await self._stop_refresher():
+                return
+            generation = self.grant_generation
+        # Outside the lock: a release is a network call, and nothing here ever
+        # makes a lane wait on the network. A lane joining while this is in
+        # flight reopens the lease and acquires a grant of its own; the fence
+        # is what keeps this release off it — it retires the generation it was
+        # granted, not whatever is current. Best-effort and cancellation-safe:
+        # the lease expires on its own if the release is lost.
+        with contextlib.suppress(BaseException):
+            await asyncio.shield(
+                self.port.release(self.user_id, self.run_ref, generation)
+            )
+
+    def spend(self) -> float:
+        """The whole turn's platform spend: every live lane plus everything
+        already retired. Each lane read is O(1) and none of them await, so
+        this is atomic against the event loop."""
+        return self._retired_credits + sum(m.spend() for m in tuple(self._members))
+
+    def rate_multiplier(self) -> float:
+        """The priciest model boundary live on this turn right now.
+
+        One reservation covers every lane, so it has to be sized for the most
+        expensive of them: a chunk sized for a cheap main run would be spent by
+        a single call on a subagent pinned to a premium model, and that lane
+        would re-ask the service on every boundary. Retired lanes are excluded
+        deliberately — they are done spending, and holding their rate would keep
+        the whole turn reserving against a model no longer running.
+        """
+        members = tuple(self._members)
+        return max((m.rate_multiplier for m in members), default=1.0)
+
+    def should_stop(self, spent: float) -> bool:
+        """Only a recorded healthy-service denial stops, and only past the
+        ceiling the turn was already granted — spend under a standing grant
+        is entitled to finish."""
+        return self.denial is not None and spent >= self.ceiling_credits
+
+    # -- verdict -----------------------------------------------------------
+
+    def _record(self, verdict: Optional[LeaseVerdict]) -> None:
+        if verdict is None:
+            return  # no verdict — keep enforcing the previous one
+        # Taken from any answered verdict, not only a grant: a denial still
+        # refreshes the reservation's reported spend, so its generation is the
+        # freshest thing the service has told us about this lease.
+        if verdict.generation is not None:
+            self.grant_generation = verdict.generation
+        if verdict.granted:
+            # Monotone on purpose: a stale response arriving out of order
+            # must not shrink a granted ceiling.
+            self.ceiling_credits = max(self.ceiling_credits, verdict.ceiling_credits)
+            self.denial = None
+            self._lease_deadline = time.monotonic() + verdict.ttl_seconds
+        else:
+            # Empty rather than None: ``should_stop`` reads the presence of a
+            # denial, and the pause copy falls back on its own.
+            self.denial = verdict.quota or {}
+
+    async def _acquire(self, spent: float) -> Optional[LeaseVerdict]:
+        try:
+            return await self.port.acquire(
+                self.user_id,
+                self.run_ref,
+                spent,
+                self.rate_multiplier(),
+                self.is_byok,
+            )
+        except Exception:
+            logger.warning(
+                "[CreditGate] lease acquire failed for %s; failing open",
+                self.run_ref,
+                exc_info=True,
+            )
+            return None
+
+    # -- refresher ---------------------------------------------------------
+
+    def _start_refresher(self) -> None:
+        """Idempotent: every lane joins, the first one starts the loop. Call
+        under the lock."""
+        if self._refresher is None and not self._closed:
+            self._refresher = asyncio.create_task(
+                self._refresh_loop(), name=f"credit-lease-{self.run_ref[:8]}"
+            )
+
+    async def _refresh_loop(self) -> None:
+        # First acquire immediately: the turn starts with ceiling 0, and the
+        # sooner a real grant lands the sooner the gate has a verdict newer
+        # than admission's. Guarded like every later tick, and for a sharper
+        # reason: a tick that raises loses one verdict, but this one would kill
+        # the task before the poll loop starts — and a dead refresher never
+        # comes back, because ``start`` sees a non-None task and returns. The
+        # turn would run to completion with no ceiling and no denial.
+        try:
+            self._record(await self._acquire(self.spend()))
+        except Exception:
+            logger.warning(
+                "[CreditGate] lease priming acquire failed for %s",
+                self.run_ref,
+                exc_info=True,
+            )
+        await self._poll_forever(self._tick, f"lease {self.run_ref}")
+
+    async def _tick(self) -> None:
+        now = time.monotonic()
+        if now < self._next_acquire_at:
+            return
+        credits = self.spend()
+        if self.denial is None:
+            needs_lease = (
+                credits >= self.ceiling_credits
+                or self._lease_deadline - now < LEASE_RENEW_MARGIN_SECONDS
+            )
+        else:
+            # A denied turn under its ceiling keeps asking: a top-up in the
+            # gap turns its next verdict green and it never stops at all.
+            # Past its ceiling it stops at the next boundary — re-asking
+            # is the resume path's job, not the refresher's.
+            #
+            # Ceiling 0 is the exception, and it is the common denial: a denial
+            # carries no ceiling, so a run refused on its first acquire is
+            # "past" one it was never granted. Excluding it would withhold the
+            # top-up window from exactly the user most likely to use it.
+            needs_lease = (
+                credits < self.ceiling_credits or self.ceiling_credits <= 0.0
+            )
+        if needs_lease:
+            verdict = await self._acquire(credits)
+            self._record(verdict)
+            # Space the next ask on every branch. Backing further off when
+            # there was no verdict keeps an unreachable service from being
+            # hammered; the shorter floor on an answered one costs at most a
+            # boundary of enforcement lag, which this gate is built to absorb
+            # anyway — it is one verdict behind by design.
+            self._next_acquire_at = now + (
+                _ACQUIRE_RETRY_BACKOFF_SECONDS
+                if verdict is None
+                else _ACQUIRE_MIN_SPACING_SECONDS
+            )
+
+
+@dataclass(eq=False)
+class CreditGateState(_GateLoop):
+    """One lane's metering and ledger heartbeat, gated by the turn's lease.
+
+    The lane owns what is genuinely per-run — its trackers and its own
+    ledger row — and nothing about the reservation, which is the lease's.
+    ``port.heartbeat(kind, run_ref, credits)`` returns True when the run's
+    ledger row accepted the absolute spend value, False when the row is no
+    longer open, None on error.
+    """
+
+    run_ref: str
+    kind: Literal["run", "task"]  # conversation response | subagent run
+    port: Any
+    lease: CreditLease
+    tracker: Any = None
+    tool_tracker: Any = None
+    # How much one model boundary on this lane costs relative to the baseline
+    # the reservation is sized in. 1.0 is "no opinion", which is what an
+    # unpriced model and every OSS build get.
+    rate_multiplier: float = 1.0
+
+    _refresher: Optional[asyncio.Task] = None
+    _closed: bool = False
+    _last_flush_at: float = field(default_factory=time.monotonic)
+    _last_flushed_credits: float = 0.0
+    _last_attempted_credits: float = 0.0
+    _dead_row_count: int = 0
+    _last_spend: float = 0.0
+    _spend_error_logged: bool = False
+
+    def spend(self) -> float:
+        """This lane's cumulative platform spend, in credits — the tracker's
+        incremental platform-USD total (priced per record at record time, so
+        peak-hour schedules are honored) plus per-use infrastructure credits.
+        Advisory; billing truth stays the finalize-time batch pass.
+
+        Never raises. Both reads are best-effort — the tool-usage map is
+        mutated lock-free by concurrently running tools, and the pricing pass
+        can reject a malformed entry — and this sits on the model-boundary
+        path, where inability to check must never stop a run. On failure the
+        last good value stands, so a broken meter costs the gate precision,
+        never the run.
+        """
+        try:
+            credits = 0.0
+            if self.tracker is not None:
+                credits += self.tracker.platform_usd_total() * USD_TO_CREDITS_RATE
+            if self.tool_tracker is not None:
+                usage = self.tool_tracker.get_summary()
+                if usage:
+                    credits += float(
+                        calculate_infrastructure_credits(usage).get("total_credits")
+                        or 0.0
+                    )
+        except Exception:
+            if not self._spend_error_logged:
+                # Once per lane: the heartbeat re-reads every couple of
+                # seconds, and a persistent fault would drown the log.
+                self._spend_error_logged = True
+                logger.warning(
+                    "[CreditGate] spend read failed for %s %s; holding %.2f",
+                    self.kind,
+                    self.run_ref,
+                    self._last_spend,
+                    exc_info=True,
+                )
+            return self._last_spend
+        self._last_spend = credits
+        return credits
+
+    def spawn_child(
+        self,
+        *,
+        run_ref: str,
+        tracker: Any,
+        tool_tracker: Any,
+        rate_multiplier: Optional[float] = None,
+    ) -> "CreditGateState":
+        """A subagent lane: its own metering and ledger row, the same lease.
+        Children spend from the turn's budget, so they reserve nothing of
+        their own — asking separately is what got them denied against their
+        own parent's grant.
+
+        A lane keeps the parent's rate unless it was given one of its own: a
+        subagent may be pinned to a pricier model than the turn it serves, and
+        the reservation has to cover the boundary it will actually hit.
+        """
+        return CreditGateState(
+            run_ref=run_ref,
+            kind="task",
+            port=self.port,
+            lease=self.lease,
+            tracker=tracker,
+            tool_tracker=tool_tracker,
+            rate_multiplier=(
+                self.rate_multiplier if rate_multiplier is None else rate_multiplier
+            ),
+        )
+
+    # -- heartbeat ---------------------------------------------------------
+
+    async def start(self) -> None:
+        """Join the turn's lease and start flushing this lane's spend."""
+        if self._refresher is not None or self._closed:
+            return
+        await self.lease.join(self)
+        # Self-stop (a closed ledger row) is not teardown: aclose() still owns
+        # the final flush and leaving the lease.
+        self._refresher = asyncio.create_task(
+            self._poll_forever(
+                self._flush_if_due, f"heartbeat {self.kind} {self.run_ref}"
+            ),
+            name=f"credit-lane-{self.run_ref[:8]}",
+        )
+
+    async def _flush_if_due(self) -> None:
+        now = time.monotonic()
+        credits = self.spend()
+        if credits <= self._last_flushed_credits:
+            # Nothing new to record. GREATEST already makes an unchanged write
+            # a semantic no-op, but not a free one: in_flight_credits sits in
+            # the predicate of both partial indexes, so no update of this row
+            # can be HOT — every beat reinserts it into every index on the
+            # table. An idle lane (a long execute_code, a subagent waiting on
+            # a sandbox) would otherwise write a dead tuple every interval for
+            # the life of the run. _last_flush_at is deliberately left alone,
+            # so the moment spend resumes the next poll flushes immediately.
+            return
+        if (
+            now - self._last_flush_at >= _FLUSH_INTERVAL_SECONDS
+            or credits - self._last_attempted_credits >= _FLUSH_CREDIT_DELTA
+        ):
+            await self._flush_heartbeat(credits)
+
+    async def _flush_heartbeat(self, credits: float) -> None:
+        """Write this lane's absolute spend, advancing the cursor only if it lands.
+
+        Both markers move before the await, but they answer different questions.
+        ``_last_attempted_credits`` spaces retries, so a lane whose write failed
+        backs off to the flush interval rather than re-asking on every poll,
+        while ``_last_flushed_credits`` is what the unchanged-spend guard reads
+        and so may only ever name spend the ledger has actually accepted.
+        """
+        self._last_flush_at = time.monotonic()
+        self._last_attempted_credits = credits
+        if credits <= 0:
+            return
+        try:
+            accepted = await self.port.heartbeat(self.kind, self.run_ref, credits)
+        except Exception:
+            logger.warning(
+                "[CreditGate] heartbeat failed for %s %s",
+                self.kind,
+                self.run_ref,
+                exc_info=True,
+            )
+            return
+        if accepted is False:
+            self._dead_row_count += 1
+            if self._dead_row_count >= _DEAD_ROW_STOPS:
+                logger.info(
+                    "[CreditGate] run row closed; heartbeat stopping for %s %s",
+                    self.kind,
+                    self.run_ref,
+                )
+                self._closed = True
+            return
+        if accepted is not True:
+            # The port's documented error shape. It is not evidence the row is
+            # still open, so the dead-row count stands rather than resetting.
+            return
+        self._last_flushed_credits = credits
+        self._dead_row_count = 0
+
+    async def aclose(self) -> None:
+        """Teardown: stop the heartbeat, flush the final absolute spend, then
+        leave the lease (which releases it if this was the last lane). Every
+        step best-effort and cancellation-safe."""
+        if not await self._stop_refresher():
+            return
+        with contextlib.suppress(BaseException):
+            await asyncio.shield(self._flush_heartbeat(self.spend()))
+        with contextlib.suppress(BaseException):
+            await asyncio.shield(self.lease.leave(self))
+
+
+current_credit_gate: contextvars.ContextVar[Optional[CreditGateState]] = (
+    contextvars.ContextVar("current_credit_gate", default=None)
+)
+
+
+async def run_with_credit_gate(
+    gate: Optional[CreditGateState], stream: AsyncIterator[Any]
+) -> AsyncIterator[Any]:
+    """Drive a turn's stream inside its gate's lifetime.
+
+    Sets the lane ContextVar and joins the lease before the first event, and
+    closes the lane when the stream ends however it ends — completion, error,
+    interrupt, or the driving task being cancelled all funnel through the
+    ``finally``. Closing the main lane does not necessarily release the
+    lease: subagent lanes that outlive this stream hold it open. With
+    ``gate=None`` the stream passes through untouched (the OSS shape).
+    """
+    if gate is None:
+        async for event in stream:
+            yield event
+        return
+    token = current_credit_gate.set(gate)
+    await gate.start()
+    try:
+        async for event in stream:
+            yield event
+    finally:
+        # A generator finalized from a task other than the one that started it
+        # cannot reset the token; teardown must still run, or the lease and
+        # both loops outlive the turn.
+        with contextlib.suppress(ValueError):
+            current_credit_gate.reset(token)
+        await gate.aclose()
+
+
+def build_pause_payload(lease: CreditLease) -> dict:
+    """The interrupt payload for a credit pause — the service's denial copy
+    relayed verbatim, with a bare fallback so the card can never render an
+    explanation-less box (a denial without copy is the service's own edge
+    case, not ours to word)."""
+    denial = lease.denial or {}
+    return {
+        "action_requests": [
+            {
+                "type": INTERRUPT_REASON_CREDIT_PAUSE,
+                "message": denial.get("message") or _DEFAULT_STOP_MESSAGE,
+            }
+        ]
+    }
+
+
+class CreditGateMiddleware(AgentMiddleware):
+    """Model-boundary enforcement point. Stateless — shared across lanes."""
+
+    async def abefore_model(
+        self, state: AgentState, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        gate = current_credit_gate.get()
+        if gate is None:
+            return None
+        lease = gate.lease
+        # One family-spend read per boundary, reused by the stop decision,
+        # the log line, and (via recheck) the next acquire.
+        spent = lease.spend()
+        if not lease.should_stop(spent):
+            return None
+        if gate.kind == "task":
+            denial = lease.denial or {}
+            raise CreditStopError(denial.get("message") or _DEFAULT_STOP_MESSAGE)
+        # Main run: pause at a clean checkpoint. Nothing here re-checks on the
+        # way back — a resume arrives as a new POST with its own lease, and
+        # admission (``enforce_credit_limit``) has already refused it if the
+        # account is still short, before any model call is paid for.
+        logger.info(
+            "[CreditGate] pausing run %s: spent=%.2f ceiling=%.2f",
+            gate.run_ref,
+            spent,
+            lease.ceiling_credits,
+        )
+        interrupt(build_pause_payload(lease))
+        return None

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -609,6 +609,16 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Failed to start ProvenanceGCService: {e}")
 
+    # Confirm the runtime credit gate can reach its lease service, and on
+    # terms its refresher can work with. Both failures it catches are silent
+    # at request time.
+    try:
+        from src.server.services.credit_gate_port import verify_credit_gate_wiring
+
+        await verify_credit_gate_wiring()
+    except Exception as e:
+        logger.warning(f"Credit gate wiring check failed: {e}")
+
     yield  # Server is running
 
     # Shutdown

--- a/src/server/contracts/status.py
+++ b/src/server/contracts/status.py
@@ -100,20 +100,77 @@ def is_live(raw: Any) -> bool:
     return value is not None and str(value) in _LIVE
 
 
-def classify_interrupt_reason(interrupts: Any) -> str:
-    """Classify HITL interrupt payloads: user question vs plan review.
+# The credit gate's two wire spellings, declared rather than derived. Both are
+# matched outside Python — the resume query filters on them in SQL and the
+# stream reducer compares the error type in TypeScript — so neither may follow
+# a class name: a rename would silently stop the resume from finding anything
+# and the stopped task from ever reading as stopped. The frontend mirrors
+# CREDIT_STOP_ERROR_TYPE by hand in web/src/types/sse.ts, like the status
+# families above — change here first, then the mirror.
+INTERRUPT_REASON_CREDIT_PAUSE = "credit_pause"
+CREDIT_STOP_ERROR_TYPE = "credit_stop"
 
-    One authority for the ``interrupt_reason`` column spelling — the live
-    streaming path and the recovery scanner must never drift apart on it.
-    Accepts Interrupt objects or their dict form.
+# Every interrupt raised here names itself: the ones this codebase raises
+# directly carry ``type``, and the tool-approval middleware carries
+# ``name``/``args`` instead. Reading that discriminator IS the classification,
+# so the only thing spelled out below is which of the three questions the user
+# is being asked. Enumerating actions instead would rot on the next one added.
+_QUESTION_TYPE = "ask_user_question"
+
+# The ``interrupt_reason`` vocabulary, most specific first — one tuple serving
+# as both the closed value set and the precedence order, so a new reason cannot
+# be added without deciding what it outranks. ``credit_pause`` leads because it
+# is the one value with behaviour attached (the resume query selects on it), so
+# it must not lose to a proposal raised alongside it. ``_classify_one`` must
+# only ever return a member; ``.index`` below is what enforces that.
+INTERRUPT_REASONS = (
+    INTERRUPT_REASON_CREDIT_PAUSE,
+    "user_question",
+    "plan_review_required",
+    "approval_required",
+)
+
+
+def _action_requests(interrupts: Any):
+    """Every action request across every payload.
+
+    The approval middleware batches a turn's whole approval set into one
+    ``interrupt()``, so a payload's requests are siblings, not a leader and a
+    tail — reading only the first would let precedence depend on tool-call
+    order within a payload while claiming to be order-independent.
     """
     for intr in interrupts:
         value = getattr(intr, "value", None)
-        if value is None and isinstance(intr, dict):
-            value = intr.get("value")
         if isinstance(value, dict):
-            requests = value.get("action_requests", [])
-            if requests and isinstance(requests[0], dict):
-                if requests[0].get("type") == "ask_user_question":
-                    return "user_question"
-    return "plan_review_required"
+            yield from (
+                r for r in value.get("action_requests", ()) if isinstance(r, dict)
+            )
+
+
+def _classify_one(request: dict) -> Optional[str]:
+    kind = request.get("type")
+    if kind == INTERRUPT_REASON_CREDIT_PAUSE:
+        return INTERRUPT_REASON_CREDIT_PAUSE
+    if kind == _QUESTION_TYPE:
+        return "user_question"
+    if kind:
+        # A typed interrupt this function has not met. An interrupt always
+        # waits on the user, and past a question or a top-up the only shape
+        # left is "approve this", so the generalization holds where naming a
+        # specific action would be a guess.
+        return "approval_required"
+    name = request.get("name")
+    if name == "SubmitPlan":
+        return "plan_review_required"
+    return "approval_required" if name else None
+
+
+def classify_interrupt_reason(interrupts: Any) -> Optional[str]:
+    """Classify HITL interrupt payloads into the ``interrupt_reason`` column.
+
+    One authority for the spelling: the live streaming path and the recovery
+    scanner must never drift apart on it. ``None`` when no payload carries a
+    discriminator at all, which the column already stores as NULL.
+    """
+    reasons = [r for r in map(_classify_one, _action_requests(interrupts)) if r]
+    return min(reasons, key=INTERRUPT_REASONS.index, default=None)

--- a/src/server/database/runs/credit_ledger.py
+++ b/src/server/database/runs/credit_ledger.py
@@ -121,13 +121,23 @@ async def settle_abandoned(kind: RunKind) -> int:
     task run is not, whatever status it carries: the collector claims by
     ownership rather than status, so a row it is about to bill is
     indistinguishable from one whose parent died before collecting. So that
-    lane needs two proofs rather than one. The grace interval answers "the
-    collector already had its chance"; the parent predicate answers "it has not
-    had its chance yet", because the collector is spawned only once the PARENT
-    turn goes terminal. Age alone cannot see that: a subagent that finishes
-    early under a long turn would be stamped billed 30 minutes later and drop
-    out of the in-flight aggregate for the rest of that turn, understating the
-    balance every admission in the window is measured against.
+    lane needs two proofs rather than one, and both are the same grace read
+    against different clocks: the collector is spawned only once the PARENT
+    turn goes terminal, so its chance starts at whichever came later, the
+    child's own finalization or the parent's. The child's age alone cannot see
+    that — a subagent that finishes early under a long turn would be stamped
+    billed 30 minutes later and drop out of the in-flight aggregate for the
+    rest of that turn, understating the balance every admission in the window
+    is measured against. The parent's status alone cannot see it either: a
+    child that finished long before its parent satisfies its own grace already,
+    so a bare "parent is not in_progress" opens the moment the parent commits,
+    which is the moment BEFORE the collector it spawns has inserted anything.
+    Hence the parent's terminal instant, and hence ``usage_settled_at`` for it:
+    the finalize CAS stamps that in the same statement that turns the row
+    terminal, and it is the only timestamp the response table keeps. A parent
+    finalized by pre-gate code carries none, which reads as "chance not started"
+    and holds the child until the run lane above stamps it — a grace later than
+    strictly needed, in the direction that cannot overstate anyone's balance.
 
     ``user_id IS NOT NULL`` is what lets this use the partial in-flight index
     rather than scanning the table: the index carries that predicate, so
@@ -143,7 +153,12 @@ async def settle_abandoned(kind: RunKind) -> int:
                   AND NOT EXISTS (
                       SELECT 1 FROM conversation_responses r
                       WHERE r.conversation_response_id = {table}.parent_run_id
-                        AND r.status = 'in_progress'
+                        AND (
+                            r.status = 'in_progress'
+                            OR r.usage_settled_at IS NULL
+                            OR r.usage_settled_at
+                                > NOW() - INTERVAL '{_ABANDONED_SETTLE_GRACE}'
+                        )
                   )
         """
         if kind == "task"

--- a/src/server/database/runs/credit_ledger.py
+++ b/src/server/database/runs/credit_ledger.py
@@ -1,0 +1,248 @@
+"""The runtime credit gate's SQL surface, over both run tables.
+
+Everything here exists because a run's platform spend is invisible until
+finalize writes its usage row. The ledger columns make it visible in between,
+so a reader can aggregate "unsettled in-flight spend per user" while the runs
+are still going, and the resume query at the bottom is how a turn that stopped
+for money finds the tasks that stopped with it.
+
+Terminal and billing-settled are separate states throughout, deliberately: a
+task run turns terminal in one CAS while its usage is collected later, so a row
+keeps counting toward in-flight spend until ``usage_settled_at`` is stamped,
+whatever its status says.
+
+Held apart from ``lifecycle`` and ``subagent_runs`` rather than split between
+them because it is one concept with one client. Both ledgers carry the same
+columns and answer the same questions, so a lane names itself with ``kind`` and
+the table is resolved below — the shape it replaced was the same two statements
+written out twice, in two modules, kept in agreement by hand.
+"""
+
+import logging
+from decimal import Decimal
+from typing import Any, Dict, List, Literal, Tuple
+
+from psycopg.rows import dict_row
+
+from src.server.contracts.status import (
+    CREDIT_STOP_ERROR_TYPE,
+    INTERRUPT_REASON_CREDIT_PAUSE,
+)
+from src.server.database import pool
+
+logger = logging.getLogger(__name__)
+
+RunKind = Literal["run", "task"]
+
+# The only thing that differs between the two ledgers. Closed literal, and the
+# only source of the identifiers interpolated into the statements below.
+_TABLES: Dict[RunKind, Tuple[str, str]] = {
+    "run": ("conversation_responses", "conversation_response_id"),
+    "task": ("subagent_runs", "task_run_id"),
+}
+
+_ABANDONED_SETTLE_GRACE = "30 minutes"
+
+
+async def heartbeat(kind: RunKind, run_id: str, credits: float) -> bool:
+    """Absolute write of a live run's cumulative platform spend onto its own row.
+
+    GREATEST keeps the value monotone under reordered or duplicate flushes; the
+    status and settle guards make a late heartbeat racing finalize a no-op
+    rather than a resurrection of already-billed spend. Always a fresh app-pool
+    connection — this fires from a background refresher and must never touch a
+    run's pinned checkpointer session. Returns False when the row was already
+    terminal or settled.
+
+    Bound as Decimal because GREATEST(numeric, float8) resolves in double
+    precision: a float parameter would drag the stored column value out to
+    binary float and back on every beat, rounding a money-shaped number for
+    no reason.
+    """
+    table, key = _TABLES[kind]
+    async with pool.get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                f"""
+                UPDATE {table}
+                SET in_flight_credits = GREATEST(in_flight_credits, %s)
+                WHERE {key} = %s
+                  AND status = 'in_progress'
+                  AND usage_settled_at IS NULL
+                """,
+                (Decimal(str(credits)), run_id),
+            )
+            return cur.rowcount == 1
+
+
+async def settle_task_run(task_run_id: str, *, conn) -> bool:
+    """Stamp a task run billing-settled, in the collector's usage transaction.
+
+    ``conn`` is mandatory: the whole point of the stamp is that it commits or
+    rolls back with the usage row the collector just inserted, so the row can
+    never read settled while its spend is missing from billing, nor billed
+    while still counting as in-flight.
+
+    The chain, not the row: a resume re-points the task at a new run id while
+    its predecessor's records stay merged into the batch being billed here, so
+    the predecessor settles in the same transaction or never.
+    """
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """
+            WITH RECURSIVE chain AS (
+                SELECT task_run_id, predecessor_run_id
+                FROM subagent_runs WHERE task_run_id = %s
+              -- UNION, not UNION ALL: the pair is functional, so dedup costs
+              -- nothing on a real chain and is what terminates the walk if a
+              -- predecessor ever points back into it. This runs inside the
+              -- collector's open write transaction.
+              UNION
+                SELECT s.task_run_id, s.predecessor_run_id
+                FROM subagent_runs s
+                JOIN chain c ON s.task_run_id = c.predecessor_run_id
+            )
+            UPDATE subagent_runs
+            SET usage_settled_at = NOW()
+            WHERE task_run_id IN (SELECT task_run_id FROM chain)
+              AND usage_settled_at IS NULL
+            """,
+            (task_run_id,),
+        )
+        return cur.rowcount >= 1
+
+
+async def settle_abandoned(kind: RunKind) -> int:
+    """Degraded settle: stamp terminal-but-unsettled rows no settle path reaches.
+
+    The two lanes need different proof that none is coming. A terminal response
+    row is proof on its own — finalize stamps the settle in the same CAS, so
+    anything caught here was finalized by code predating the stamp. A terminal
+    task run is not, whatever status it carries: the collector claims by
+    ownership rather than status, so a row it is about to bill is
+    indistinguishable from one whose parent died before collecting. So that
+    lane needs two proofs rather than one. The grace interval answers "the
+    collector already had its chance"; the parent predicate answers "it has not
+    had its chance yet", because the collector is spawned only once the PARENT
+    turn goes terminal. Age alone cannot see that: a subagent that finishes
+    early under a long turn would be stamped billed 30 minutes later and drop
+    out of the in-flight aggregate for the rest of that turn, understating the
+    balance every admission in the window is measured against.
+
+    ``user_id IS NOT NULL`` is what lets this use the partial in-flight index
+    rather than scanning the table: the index carries that predicate, so
+    without it here the planner cannot prove the index covers every matching
+    row. It costs nothing to add, because an owner-less row is exactly the row
+    this sweep exists to keep out of a per-user aggregate that can never see
+    it anyway. On a healthy ledger the scan touches nothing.
+    """
+    table, _ = _TABLES[kind]
+    guard = (
+        f"""
+                  AND finalized_at < NOW() - INTERVAL '{_ABANDONED_SETTLE_GRACE}'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM conversation_responses r
+                      WHERE r.conversation_response_id = {table}.parent_run_id
+                        AND r.status = 'in_progress'
+                  )
+        """
+        if kind == "task"
+        else ""
+    )
+    async with pool.get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                f"""
+                UPDATE {table}
+                SET usage_settled_at = NOW()
+                WHERE usage_settled_at IS NULL
+                  AND in_flight_credits > 0
+                  AND user_id IS NOT NULL
+                  AND status != 'in_progress'
+                  {guard}
+                """
+            )
+            return cur.rowcount
+
+
+async def list_credit_stopped_for_resume(
+    thread_id: str, resuming_run_id: str
+) -> List[Dict[str, Any]]:
+    """Task runs the credit gate stopped under the attempt being resumed.
+
+    Feeds the resume-time injection: the model gets a mechanical record of
+    which tasks stopped so it can re-enter them via Task(action="resume").
+
+    The scope is the run immediately before ``resuming_run_id``, and it yields
+    nothing unless that run is itself the credit pause. Anchoring on "the
+    newest credit pause" instead would re-announce the same stops into
+    checkpoint state on every later approval the thread ever asks for.
+
+    The resuming run is excluded by attempt chain rather than by being newer
+    than the query: a resume opens its row in the START transaction, well
+    before this is called, so "latest row in the thread" is that row and every
+    predicate below would miss. The chain rather than the single id, because a
+    resume that fails retryably is retried as a NEW row chained by
+    ``retry_of_run_id`` while the pause stays two rows back — excluding only
+    the resuming run would anchor on the failed attempt, whose status is
+    'error', and the retry that finally succeeds would announce nothing.
+    """
+    async with pool.get_db_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                WITH RECURSIVE attempt_chain AS (
+                    SELECT conversation_response_id, retry_of_run_id
+                    FROM conversation_responses
+                    WHERE conversation_response_id = %s
+                  -- UNION, not UNION ALL: same reason as the predecessor walk
+                  -- in settle_task_run, and the pair is functional so dedup
+                  -- costs nothing on a real chain.
+                  UNION
+                    SELECT r.conversation_response_id, r.retry_of_run_id
+                    FROM conversation_responses r
+                    JOIN attempt_chain c
+                      ON r.conversation_response_id = c.retry_of_run_id
+                ),
+                resumed AS (
+                    SELECT conversation_response_id, status, interrupt_reason
+                    FROM conversation_responses
+                    WHERE conversation_thread_id = %s
+                      AND conversation_response_id NOT IN (
+                          SELECT conversation_response_id FROM attempt_chain
+                      )
+                    ORDER BY run_seq DESC
+                    LIMIT 1
+                )
+                SELECT s.task_id
+                FROM subagent_runs s
+                JOIN resumed r ON s.parent_run_id = r.conversation_response_id
+                -- Redundant against the join, but it is what makes this an
+                -- index scan: parent_run_id carries no index of its own, so
+                -- without the thread the join drives off a full table scan.
+                WHERE s.thread_id = %s
+                  AND r.status = 'interrupted'
+                  AND r.interrupt_reason = %s
+                  AND s.status = 'cancelled'
+                  AND s.failure->>'error_type' = %s
+                ORDER BY s.started_at
+                """,
+                (
+                    resuming_run_id,
+                    thread_id,
+                    thread_id,
+                    INTERRUPT_REASON_CREDIT_PAUSE,
+                    CREDIT_STOP_ERROR_TYPE,
+                ),
+            )
+            rows = await cur.fetchall()
+            return [dict(r) for r in rows]
+
+
+__all__ = [
+    "RunKind",
+    "heartbeat",
+    "list_credit_stopped_for_resume",
+    "settle_abandoned",
+    "settle_task_run",
+]

--- a/src/server/database/runs/lifecycle.py
+++ b/src/server/database/runs/lifecycle.py
@@ -140,6 +140,7 @@ async def start_run(
     fork: Optional[ForkSpec] = None,
     metadata: Optional[Dict[str, Any]] = None,
     created_at: Optional[datetime] = None,
+    user_id: Optional[str] = None,
     conn=None,
 ) -> Dict[str, Any]:
     """The START transaction: fork cleanup + query row + in_progress run row +
@@ -248,9 +249,9 @@ async def start_run(
                         INSERT INTO conversation_responses (
                             conversation_response_id, conversation_thread_id,
                             turn_index, status, metadata, created_at,
-                            attempt_no, retry_of_run_id, request_key
+                            attempt_no, retry_of_run_id, request_key, user_id
                         )
-                        VALUES (%s, %s, %s, 'in_progress', %s, %s, %s, %s, %s)
+                        VALUES (%s, %s, %s, 'in_progress', %s, %s, %s, %s, %s, %s)
                         RETURNING *
                         """,
                         (
@@ -262,6 +263,7 @@ async def start_run(
                             attempt_no,
                             retry_of_run_id,
                             request_key,
+                            user_id,
                         ),
                     )
                     run_row = dict(await cur.fetchone())
@@ -380,6 +382,15 @@ async def finalize_run(
                             warnings = %s,
                             errors = %s,
                             execution_time = %s,
+                            -- The turn's own usage (when any) is inserted by
+                            -- usage_writer inside this same transaction, so the
+                            -- terminal CAS is also the billing settle for the
+                            -- row: its heartbeated in-flight spend stops
+                            -- counting the instant the real usage row exists.
+                            -- Subagent spend settles on subagent_runs rows,
+                            -- never here — a tail-draining child keeps counting
+                            -- on its own row after this parent settles.
+                            usage_settled_at = NOW(),
                             -- Merge, never replace: mid-run appenders
                             -- (append_sse_event, e.g. manual compact/offload
                             -- context_window persists) may have durably written

--- a/src/server/database/runs/subagent_runs.py
+++ b/src/server/database/runs/subagent_runs.py
@@ -6,6 +6,23 @@ admission-authoritative from day one — a unique violation here rejects the
 spawn/resume; a ledger that tolerates conflicting writers is worse than none.
 Constraint names map 1:1 to admission semantics: active slot, duplicate
 launch call (checkpoint re-execution), claimed predecessor (resume race).
+
+**Terminal vs billing-settled.** Two separate states, and no terminal implies
+the other. A run stays countable until the turn collector inserts its usage row
+and stamps ``usage_settled_at`` in that same transaction, whatever status it
+finalized on; rows no collector ever claims are settled by the abandoned sweep
+instead.
+
+Settling at finalize would be the shorter path, and it is wrong in the one
+direction this gate cannot afford. The collector selects on ownership rather
+than status, so an error/cancelled run that accrued usage is billed later, and
+between an early stamp and that insert its spend counts in neither the in-flight
+aggregate nor ``conversation_usages``. A turn admitted in that window is
+measured against an understated balance -- and a credit stop lands in it by
+construction, which is exactly when a resume is about to be admitted. Waiting
+for the insert instead over-reserves an abandoned row for at most the sweep's
+grace, which costs a user headroom they get back rather than money they did not
+have.
 """
 
 import logging
@@ -16,7 +33,10 @@ import psycopg
 from psycopg.rows import dict_row
 
 from src.server.database import pool
-from src.server.contracts.status import REPORT_BACK_STATUSES, TERMINAL_STATUSES
+from src.server.contracts.status import (
+    REPORT_BACK_STATUSES,
+    TERMINAL_STATUSES,
+)
 from src.server.utils.pg_sanitize import SafeJson
 
 logger = logging.getLogger(__name__)
@@ -143,9 +163,19 @@ async def start_task_run(
                         INSERT INTO subagent_runs (
                             task_run_id, thread_id, task_id, parent_run_id,
                             launch_tool_call_id, predecessor_run_id, cause,
-                            start_checkpoint_id
+                            start_checkpoint_id, user_id
                         )
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s,
+                            -- Denormalized owner for the in-flight spend
+                            -- aggregate. Derived here rather than threaded
+                            -- through the agent-side ledger port: the port's
+                            -- callers don't carry user identity, and the
+                            -- thread's owner is one indexed hop away.
+                            (SELECT w.user_id
+                             FROM conversation_threads t
+                             JOIN workspaces w ON w.workspace_id = t.workspace_id
+                             WHERE t.conversation_thread_id = %s)
+                        )
                         RETURNING *
                         """,
                         (
@@ -157,6 +187,7 @@ async def start_task_run(
                             predecessor_run_id,
                             cause,
                             start_checkpoint_id,
+                            thread_id,
                         ),
                     )
                     run_row = dict(await cur.fetchone())
@@ -295,6 +326,9 @@ async def finalize_task_run(
                         failure = COALESCE(%s::jsonb, failure),
                         final_checkpoint_id = COALESCE(%s, final_checkpoint_id),
                         finalized_at = NOW()
+                        -- usage_settled_at is deliberately not stamped here:
+                        -- terminating is not being billed. See "Terminal vs
+                        -- billing-settled" in the module docstring.
                     WHERE task_run_id = %s AND status = 'in_progress'
                     RETURNING *
                     """,
@@ -647,11 +681,14 @@ async def get_task_run_statuses(task_run_ids: List[str]) -> Dict[str, str]:
 async def get_latest_run_details(
     thread_id: str, task_ids: List[str]
 ) -> Dict[str, Dict[str, Any]]:
-    """task_id -> {status, error} for tasks that HAVE a ledgered run.
+    """task_id -> {status, error, error_type} for tasks that HAVE a ledgered run.
 
-    ``error`` is the human-readable ``failure->>'error'`` message (None for
-    non-errored runs). Same anchoring as :func:`get_latest_run_statuses`;
-    absent task_ids are pre-ledger / shadow-damaged and left to the caller.
+    ``error`` is the human-readable ``failure->>'error'`` message, present for
+    any terminal that settled with a failure payload; ``error_type`` is the
+    machine spelling stored beside it, and it is what separates a stop the
+    user can act on from one they cannot. Same anchoring as
+    :func:`get_latest_run_statuses`; absent task_ids are pre-ledger /
+    shadow-damaged and left to the caller.
     """
     if not task_ids:
         return {}
@@ -659,7 +696,10 @@ async def get_latest_run_details(
         async with conn.cursor(row_factory=dict_row) as cur:
             await cur.execute(
                 """
-                SELECT t.task_id, r.status, r.failure->>'error' AS error
+                SELECT t.task_id,
+                       r.status,
+                       r.failure->>'error' AS error,
+                       r.failure->>'error_type' AS error_type
                 FROM subagent_tasks t
                 JOIN subagent_runs r ON r.task_run_id = t.latest_run_id
                 WHERE t.thread_id = %s AND t.task_id = ANY(%s)
@@ -671,6 +711,7 @@ async def get_latest_run_details(
                 str(r["task_id"]): {
                     "status": str(r["status"]),
                     "error": r["error"],
+                    "error_type": r["error_type"],
                 }
                 for r in rows
             }

--- a/src/server/dependencies/usage_limits.py
+++ b/src/server/dependencies/usage_limits.py
@@ -71,12 +71,19 @@ def _burst_reap_horizon() -> int:
 
     return get_workflow_timeout() + _BURST_REAP_MARGIN
 
+# -- the declared surface other modules call this one through ------------------
+# The three below are the whole of how this service talks to the quota service:
+# whose client, whether to talk at all, and what it authenticates with. They are
+# public because the credit gate's port needs the same three, and a borrowed
+# underscore name is a dependency no refactor here can see.
+
 # Shared httpx client (created lazily, async-safe)
 _http_client: Optional[httpx.AsyncClient] = None
 _http_client_lock = asyncio.Lock()
 
 
-async def _get_http_client() -> httpx.AsyncClient:
+async def get_http_client() -> httpx.AsyncClient:
+    """The shared client. One per process, closed at shutdown."""
     global _http_client
     async with _http_client_lock:
         if _http_client is None:
@@ -93,9 +100,33 @@ async def close_http_client() -> None:
             _http_client = None
 
 
-def _platform_gating_active() -> bool:
+def platform_gating_active() -> bool:
     """True when platform scope/quota gates should run (not OSS and an auth URL set)."""
     return HOST_MODE != "oss" and bool(AUTH_SERVICE_URL)
+
+
+def service_headers(user_id: Optional[str] = None) -> dict:
+    """Headers for a service-to-service call to the quota service.
+
+    The token is a shared secret, not a JWT, and is omitted when unset — which
+    is a deployment fault rather than a mode: every gated endpoint answers 401
+    without it. Callers that fail open on a non-200 cannot tell that apart from
+    an outage, so they check for it themselves.
+    """
+    headers = {}
+    if user_id:
+        headers["X-User-Id"] = user_id
+    token = os.getenv("INTERNAL_SERVICE_TOKEN", "")
+    if token:
+        headers["X-Service-Token"] = token
+    return headers
+
+
+def service_token_missing() -> bool:
+    """Platform gating is on but nothing is configured to authenticate with."""
+    return platform_gating_active() and not os.getenv(
+        "INTERNAL_SERVICE_TOKEN", ""
+    ).strip()
 
 
 @dataclass
@@ -261,7 +292,7 @@ async def enforce_credit_limit(user_id: str, *, byok: bool = False) -> None:
     it is an unbounded spend by a user the service may well have been about to
     refuse, landing on them later as debt they never agreed to.
     """
-    if not _platform_gating_active():
+    if not platform_gating_active():
         return
 
     try:
@@ -323,15 +354,11 @@ async def _call_validate_for_user(
     — see the fail-open notes at those call sites for why that is safe there and
     not at the credit gate.
     """
-    if not _platform_gating_active():
+    if not platform_gating_active():
         return None
 
-    client = await _get_http_client()
-    headers = {"X-User-Id": user_id}
-
-    internal_token = os.getenv("INTERNAL_SERVICE_TOKEN", "")  # shared secret, not a JWT
-    if internal_token:
-        headers["X-Service-Token"] = internal_token
+    client = await get_http_client()
+    headers = service_headers(user_id)
 
     body = {}
     if check_quota:
@@ -384,7 +411,7 @@ async def enforce_workspace_limit(
     user_id: str = Depends(get_current_user_id),
 ) -> str:
     """FastAPI dependency: enforce active workspace limit via the auth/quota service. No-op in OSS mode."""
-    if not _platform_gating_active():
+    if not platform_gating_active():
         return user_id
 
     result = await _call_validate_for_user(user_id, check_quota="workspace")
@@ -435,7 +462,7 @@ async def _fetch_platform_membership(user_id: str) -> dict:
     ``plan_display_name`` is ``None`` when the user has no active subscription.
     Cached in Redis for 5 minutes. No-op in OSS mode.
     """
-    if not _platform_gating_active():
+    if not platform_gating_active():
         return {"access_tier": -1, "plan_display_name": None}
 
     from src.utils.cache.redis_cache import get_cache_client
@@ -517,7 +544,7 @@ async def _get_user_scopes(user_id: str) -> list[str] | None:
 def require_scope(scope: str):
     """FastAPI dependency factory — checks user has scope. No-op in OSS mode."""
     async def check(user_id: str = Depends(get_current_user_id)):
-        if not _platform_gating_active():
+        if not platform_gating_active():
             return user_id  # OSS mode: everything allowed
         scopes = await _get_user_scopes(user_id)
         if scopes is not None and scope not in scopes:
@@ -537,7 +564,7 @@ async def require_workspace_scope(user_id: str, scope: str) -> None:
     omits scopes (``_get_user_scopes`` returns None). A definitive list —
     including an empty one — is enforced.
     """
-    if not _platform_gating_active():
+    if not platform_gating_active():
         return
     scopes = await _get_user_scopes(user_id)
     if scopes is not None and scope not in scopes:
@@ -547,9 +574,9 @@ async def require_workspace_scope(user_id: str, scope: str) -> None:
 def _extract_capacity(quota: dict) -> tuple[int | None, int | None]:
     """Extract ``(used, limit)`` counts from a platform quota object.
 
-    Prefers the ``capacity_used``/``capacity_limit`` names (see ginlix-platform
-    QuotaInfo), falling back to the legacy ``active``/``limit`` and
-    ``active_workspaces``/``workspace_limit`` aliases.
+    Prefers the ``capacity_used``/``capacity_limit`` names, falling back to the
+    legacy ``active``/``limit`` and ``active_workspaces``/``workspace_limit``
+    aliases.
     """
     used = quota.get("capacity_used", quota.get("active", quota.get("active_workspaces")))
     limit = quota.get("capacity_limit", quota.get("limit", quota.get("workspace_limit")))
@@ -563,7 +590,7 @@ async def enforce_capacity(user_id: str, check_quota: str) -> None:
     ``spec_performance``, ``spec_max``). No-op in OSS mode and fail-open when the
     platform is unreachable or omits the quota object.
     """
-    if not _platform_gating_active():
+    if not platform_gating_active():
         return
 
     result = await _call_validate_for_user(user_id, check_quota=check_quota)
@@ -600,7 +627,7 @@ async def get_capacity_status(user_id: str, check_quota: str) -> Optional[dict]:
     unreachable, or when it reports no counts for ``check_quota``. Never raises — this
     backs a UI hint, not a gate.
     """
-    if not _platform_gating_active():
+    if not platform_gating_active():
         return None
 
     result = await _call_validate_for_user(user_id, check_quota=check_quota)
@@ -706,7 +733,7 @@ async def _scope_entitlement_lost(user_id: str, scope: str) -> bool:
     validate call directly (not the cached ``_get_user_scopes``) so a failed
     fetch is distinguishable from a 200 that simply lacks the scope.
     """
-    if not _platform_gating_active():
+    if not platform_gating_active():
         return False
     result = await _call_validate_for_user(user_id)
     if result is None:

--- a/src/server/handlers/chat/admission_gate.py
+++ b/src/server/handlers/chat/admission_gate.py
@@ -56,7 +56,7 @@ def admission_conflict_detail(state: str) -> dict:
     if state == "stopping":
         return {
             "code": "stopping",
-            "message": "The workflow is stopping. Wait a moment, then retry.",
+            "message": "The turn is stopping. Wait a moment, then retry.",
         }
     if state == "compacting":
         return {
@@ -66,12 +66,12 @@ def admission_conflict_detail(state: str) -> dict:
     if state == "not_running":
         return {
             "code": "not_running",
-            "message": "No workflow is running to steer. Resubmit as a new message.",
+            "message": "No turn is running to steer. Resubmit as a new message.",
         }
     return {
         "code": "running",
         "message": (
-            "The workflow is still running. Wait a moment, then retry — "
+            "The turn is still running. Wait a moment, then retry — "
             "or use /reconnect to continue streaming, or /cancel to stop it."
         ),
     }

--- a/src/server/handlers/chat/error_handling.py
+++ b/src/server/handlers/chat/error_handling.py
@@ -477,7 +477,7 @@ async def handle_workflow_error(
                 return  # durable cancel won — no failure surface
 
             error_data = {
-                "message": f"Workflow failed after {MAX_RETRIES} retry attempts",
+                "message": f"Turn failed after {MAX_RETRIES} retry attempts",
                 "error_type": error_type,
                 "error_class": type(e).__name__,
                 "retry_count": retry_count,
@@ -510,7 +510,7 @@ async def handle_workflow_error(
                 return  # durable cancel won — cancelled, not retryable: no retry SSE
 
             retry_data = {
-                "message": "Temporary error occurred, you can retry or resume the workflow",
+                "message": "Temporary error occurred, you can retry or resume the turn",
                 "thread_id": thread_id,
                 "auto_retry": True,
                 "error_type": error_type,

--- a/src/server/handlers/chat/flash_run.py
+++ b/src/server/handlers/chat/flash_run.py
@@ -87,7 +87,7 @@ from src.config.settings import get_flash_recursion_limit
 
 from .admission_gate import admission_conflict_detail, wait_or_steer
 from .error_handling import handle_workflow_error
-from src.server.services.llm.config import resolve_llm_config
+from src.server.services.llm.config import is_own_key_turn, resolve_llm_config
 from .steering import (
     drain_steering_return_event,
     steer_thread,
@@ -245,6 +245,10 @@ async def astream_flash_workflow(
         # in history).  This block is flash-specific because of multimodal guard
         # differences vs PTC.
         effective_model = config.llm.flash if config and config.llm else None
+        # Off the resolved credential, not off ``is_byok``: that flag answers
+        # which ladder to try, and an automation with only an OAuth token
+        # passes it false while still paying its own vendor bill.
+        own_key = is_own_key_turn(config)
         query_metadata = {"msg_type": "flash"}
         if effective_model:
             query_metadata["llm_model"] = effective_model
@@ -341,7 +345,7 @@ async def astream_flash_workflow(
         # metered the same way.
         credit_gate = build_run_credit_gate(
             user_id, run_id, token_callback, tool_tracker, effective_model,
-            is_byok=is_byok,
+            is_byok=own_key,
         )
 
         # =================================================================

--- a/src/server/handlers/chat/flash_run.py
+++ b/src/server/handlers/chat/flash_run.py
@@ -56,6 +56,7 @@ from src.server.utils.multimodal_context import (
 from src.utils.tracking import ExecutionTracker
 from ptc_agent.agent.flash import build_flash_graph
 from ptc_agent.agent.graph import get_user_profile_for_prompt
+from ptc_agent.agent.middleware.credit_gate import run_with_credit_gate
 
 from .request_prep import (
     DISPATCH_STARTED_MARKER,
@@ -76,6 +77,7 @@ from .request_prep import (
     turn_skill_names,
     user_skill_commands,
 )
+from src.server.services.credit_gate_port import build_run_credit_gate
 from src.server.services.runs.admission import (
     RunScope,
     begin_run,
@@ -334,6 +336,14 @@ async def astream_flash_workflow(
 
         token_callback, tool_tracker = init_tracking(thread_id)
 
+        # Runtime credit gate (None when platform gating is inactive) —
+        # same wiring as the PTC path; a Flash turn is shorter but is
+        # metered the same way.
+        credit_gate = build_run_credit_gate(
+            user_id, run_id, token_callback, tool_tracker, effective_model,
+            is_byok=is_byok,
+        )
+
         # =================================================================
         # Build Flash Agent Graph
         # =================================================================
@@ -492,10 +502,13 @@ async def astream_flash_workflow(
             await manager.start_run(
                 thread_id=thread_id,
                 run_id=run_id,
-                workflow_generator=handler.stream_workflow(
-                    graph=flash_graph,
-                    input_state=input_state,
-                    config=graph_config,
+                workflow_generator=run_with_credit_gate(
+                    credit_gate,
+                    handler.stream_workflow(
+                        graph=flash_graph,
+                        input_state=input_state,
+                        config=graph_config,
+                    ),
                 ),
                 metadata={
                     "workspace_id": workspace_id,

--- a/src/server/handlers/chat/ptc_run.py
+++ b/src/server/handlers/chat/ptc_run.py
@@ -47,6 +47,7 @@ from src.server.utils.chart_selection_context import (
     parse_chart_selection_contexts,
     serialize_chart_selections_for_metadata,
 )
+from src.server.utils.credit_resume_context import build_credit_resume_update
 from src.llms.llm import get_input_modalities
 from src.server.utils.multimodal_context import (
     build_attachment_metadata,
@@ -60,6 +61,7 @@ from src.server.utils.multimodal_context import (
 from src.utils.tracking import ExecutionTracker
 
 from ptc_agent.agent.graph import build_ptc_graph_with_session
+from ptc_agent.agent.middleware.credit_gate import run_with_credit_gate
 
 from .request_prep import (
     DISPATCH_STARTED_MARKER,
@@ -81,6 +83,7 @@ from .request_prep import (
     turn_skill_names,
     user_skill_commands,
 )
+from src.server.services.credit_gate_port import build_run_credit_gate
 from src.server.services.runs.admission import (
     RunScope,
     begin_run,
@@ -373,6 +376,14 @@ async def astream_ptc_workflow(
 
         token_callback, tool_tracker = init_tracking(thread_id)
 
+        # Runtime credit gate (None when platform gating is inactive): the
+        # run's spend meter, lease, and refresher. Admission above is its
+        # seed verdict; the stream wrapper below owns its lifetime.
+        credit_gate = build_run_credit_gate(
+            user_id, run_id, token_callback, tool_tracker, effective_model,
+            is_byok=is_byok,
+        )
+
         _mark_phase("db_setup")
 
         # =====================================================================
@@ -642,7 +653,12 @@ async def astream_ptc_workflow(
             # Pydantic validates this into HITLResponse models, but LangChain's
             # HumanInTheLoopMiddleware expects plain dicts (subscriptable).
             resume_payload = serialize_hitl_response_map(request.hitl_response)
-            input_state = Command(resume=resume_payload)
+            input_state = Command(
+                resume=resume_payload,
+                # None for a resume that was not credit-paused, which is what
+                # ``update`` defaults to anyway.
+                update=await build_credit_resume_update(thread_id, run_id),
+            )
             logger.info(
                 f"[PTC_RESUME] thread_id={thread_id} "
                 f"hitl_response keys={list(request.hitl_response.keys())}"
@@ -820,10 +836,13 @@ async def astream_ptc_workflow(
         await manager.start_run(
             thread_id=thread_id,
             run_id=run_id,
-            workflow_generator=handler.stream_workflow(
-                graph=ptc_graph,
-                input_state=input_state,
-                config=graph_config,
+            workflow_generator=run_with_credit_gate(
+                credit_gate,
+                handler.stream_workflow(
+                    graph=ptc_graph,
+                    input_state=input_state,
+                    config=graph_config,
+                ),
             ),
             metadata={
                 "workspace_id": workspace_id,

--- a/src/server/handlers/chat/ptc_run.py
+++ b/src/server/handlers/chat/ptc_run.py
@@ -93,7 +93,7 @@ from src.config.settings import get_ptc_recursion_limit
 
 from .admission_gate import wait_or_steer
 from .error_handling import handle_workflow_error
-from src.server.services.llm.config import resolve_llm_config
+from src.server.services.llm.config import is_own_key_turn, resolve_llm_config
 from .steering import drain_steering_return_event
 from .run_stream_reader import stream_from_log
 from .detached import fire_and_forget as _fire_and_forget
@@ -275,6 +275,10 @@ async def astream_ptc_workflow(
         feedback_action = None
         query_content = user_input
         effective_model = config.llm.name if config and config.llm else None
+        # Off the resolved credential, not off ``is_byok``: that flag answers
+        # which ladder to try, and an automation with only an OAuth token
+        # passes it false while still paying its own vendor bill.
+        own_key = is_own_key_turn(config)
         query_metadata = {
             "workspace_id": request.workspace_id,
             "msg_type": "ptc",
@@ -381,7 +385,7 @@ async def astream_ptc_workflow(
         # seed verdict; the stream wrapper below owns its lifetime.
         credit_gate = build_run_credit_gate(
             user_id, run_id, token_callback, tool_tracker, effective_model,
-            is_byok=is_byok,
+            is_byok=own_key,
         )
 
         _mark_phase("db_setup")

--- a/src/server/handlers/chat/reconnect_admission.py
+++ b/src/server/handlers/chat/reconnect_admission.py
@@ -121,7 +121,7 @@ async def classify_reconnect(
         if task_info is not None:
             return run_id or task_info.run_id
         raise HTTPException(
-            status_code=404, detail=f"Workflow {thread_id} not found"
+            status_code=404, detail=f"No active turn on thread {thread_id}"
         )
 
     if run["status"] == "in_progress":

--- a/src/server/services/cancel_dispatch.py
+++ b/src/server/services/cancel_dispatch.py
@@ -201,7 +201,7 @@ async def cancel_workflow(thread_id: str, run_id: Optional[str] = None) -> dict:
         return _cancel_outcome(
             cancelled=True,
             thread_id=thread_id,
-            message="Cancellation signal sent. Workflow will stop shortly.",
+            message="Cancellation signal sent. The turn will stop shortly.",
         )
 
     except Exception as e:
@@ -211,7 +211,7 @@ async def cancel_workflow(thread_id: str, run_id: Optional[str] = None) -> dict:
         # credential fragments, and this reply crosses to an authenticated
         # caller (src/server/AGENTS.md: sanitize before the wire).
         raise HTTPException(
-            status_code=500, detail="Failed to cancel workflow."
+            status_code=500, detail="Failed to cancel the turn."
         ) from e
 
 

--- a/src/server/services/credit_gate_port.py
+++ b/src/server/services/credit_gate_port.py
@@ -1,0 +1,520 @@
+"""Server wiring for the runtime credit gate.
+
+The gate middleware (``ptc_agent.agent.middleware.credit_gate``) is
+deployment-agnostic: it talks to a duck-typed port. This module is the
+platform-mode implementation — leases against the quota service's
+``/api/auth/billing/leases`` endpoints, heartbeats into this service's own
+run ledgers — and the factory that decides whether a run gets a gate at
+all. With platform gating inactive (OSS mode or no ``AUTH_SERVICE_URL``)
+the factory returns None and the gate never engages.
+"""
+
+import asyncio
+import logging
+import math
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from ptc_agent.agent.middleware.credit_gate import (
+    LEASE_RENEW_MARGIN_SECONDS,
+    CreditGateState,
+    CreditLease,
+    LeaseVerdict,
+)
+
+from src.config.env import USD_TO_CREDITS_RATE
+from src.config.settings import AUTH_SERVICE_URL
+from src.llms.pricing_utils import chunk_multiplier
+from src.server.database.runs import credit_ledger
+from src.server.dependencies import usage_limits
+
+logger = logging.getLogger(__name__)
+
+# Stand-in when the service does not say when the lease expires. Comfortably
+# above the gate's renew margin on purpose: the renewal cadence degrades to a
+# slow poll rather than a hot one, and the gate keeps enforcing the ceiling it
+# was granted in the meantime.
+_UNKNOWN_TTL_SECONDS = 300.0
+
+# A figure this large is a metering bug on our side, not a spend. Declining to
+# send it fails open for one tick, which the next heartbeat corrects — cheaper
+# than asking for a ceiling sized off a number we do not believe.
+_MAX_REPORTABLE_SPEND = 1_000_000.0
+
+# Bounds on the multiplier we are willing to send. The floor keeps a bad rate
+# from asking for a reservation too small to cover a single call; the ceiling
+# keeps one from reserving a user's whole balance against one turn. A figure
+# outside them is a manifest or arithmetic fault, not a price.
+# The unit both services count in. Not a deployment knob while a quota
+# service is comparing against it: see the boot check below.
+_CANONICAL_CREDIT_UNIT = 1000
+_MIN_RATE_MULTIPLIER = 0.1
+_MAX_RATE_MULTIPLIER = 100.0
+
+
+def _reportable_multiplier(value: Any) -> float:
+    """Clamp to something a reservation can be sized from. Never raises: this
+    sits on the acquire path, where a bad number must cost precision rather
+    than the verdict itself."""
+    try:
+        m = float(value)
+    except (TypeError, ValueError):
+        return 1.0
+    if not math.isfinite(m):
+        return 1.0
+    return min(max(m, _MIN_RATE_MULTIPLIER), _MAX_RATE_MULTIPLIER)
+
+
+# A lost release is not free: the reservation holds the entire ceiling it was
+# granted until the TTL expires, and that is exactly the window a user who has
+# just topped up spends trying to resume. Worth a couple of seconds of teardown
+# to avoid, and no more — the TTL is the backstop either way. One waits between
+# attempts, so the attempt count is this plus the first try.
+_RELEASE_BACKOFF_SECONDS = (0.5, 1.5)
+_RELEASE_ATTEMPTS = len(_RELEASE_BACKOFF_SECONDS) + 1
+
+# The ceiling that makes "and no more" true. Retries and backoffs bound the
+# attempts but not the wait: a service that accepts connections and then does
+# not answer gives every attempt the shared client's full timeout, and the
+# teardown this sits in is what ends the user's stream. Sized so a service that
+# is merely failing still gets all three attempts, while one that is hanging
+# costs a single client timeout instead of three plus the backoffs.
+_RELEASE_BUDGET_SECONDS = 5.0
+
+# Bounded separately from the shared client's default: this one runs inside
+# startup, where a slow answer delays every worker's boot.
+_CAPABILITY_TIMEOUT_SECONDS = 5.0
+
+
+def _reportable_spend(value: Any, run_ref: str) -> Optional[float]:
+    """The figure, or None when it is a metering fault rather than a spend.
+
+    The lease and the ledger refuse the same values, and the ledger is the
+    reason they must: its write is monotone and Postgres ranks NaN above every
+    real numeric, so an unusable figure that lands once can never be lowered by
+    a later correct one, and it carries through the per-user SUM to every other
+    run that user has open.
+    """
+    try:
+        spent = float(value)
+    except (TypeError, ValueError):
+        spent = float("nan")
+    if not math.isfinite(spent) or spent > _MAX_REPORTABLE_SPEND:
+        logger.error(
+            "[CreditGate] not reporting spend %r for run %s — outside the "
+            "range this deployment will record",
+            value,
+            run_ref,
+        )
+        return None
+    return spent
+
+
+def _token_hint() -> str:
+    """Names the one acquire failure that no amount of retrying resolves."""
+    return (
+        "; INTERNAL_SERVICE_TOKEN is not set"
+        if usage_limits.service_token_missing()
+        else ""
+    )
+
+
+def _log_acquire_failure(status_code: int, run_ref: str, text: str) -> None:
+    """Fail open either way, but say which failure it was."""
+    if status_code in (401, 403):
+        # This deployment cannot ask at all, so the gate is off for every run
+        # on it and stays off until someone notices.
+        logger.error(
+            "[CreditGate] lease acquire rejected with %d — the runtime credit "
+            "gate is inactive for every run on this deployment%s",
+            status_code,
+            _token_hint(),
+        )
+    elif status_code == 404:
+        # Ambiguous on its own: an unknown principal and a route this build is
+        # looking for in the wrong place answer the same way. The startup
+        # capability check is what separates them.
+        logger.error(
+            "[CreditGate] lease acquire returned 404 for run %s — an unknown "
+            "user, or the lease route is elsewhere in this deployment. Neither "
+            "resolves by asking again.",
+            run_ref,
+        )
+    else:
+        logger.warning(
+            "[CreditGate] lease acquire returned %d: %s", status_code, text[:200]
+        )
+
+
+def _ttl_seconds(body: dict) -> float:
+    """Seconds until the grant lapses.
+
+    ``expires_in_seconds`` wins over differencing ``expires_at``: the service
+    differences it against its own clock, so the answer carries none of the skew
+    between the two hosts. Subtracting an absolute stamp from a local ``now()``
+    does, and skew big enough to eat the renew margin parks every lease inside
+    its renew window for the whole turn.
+
+    Falls back to a stand-in rather than to zero: an unreadable expiry read as
+    "expires now" has exactly that effect.
+    """
+    remaining = body.get("expires_in_seconds")
+    if isinstance(remaining, (int, float)) and not isinstance(remaining, bool):
+        return max(float(remaining), 0.0)
+    expires_at = body.get("expires_at")
+    if not expires_at:
+        return _UNKNOWN_TTL_SECONDS
+    try:
+        expiry = datetime.fromisoformat(str(expires_at).replace("Z", "+00:00"))
+        return max((expiry - datetime.now(timezone.utc)).total_seconds(), 0.0)
+    except Exception:
+        # Naive timestamps land here: they parse, then the subtraction raises
+        # because the other side is aware.
+        logger.warning(
+            "[CreditGate] lease expires_at unreadable (%r); assuming a %.0fs TTL",
+            expires_at,
+            _UNKNOWN_TTL_SECONDS,
+        )
+        return _UNKNOWN_TTL_SECONDS
+
+
+def _normalize_verdict(body: Any) -> Optional[LeaseVerdict]:
+    """The service's answer as the gate's own type, or None when it is not one.
+
+    An unreadable answer is not an answer: collapsing it into ``granted=False``
+    records a denial with no ceiling, which stops the turn at its first model
+    boundary.
+    """
+    if not isinstance(body, dict) or "granted" not in body:
+        logger.warning("[CreditGate] lease acquire body unusable: %.200s", body)
+        return None
+    # Strictly the boolean the contract declares. bool() would read the string
+    # "false", or any non-empty string, as a grant.
+    granted = body.get("granted")
+    if not isinstance(granted, bool):
+        logger.warning(
+            "[CreditGate] lease acquire 'granted' not a boolean: %r", granted
+        )
+        return None
+    ceiling = 0.0
+    if granted:
+        # A grant whose ceiling will not read as a number is not usable as one.
+        try:
+            ceiling = float(body.get("ceiling_credits") or 0.0)
+        except (TypeError, ValueError):
+            logger.warning(
+                "[CreditGate] lease acquire ceiling unusable: %r",
+                body.get("ceiling_credits"),
+            )
+            return None
+    # Anything but a plain integer leaves that release unfenced, which is the
+    # shape before the service offered a fence, not a failure. ``bool`` is an
+    # ``int`` in Python and is not one of these.
+    generation = body.get("generation")
+    if isinstance(generation, bool) or not isinstance(generation, int):
+        generation = None
+    quota = body.get("quota")
+    return LeaseVerdict(
+        granted=granted,
+        ceiling_credits=ceiling,
+        ttl_seconds=_ttl_seconds(body),
+        generation=generation,
+        quota=quota if isinstance(quota, dict) else None,
+    )
+
+
+class PlatformCreditGatePort:
+    """Lease + heartbeat operations for one deployment. Stateless."""
+
+    def _url(self, path: str) -> str:
+        return f"{AUTH_SERVICE_URL.rstrip('/')}/api/auth/billing/leases/{path}"
+
+    async def acquire(
+        self,
+        user_id: str,
+        run_ref: str,
+        spent_credits: float,
+        rate_multiplier: float = 1.0,
+        byok: bool = False,
+    ) -> Optional[LeaseVerdict]:
+        """One lease acquire/extend attempt. None = no verdict (fail open):
+        transport failure, any non-200, an unreadable body. A 200 is the
+        service's answer — grant or denial — normalized for the gate.
+
+        ``rate_multiplier`` is how much one model boundary on this turn costs
+        against the baseline the service sizes reservations in. Advisory: the
+        service decides what to do with it, and a build that sends nothing gets
+        whatever default it already applied.
+
+        ``byok`` travels for the same reason admission sends it, and on the same
+        terms: the service cannot reproduce its own admission verdict without
+        knowing whether the turn runs on a key the user pays for. Sent only when
+        true, so the payload is unchanged for the platform-funded case.
+        """
+        spent = _reportable_spend(spent_credits, run_ref)
+        if spent is None:
+            # No verdict rather than a rejected request: the gate keeps
+            # enforcing the ceiling it already holds, and nothing unusable
+            # reaches the reservation.
+            return None
+        client = await usage_limits.get_http_client()
+        body: dict[str, Any] = {
+            "user_id": user_id,
+            "run_ref": run_ref,
+            "spent_credits": max(spent, 0.0),
+            "rate_multiplier": _reportable_multiplier(rate_multiplier),
+        }
+        if byok:
+            body["byok"] = True
+        try:
+            resp = await client.post(
+                self._url("acquire"),
+                json=body,
+                headers=usage_limits.service_headers(),
+            )
+        except Exception as e:
+            logger.warning("[CreditGate] lease service unreachable: %s", e)
+            return None
+        if resp.status_code != 200:
+            _log_acquire_failure(resp.status_code, run_ref, resp.text)
+            return None
+        try:
+            body = resp.json()
+        except Exception:
+            return None
+        return _normalize_verdict(body)
+
+    async def release(
+        self, user_id: str, run_ref: str, generation: Optional[int] = None
+    ) -> None:
+        """Retire the run's reservation. Best-effort, but not one-shot.
+
+        ``generation`` fences it against a lane that rejoined and re-acquired
+        while this teardown was in flight: the release names the grant it is
+        retiring, so it cannot retire one this teardown never held. Omitted,
+        the release is unconditional and that race is live.
+
+        Retried only for the failures a second attempt can fix. A 4xx is an
+        answer — including the 404 that means there was nothing to release,
+        which is the idempotent case, not an error.
+
+        Bounded by a whole-teardown deadline rather than per attempt, because
+        it is the total that the caller waits out: this runs from the lane's
+        ``aclose``, so until it returns the turn's stream has stopped producing
+        but has not ended.
+        """
+        client = await usage_limits.get_http_client()
+        payload: dict[str, Any] = {"user_id": user_id, "run_ref": run_ref}
+        if generation is not None:
+            payload["generation"] = generation
+        detail = "no attempt made"
+        deadline = time.monotonic() + _RELEASE_BUDGET_SECONDS
+        for attempt in range(_RELEASE_ATTEMPTS):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                detail = f"{detail}; teardown budget spent"
+                break
+            try:
+                resp = await client.post(
+                    self._url("release"),
+                    json=payload,
+                    headers=usage_limits.service_headers(),
+                    timeout=remaining,
+                )
+                if resp.status_code < 500:
+                    return
+                detail = f"HTTP {resp.status_code}"
+            except Exception as e:
+                detail = str(e)
+            if attempt < len(_RELEASE_BACKOFF_SECONDS):
+                backoff = min(
+                    _RELEASE_BACKOFF_SECONDS[attempt],
+                    max(0.0, deadline - time.monotonic()),
+                )
+                await asyncio.sleep(backoff)
+        logger.warning(
+            "[CreditGate] lease release failed for run %s after %d attempts "
+            "(%s); its reservation stands until the lease expires",
+            run_ref,
+            _RELEASE_ATTEMPTS,
+            detail,
+        )
+
+    async def capability(self) -> Optional[dict]:
+        """What the lease service reports about itself, or None if it did not
+        answer. Read-only on both sides, so every worker asking at boot costs
+        nothing."""
+        client = await usage_limits.get_http_client()
+        try:
+            resp = await client.get(
+                self._url("capability"),
+                headers=usage_limits.service_headers(),
+                timeout=_CAPABILITY_TIMEOUT_SECONDS,
+            )
+        except Exception as e:
+            logger.warning("[CreditGate] capability check unreachable: %s", e)
+            return None
+        if resp.status_code != 200:
+            logger.error(
+                "[CreditGate] capability check returned %d — the runtime "
+                "credit gate cannot reach its lease service at %s, so every "
+                "long-running turn on this deployment goes ungated%s",
+                resp.status_code,
+                self._url("capability"),
+                _token_hint(),
+            )
+            return None
+        try:
+            body = resp.json()
+        except Exception:
+            body = None
+        if not isinstance(body, dict):
+            logger.error("[CreditGate] capability body unusable: %s", resp.text[:200])
+            return None
+        return body
+
+    async def heartbeat(
+        self, kind: credit_ledger.RunKind, run_ref: str, credits: float
+    ) -> Optional[bool]:
+        """True when the row took the value, False when it is no longer open,
+        None when there was nothing worth writing.
+
+        Validated on the same terms as ``acquire``: a beat is the write that
+        actually has to hold the line, since the ledger keeps whatever lands
+        on it.
+        """
+        spent = _reportable_spend(credits, run_ref)
+        if spent is None:
+            return None
+        return await credit_ledger.heartbeat(kind, run_ref, spent)
+
+
+_port = PlatformCreditGatePort()
+
+
+def build_run_credit_gate(
+    user_id: str,
+    run_id: str,
+    token_callback: Any,
+    tool_tracker: Any,
+    model_name: Optional[str] = None,
+    is_byok: bool = False,
+) -> Optional[CreditGateState]:
+    """The main lane's gate state, or None when platform gating is inactive.
+
+    Also mints the turn's lease, which this lane and every subagent it
+    spawns share. Admission (``enforce_credit_limit``) has already allowed
+    this run by the time this is called, which is the gate's seed verdict —
+    the first model boundary proceeds on it while the lease's first acquire
+    is in flight.
+
+    No gate without a principal: a heartbeat onto a ``user_id IS NULL`` row
+    would spend against an aggregate that can never see it.
+    """
+    if not user_id or not usage_limits.platform_gating_active():
+        return None
+    return CreditGateState(
+        run_ref=run_id,
+        kind="run",
+        port=_port,
+        lease=CreditLease(
+            user_id=user_id, run_ref=run_id, port=_port, is_byok=is_byok
+        ),
+        tracker=token_callback,
+        tool_tracker=tool_tracker,
+        rate_multiplier=_model_rate_multiplier(model_name, is_byok),
+    )
+
+
+def _model_rate_multiplier(model_name: Optional[str], is_byok: bool = False) -> float:
+    """What one boundary on this model costs against the baseline, or 1.0.
+
+    A BYOK turn pays its tokens to the user's own vendor account, so the only
+    thing left to meter is infrastructure, and an infrastructure credit is
+    computed from tool-use counts alone -- there is no model term anywhere in
+    ``calculate_infrastructure_credits``. So the rate is not a large estimate
+    of that spend, it is an unrelated one, and scaling the reservation by it
+    sizes the ask on a quantity the spend cannot vary with.
+
+    Resolved per turn rather than cached: the answer moves with the manifest,
+    and for a model on hourly pricing it moves with the clock. Never raises —
+    an unreadable rate costs the reservation its sizing, not the turn.
+    """
+    if is_byok or not model_name:
+        return 1.0
+    try:
+        return chunk_multiplier(model_name) or 1.0
+    except Exception:
+        logger.warning(
+            "[CreditGate] could not size a rate for %r; reserving at baseline",
+            model_name,
+            exc_info=True,
+        )
+        return 1.0
+
+
+async def verify_credit_gate_wiring() -> None:
+    """Startup assertion for the runtime credit gate. Never raises.
+
+    The gate has two ways to die without producing a single error at request
+    time. A lease route that is not where this build looks leaves every
+    long-running turn ungated, and a granted TTL at or below the renew margin
+    puts each lease inside the renew window the moment it is issued, so the
+    refresher re-acquires for the whole turn — load with nothing to show for
+    it. One GET answers both at boot instead of in a bill.
+
+    Silent when gating is inactive: OSS builds have no service to ask.
+    """
+    if not usage_limits.platform_gating_active():
+        return
+    body = await _port.capability()
+    if body is None:
+        return  # the check logged what it found
+    if not body.get("enabled"):
+        logger.info(
+            "[CreditGate] lease reservations are switched off on the quota "
+            "service; turns run without a runtime credit gate"
+        )
+        return
+    ttl = body.get("lease_ttl_seconds")
+    if not isinstance(ttl, (int, float)) or isinstance(ttl, bool):
+        logger.error("[CreditGate] capability reported no usable TTL: %r", ttl)
+        return
+    if ttl <= LEASE_RENEW_MARGIN_SECONDS:
+        logger.error(
+            "[CreditGate] lease TTL is %ss against a %ss renew margin — every "
+            "lease arrives already due for renewal, so runs will re-acquire "
+            "continuously instead of gating",
+            ttl,
+            LEASE_RENEW_MARGIN_SECONDS,
+        )
+        return
+    lo = body.get("rate_multiplier_min")
+    hi = body.get("rate_multiplier_max")
+    if isinstance(lo, (int, float)) and isinstance(hi, (int, float)):
+        if float(lo) != _MIN_RATE_MULTIPLIER or float(hi) != _MAX_RATE_MULTIPLIER:
+            logger.error(
+                "[CreditGate] multiplier bounds disagree: the service accepts "
+                "[%s, %s], this build clamps to [%s, %s]. A multiplier outside "
+                "the service's range is rejected, and a rejected acquire is no "
+                "verdict, which leaves the turn ungated.",
+                lo,
+                hi,
+                _MIN_RATE_MULTIPLIER,
+                _MAX_RATE_MULTIPLIER,
+            )
+    # The service counts in credits and has no view of what one cost to
+    # produce, so it cannot detect a build that converts at a different rate:
+    # halving this reports half the credits for the same work, which from there
+    # is indistinguishable from a cheaper turn. The check only exists here.
+    if USD_TO_CREDITS_RATE != _CANONICAL_CREDIT_UNIT:
+        logger.error(
+            "[CreditGate] USD_TO_CREDITS_RATE is %s, not the canonical %s, so "
+            "every spend this build reports is scaled %.4gx against the "
+            "ceilings it is compared with.",
+            USD_TO_CREDITS_RATE,
+            _CANONICAL_CREDIT_UNIT,
+            USD_TO_CREDITS_RATE / _CANONICAL_CREDIT_UNIT,
+        )
+    logger.info("[CreditGate] lease service ready (TTL %ss)", ttl)

--- a/src/server/services/history/projector.py
+++ b/src/server/services/history/projector.py
@@ -56,6 +56,11 @@ _STEERING_MARKERS = (
 _MARKET_WATCH_SOURCE = "market_watch"
 _MARKET_WATCH_STAMP_OPEN = "<market-watch>"
 
+# Written by src/server/utils/credit_resume_context.py — the lc_source tag on
+# the record of gate-stopped background tasks injected when a credit-paused
+# turn resumes.
+_CREDIT_GATE_SOURCE = "credit_gate"
+
 _FILE_OPERATION_TOOLS = {"Write", "Edit"}
 _ARTIFACT_FROM_TOOL_MESSAGE = {
     "ShowWidget": "html_widget",
@@ -223,7 +228,14 @@ def _sse(event_type: str, data: dict[str, Any]) -> dict[str, Any]:
 
 def _human_message_kind(message: HumanMessage) -> str:
     """Classify a HumanMessage by its injection stamp: ``market-watch``,
-    ``steering``, ``summarization``, or ``plain`` (real user input)."""
+    ``steering``, ``summarization``, ``credit-gate``, or ``plain`` (real
+    user input).
+
+    Every stamp a writer emits must be registered here. ``plain`` is the
+    fallback, and it is load-bearing — it is what ``is_run_boundary_message``
+    treats as a run's opening input, so an unregistered stamp would open a
+    run it only landed inside.
+    """
     kwargs = message.additional_kwargs or {}
     source = kwargs.get("lc_source")
     content = message.content if isinstance(message.content, str) else ""
@@ -235,6 +247,8 @@ def _human_message_kind(message: HumanMessage) -> str:
         return "steering"
     if source == "summarization":
         return "summarization"
+    if source == _CREDIT_GATE_SOURCE:
+        return "credit-gate"
     return "plain"
 
 
@@ -258,9 +272,10 @@ def _project_human_message(message: HumanMessage, agent: str) -> list[HistoryEve
     content = message.content if isinstance(message.content, str) else ""
     kind = _human_message_kind(message)
 
-    if kind == "market-watch":
-        # Live-price stamps are model-facing only — skipping them here keeps
-        # them out of history.
+    if kind in ("market-watch", "credit-gate"):
+        # Model-facing only. Returning here rather than falling through also
+        # keeps them out of a task namespace's ``user-message`` projection,
+        # where the raw reminder would surface as if the user had typed it.
         return []
 
     if kind == "steering":

--- a/src/server/services/history/task_status.py
+++ b/src/server/services/history/task_status.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from src.server.utils.error_sanitization import sanitize_error_text
+
 logger = logging.getLogger(__name__)
 
 # Client vocabulary (see _LEDGER_TO_CLIENT), not the ledger's — everything
@@ -56,11 +58,14 @@ def collect_task_ids(items: list[dict]) -> list[str]:
 async def resolve_task_details(
     thread_id: str, task_ids: list[str]
 ) -> dict[str, dict[str, Any]]:
-    """Map each task id to ``{"status", "error"}``.
+    """Map each task id to ``{"status", "error", "error_type"}``.
 
     ``status`` is ``running`` / ``completed`` / ``cancelled`` / ``error``;
-    ``error`` is the ledger failure message, present only when the client
-    status is ``error`` (None otherwise). The run ledger is the authority
+    ``error`` is the ledger failure message, present for any terminal that
+    settled with a failure payload (``error`` and ``cancelled``), None
+    otherwise, and ``error_type`` is its machine spelling — the client reads
+    it to tell a stop it can offer a remedy for from one it can only report.
+    The run ledger is the authority
     (M4): the latest run row's status maps straight to the client vocabulary —
     a dead worker's in_progress row reads "running" only until the recovery
     scanner finalizes it. Tasks without a ledgered run (pre-ledger launches,
@@ -89,16 +94,29 @@ async def resolve_task_details(
             legacy_ids.append(task_id)
         else:
             client_status = _LEDGER_TO_CLIENT.get(row.get("status"), "error")
+            # A run that ended on a failure payload carries its reason
+            # whatever terminal it settled on. Restricting this to "error"
+            # silently blanked the one case that needs it most: a credit stop
+            # settles "cancelled" by design, and its denial copy is the whole
+            # explanation the user gets.
+            carries_reason = client_status in ("error", "cancelled")
+            # Scrubbed on the way out, the way the neighbouring lane already
+            # reads this column: a setup failure quotes whatever DSN it choked
+            # on, and widening the predicate above to "cancelled" put a second
+            # terminal on this path.
+            ledger_error = row.get("error") if carries_reason else None
             details[task_id] = {
                 "status": client_status,
-                # Only an errored task carries a reason to the client.
-                "error": row.get("error") if client_status == "error" else None,
+                "error": sanitize_error_text(ledger_error) if ledger_error else None,
+                # Not sanitized: unlike the message beside it, this is a closed
+                # vocabulary this codebase writes, never quoted upstream text.
+                "error_type": row.get("error_type") if carries_reason else None,
             }
     if legacy_ids:
         for task_id, status in (
             await _resolve_legacy_statuses(thread_id, legacy_ids)
         ).items():
-            details[task_id] = {"status": status, "error": None}
+            details[task_id] = {"status": status, "error": None, "error_type": None}
     return details
 
 
@@ -137,10 +155,11 @@ async def _resolve_legacy_statuses(
 def stamp_task_artifact_data(
     data: Any, details: dict[str, dict[str, Any]], *, status_only: bool = False
 ) -> Any:
-    """Return ``data`` with ``payload.status`` (and ``payload.error`` when the
-    task errored) stamped — copies, never mutates: stored/cached event dicts
-    are shared objects. ``status_only`` restricts the stamp to the whitelisted
-    status value — public replay must never ship failure text unauthenticated."""
+    """Return ``data`` with ``payload.status`` (and the failure reason when the
+    task settled with one) stamped — copies, never mutates: stored/cached event
+    dicts are shared objects. ``status_only`` restricts the stamp to the
+    whitelisted status value — public replay must never ship failure text
+    unauthenticated, and the type travels with the message it classifies."""
     task_id = _artifact_task_id(data)
     if not task_id or task_id not in details:
         return data
@@ -148,6 +167,8 @@ def stamp_task_artifact_data(
     payload = {**(data.get("payload") or {}), "status": detail["status"]}
     if not status_only and detail.get("error"):
         payload["error"] = detail["error"]
+        if detail.get("error_type"):
+            payload["error_type"] = detail["error_type"]
     return {**data, "payload": payload}
 
 

--- a/src/server/services/llm/config.py
+++ b/src/server/services/llm/config.py
@@ -50,6 +50,24 @@ class ResolvedClient:
     credential_source: CredentialSource
 
 
+def is_own_key_turn(config: Any) -> bool:
+    """Did the user's own credential pay the vendor for this turn?
+
+    The billing question, and deliberately not the same one as ``is_byok``,
+    which asks whether to attempt the BYOK ladder. For an OAuth-only user the
+    two answers differ, and reading the ladder's answer as the billing one
+    meters an own-key turn as though the platform had funded it.
+
+    Taken off the RESOLVED credential rather than off a flag a caller passed
+    down, because the caller that knows which ladder to try is not always the
+    one that knows who ends up paying.
+    """
+    return getattr(config, "credential_source", None) in (
+        CredentialSource.OAUTH,
+        CredentialSource.BYOK,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------

--- a/src/server/services/persistence/usage.py
+++ b/src/server/services/persistence/usage.py
@@ -250,7 +250,8 @@ class UsagePersistenceService:
         deepthinking: bool = False,
         status: str = "completed",
         conn: Optional[Any] = None,
-        is_byok: bool = False
+        is_byok: bool = False,
+        settle_task_run_id: Optional[str] = None,
     ) -> bool:
         """
         Persist usage data to conversation_usage table.
@@ -274,12 +275,18 @@ class UsagePersistenceService:
             status: Workflow completion status (completed, error, cancelled, interrupted)
             conn: Optional database connection for transaction support
             is_byok: Caller hint for billing type (overridden by per-call data when available)
+            settle_task_run_id: When set, stamp this subagent run billing-settled
+                in the same transaction as the usage insert — the pair commits or
+                rolls back together, so the run can never read settled with its
+                spend missing from billing, nor billed while still counting as
+                in-flight.
 
         Returns:
             True if successful, False otherwise
         """
         from src.server.database import conversation as qr_db
         from src.server.database import pool
+        from src.server.database.runs import credit_ledger
 
         if timestamp is None:
             timestamp = datetime.now(timezone.utc)
@@ -328,9 +335,19 @@ class UsagePersistenceService:
             # Persist to database (use provided conn for transaction support)
             if conn:
                 await qr_db.create_usage_record(usage_data, conn=conn)
+                if settle_task_run_id:
+                    await credit_ledger.settle_task_run(settle_task_run_id, conn=conn)
             else:
                 async with pool.get_db_connection() as new_conn:
-                    await qr_db.create_usage_record(usage_data, conn=new_conn)
+                    # One transaction either way. The settle stamp has to land
+                    # with the usage row or not at all, and wrapping the lone
+                    # insert when there is no stamp costs nothing.
+                    async with new_conn.transaction():
+                        await qr_db.create_usage_record(usage_data, conn=new_conn)
+                        if settle_task_run_id:
+                            await credit_ledger.settle_task_run(
+                                settle_task_run_id, conn=new_conn
+                            )
 
             logger.info(
                 f"[UsagePersistence] Persisted usage for response_id={response_id}, "

--- a/src/server/services/runs/coordinator.py
+++ b/src/server/services/runs/coordinator.py
@@ -191,6 +191,7 @@ class RunCoordinator:
                     query=query,
                     fork=fork,
                     metadata=metadata,
+                    user_id=user_id,
                     conn=guard.conn if guard is not None else None,
                 )
             handle = RunHandle(
@@ -451,9 +452,9 @@ class RunCoordinator:
         """
         error_frame = {
             "thread_id": thread_id,
-            "content": "background workflow failed",
+            "content": "background turn failed",
             "error_type": "background_failure",
-            "error": error_text or "background workflow failed",
+            "error": error_text or "background turn failed",
         }
         try:
             result = await self.finalize_detached_run(
@@ -461,7 +462,7 @@ class RunCoordinator:
                 run_id,
                 RunOutcome(
                     status="error",
-                    errors=[error_text or "background workflow failed"],
+                    errors=[error_text or "background turn failed"],
                     metadata={"recovery": "dispatch_consumer_crash"},
                 ),
                 error_frame=error_frame,

--- a/src/server/services/runs/recovery.py
+++ b/src/server/services/runs/recovery.py
@@ -22,6 +22,7 @@ import random
 from typing import Any, Dict, List, Optional, Tuple
 
 from src.config.settings import get_recovery_scan_interval
+from src.server.database.runs import credit_ledger
 from src.server.database.runs import subagent_runs as sr_db
 from src.server.database.runs import lifecycle as tl_db
 
@@ -37,12 +38,19 @@ SALVAGE_MAX_EVENTS = 5000
 STOP_GRACE = 30.0
 
 
+# Scans between billing-settle sweeps. The sweep's own grace window is 30
+# minutes, so anything short of that is timely; this keeps an idle fleet from
+# issuing two table-wide UPDATEs per worker every scan interval.
+_SETTLE_SWEEP_EVERY_N_SCANS = 10
+
+
 class RecoveryScanner:
     _instance: Optional["RecoveryScanner"] = None
 
     def __init__(self) -> None:
         self._loop_task: Optional[asyncio.Task] = None
         self._stop_event = asyncio.Event()
+        self._sweep_tick = 0
 
     @classmethod
     def get_instance(cls) -> "RecoveryScanner":
@@ -141,6 +149,15 @@ class RecoveryScanner:
         # cascade-orphaned task rows sit unnoticed, so the heal must not be
         # conditional on there being open runs to recover.
         await self.heal_task_chains()
+
+        # Same reasoning for billing settle: a terminal row whose settle stamp
+        # never landed sits unnoticed precisely when nothing is running. But
+        # it is two unbounded UPDATEs over both hot run tables, fired by every
+        # worker, and its grace window is 30 minutes — so every scan is far
+        # more often than the work can possibly warrant.
+        self._sweep_tick += 1
+        if self._sweep_tick % _SETTLE_SWEEP_EVERY_N_SCANS == 1:
+            await self.settle_abandoned_usage()
 
         if not open_runs and not open_task_runs:
             return 0
@@ -582,3 +599,33 @@ class RecoveryScanner:
         except Exception:
             logger.error("[RecoveryScanner] task chain heal failed", exc_info=True)
             return {"rewound": 0, "deleted": 0}
+
+    async def settle_abandoned_usage(self) -> Dict[str, int]:
+        """Degraded billing settle for terminal rows no settle path will reach.
+
+        The normal settles are transactional (the finalize CAS for response
+        rows, the collector txn for task runs whatever status they finalized
+        on); what lands here is the leftovers — a completed child whose
+        parent died before collecting, or a row finalized by pre-gate code
+        during a rolling deploy. Settling stamps the row out of the in-flight
+        aggregate while leaving the heartbeated value in place as the last
+        durable observation of what the run spent; without this, a dead run's
+        heartbeat would count against its user forever. The grace interval
+        gives a live collector first claim on its transactional settle; both
+        updates are idempotent, so concurrent workers sweeping is harmless.
+        """
+        settled = {"responses": 0, "task_runs": 0}
+        try:
+            settled["responses"] = await credit_ledger.settle_abandoned("run")
+            settled["task_runs"] = await credit_ledger.settle_abandoned("task")
+            if settled["responses"] or settled["task_runs"]:
+                logger.warning(
+                    f"[RecoveryScanner] degraded-settled abandoned usage: "
+                    f"responses={settled['responses']} "
+                    f"task_runs={settled['task_runs']}"
+                )
+        except Exception:
+            logger.error(
+                "[RecoveryScanner] abandoned usage settle failed", exc_info=True
+            )
+        return settled

--- a/src/server/services/runs/sse_producer.py
+++ b/src/server/services/runs/sse_producer.py
@@ -576,7 +576,7 @@ class RunSSEProducer:
                             "warning",
                             {
                                 "thread_id": self.thread_id,
-                                "message": f"Workflow approaching timeout ({int(elapsed_time)}s / {self.workflow_timeout}s)",
+                                "message": f"Turn approaching timeout ({int(elapsed_time)}s / {self.workflow_timeout}s)",
                                 "type": "timeout_warning",
                                 "elapsed_seconds": int(elapsed_time),
                                 "timeout_seconds": self.workflow_timeout,
@@ -594,7 +594,7 @@ class RunSSEProducer:
                             "error",
                             {
                                 "thread_id": self.thread_id,
-                                "error": f"Workflow timeout after {int(elapsed_time)} seconds",
+                                "error": f"Turn timed out after {int(elapsed_time)} seconds",
                                 "type": "timeout_error",
                                 "elapsed_seconds": int(elapsed_time),
                                 "timeout_seconds": self.workflow_timeout,
@@ -1083,8 +1083,8 @@ class RunSSEProducer:
             )
             return False
 
-    def _derive_interrupt_reason(self) -> str:
-        """Classify the buffered interrupt: user question vs plan review."""
+    def _derive_interrupt_reason(self) -> Optional[str]:
+        """Classify the buffered interrupt into the ledger's reason column."""
         from src.server.contracts.status import classify_interrupt_reason
 
         return classify_interrupt_reason(

--- a/src/server/services/runs/subagent_collection.py
+++ b/src/server/services/runs/subagent_collection.py
@@ -904,7 +904,7 @@ async def persist_subagent_usage(
     persisted_count = 0
     persisted_records = 0
 
-    for task, records, tool_usage in claimed:
+    for task, records, tool_usage, settle_run_id in claimed:
         try:
             usage_service = UsagePersistenceService(
                 thread_id=thread_id,
@@ -925,12 +925,30 @@ async def persist_subagent_usage(
                 usage_service._token_usage["agent_id"] = task.agent_id
                 usage_service._token_usage["subagent_type"] = task.subagent_type
 
-            await usage_service.persist_usage(
+            # settle_task_run_id makes the usage insert and the ledger's
+            # billing-settle stamp one transaction; on failure (False) the
+            # row stays countable for the recovery sweep to degraded-settle.
+            persisted = await usage_service.persist_usage(
                 response_id=response_id,
                 msg_type="task",
                 status="completed",
                 is_byok=is_byok,
+                settle_task_run_id=settle_run_id,
             )
+            if not persisted:
+                # The records left task memory before this call, so a swallowed
+                # False loses them outright: the ledger row stays countable for
+                # the sweep to degraded-settle, but no billing row will ever be
+                # written for this task. Counting it as persisted would report
+                # the loss as a success.
+                logger.error(
+                    "[SubagentUsage] usage persist reported failure for task "
+                    "%s in thread_id=%s; %d record(s) are unrecoverable",
+                    task.task_id,
+                    thread_id,
+                    len(records),
+                )
+                continue
             persisted_count += 1
             persisted_records += len(records)
 

--- a/src/server/services/thread_status.py
+++ b/src/server/services/thread_status.py
@@ -189,6 +189,4 @@ async def read_thread_runtime_status(
 
     except Exception as e:
         logger.exception(f"Error checking workflow status for {thread_id}: {e}")
-        raise HTTPException(
-            status_code=500, detail=f"Failed to check workflow status: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail="Failed to check turn status")

--- a/src/server/utils/credit_resume_context.py
+++ b/src/server/utils/credit_resume_context.py
@@ -1,0 +1,60 @@
+"""
+Credit-resume context utilities for chat endpoint.
+
+Builds the ``<system-reminder>`` state update injected when a credit-paused
+turn resumes, recording which background tasks the credit gate stopped
+alongside the pause so the model can re-enter the ones still needed.
+"""
+
+import logging
+
+from langchain_core.messages import HumanMessage
+
+from src.server.database.runs import credit_ledger
+
+logger = logging.getLogger(__name__)
+
+
+async def build_credit_resume_update(
+    thread_id: str, resuming_run_id: str
+) -> dict | None:
+    """State update for a resume of a credit-paused turn, or None.
+
+    A mechanical record of which subagent runs the gate stopped alongside
+    the pause: their checkpoints survived the terminal settle, so the model
+    re-enters the ones still needed via Task(action="resume") — or declines,
+    which is a feature. Never blocks the resume: any lookup failure just
+    resumes without the record.
+    """
+    try:
+        stopped = await credit_ledger.list_credit_stopped_for_resume(
+            thread_id, resuming_run_id
+        )
+    except Exception:
+        logger.warning(
+            "[CreditGate] credit-resume lookup failed for thread %s",
+            thread_id,
+            exc_info=True,
+        )
+        return None
+    if not stopped:
+        return None
+    lines = "\n".join(f"- task_id \"{t['task_id']}\"" for t in stopped)
+    return {
+        "messages": [
+            HumanMessage(
+                content=(
+                    "<system-reminder>\n"
+                    "This run was paused when the account ran out of credits "
+                    "and has just been resumed. The credit gate also stopped "
+                    "the following background tasks at a clean checkpoint:\n"
+                    f"{lines}\n"
+                    "Their prior work is preserved. Resume each one still "
+                    'needed with Task(action="resume", task_id=...), or '
+                    "leave it stopped if its work is no longer relevant.\n"
+                    "</system-reminder>"
+                ),
+                additional_kwargs={"lc_source": "credit_gate"},
+            )
+        ]
+    }

--- a/src/utils/tracking/infrastructure_costs.py
+++ b/src/utils/tracking/infrastructure_costs.py
@@ -100,6 +100,20 @@ def _build_pricing_table() -> Dict[str, Any]:
 # Load pricing from manifests at module import (single source of truth)
 INFRASTRUCTURE_PRICING = _build_pricing_table()
 
+# Tool names already warned about, process-wide. This function used to run once
+# per turn at finalize; the runtime credit gate calls it on every spend poll, so
+# an unpriced name would otherwise log every couple of seconds per lane for the
+# rest of the turn. The set is unbounded only in the number of distinct tool
+# names, which is bounded by the toolset.
+_UNPRICED_WARNED: set[str] = set()
+
+
+def _warn_once(key: str, message: str) -> None:
+    if key in _UNPRICED_WARNED:
+        return
+    _UNPRICED_WARNED.add(key)
+    logger.warning(message)
+
 # Service name mapping (tool class names → user-friendly service names)
 TOOL_TO_SERVICE_MAPPING = {
     "TavilySearchTool": "tavily_search",
@@ -159,9 +173,10 @@ def calculate_infrastructure_credits(
 
         pricing = pricing_config.get(tool_name)
         if not pricing:
-            logger.warning(
+            _warn_once(
+                f"missing:{tool_name}",
                 f"[InfrastructureCosts] No pricing found for tool: {tool_name}. "
-                f"Skipping credit calculation."
+                f"Skipping credit calculation.",
             )
             continue
 
@@ -179,9 +194,10 @@ def calculate_infrastructure_credits(
             credits_per_op = pricing["credits_per_op"]
             tool_credits = count * credits_per_op
         else:
-            logger.warning(
+            _warn_once(
+                f"format:{tool_name}",
                 f"[InfrastructureCosts] Unknown pricing format for {tool_name}. "
-                f"Skipping."
+                f"Skipping.",
             )
             continue
 

--- a/src/utils/tracking/per_call_token_tracker.py
+++ b/src/utils/tracking/per_call_token_tracker.py
@@ -22,6 +22,7 @@ from langchain_core.messages.ai import UsageMetadata, add_usage
 from langchain_core.outputs import ChatGeneration, LLMResult
 
 from src.llms.token_counter import extract_token_usage
+from src.utils.tracking.core import calculate_cost_from_per_call_records
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,15 @@ class PerCallTokenTracker(BaseCallbackHandler):
         self._lock = threading.Lock()
         self.per_call_records: List[Dict[str, Any]] = []
         self.usage_metadata: Dict[str, UsageMetadata] = {}
+        # Running USD total of platform-billed calls. A reader prices only the
+        # records appended since the last read, through the batch pass that
+        # bills the turn, so the gate's arithmetic is the biller's arithmetic
+        # rather than a copy of it. Advisory by design: the billed figure
+        # remains that finalize-time pass, so a pricing failure here costs
+        # gating precision, never money.
+        self._platform_usd: float = 0.0
+        self._priced_upto: int = 0
+        self._pricing_error_logged = False
         # Maps run_id → what is only knowable at dispatch: the billing attribution
         # stamped on the client that issued the call (see LLM.get_llm) — billing_type,
         # the manifest key, the pricing id/provider that key resolves to — plus the
@@ -271,20 +281,22 @@ class PerCallTokenTracker(BaseCallbackHandler):
             )
             return
 
+        record = {
+            "model_name": model_name,
+            "served_model": served_model,
+            "pricing_model_id": attribution.get("pricing_model_id"),
+            "pricing_provider": attribution.get("pricing_provider"),
+            "usage": usage_metadata,
+            "billing_type": billing_type,
+            "started_at": attribution.get("started_at"),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "run_id": str(run_id),
+            "parent_run_id": str(parent_run_id) if parent_run_id else None,
+        }
+
         with self._lock:
             # Store per-call record
-            self.per_call_records.append({
-                "model_name": model_name,
-                "served_model": served_model,
-                "pricing_model_id": attribution.get("pricing_model_id"),
-                "pricing_provider": attribution.get("pricing_provider"),
-                "usage": usage_metadata,
-                "billing_type": billing_type,
-                "started_at": attribution.get("started_at"),
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "run_id": str(run_id),
-                "parent_run_id": str(parent_run_id) if parent_run_id else None,
-            })
+            self.per_call_records.append(record)
 
             # Also maintain aggregated usage for backward compatibility
             if model_name not in self.usage_metadata:
@@ -304,6 +316,41 @@ class PerCallTokenTracker(BaseCallbackHandler):
     ) -> None:
         with self._lock:
             self._run_attribution.pop(run_id, None)
+
+    def platform_usd_total(self) -> float:
+        """Running USD total of platform-billed calls, for mid-run gating.
+
+        Prices only the records appended since the last read, through the same
+        batch pass that bills the turn — one pricing implementation rather than
+        a second one that has to be kept agreeing with it. A tail that raises
+        is skipped rather than retried: the alternative freezes this figure for
+        the rest of the turn, and a record that cannot be priced here cannot be
+        billed at finalize either, so it is already a money bug elsewhere.
+        """
+        # The lock guards the records and the cursor, not the pricing pass:
+        # this is called on every model boundary and on a two-second
+        # heartbeat, and holding it across the pass stalls the callbacks
+        # appending the records being priced.
+        with self._lock:
+            tail = self.per_call_records[self._priced_upto:]
+            self._priced_upto = len(self.per_call_records)
+            if not tail:
+                return self._platform_usd
+        try:
+            priced = calculate_cost_from_per_call_records(tail)["platform_cost"]
+        except Exception:
+            priced = 0.0
+            if not self._pricing_error_logged:
+                self._pricing_error_logged = True
+                logger.warning(
+                    "Failed to price %d record(s) into the running total; "
+                    "the mid-run spend figure undercounts them",
+                    len(tail),
+                    exc_info=True,
+                )
+        with self._lock:
+            self._platform_usd += priced
+            return self._platform_usd
 
     def get_aggregated_usage(self) -> Dict[str, UsageMetadata]:
         """
@@ -345,6 +392,9 @@ class PerCallTokenTracker(BaseCallbackHandler):
             self.per_call_records.clear()
             self.usage_metadata.clear()
             self._run_attribution.clear()
+            self._platform_usd = 0.0
+            self._priced_upto = 0
+            self._pricing_error_logged = False
 
     def __repr__(self) -> str:
         """String representation showing number of calls and models tracked."""

--- a/tests/unit/llms/test_chunk_multiplier.py
+++ b/tests/unit/llms/test_chunk_multiplier.py
@@ -1,0 +1,97 @@
+"""What a spend budget for one model is worth against another's.
+
+Every assertion here is a relationship, never a rate: the manifest's numbers
+move whenever a vendor reprices, and a test that pins them turns a price cut
+into a failure. What must hold is the ordering and the fallbacks.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.llms import pricing_utils
+from src.llms.pricing_utils import (
+    _BASELINE_BLENDED_RATE,
+    blended_rate,
+    chunk_multiplier,
+)
+
+# DeepSeek's card is the one with hours on it: peak is 01-04 and 06-10 UTC on
+# weekdays, so these two stamps straddle a boundary the manifest defines.
+_SCHEDULED = "deepseek-v4-pro"
+_PEAK = datetime(2026, 8, 27, 2, 0, tzinfo=timezone.utc)  # a Thursday
+_OFF_PEAK = datetime(2026, 8, 27, 12, 0, tzinfo=timezone.utc)
+
+
+def test_a_model_with_no_card_has_no_opinion():
+    """None, not 1.0. The caller decides what a missing rate means, and the
+    gate's answer — reserve at baseline — is a different statement from
+    'this model costs the baseline'."""
+    assert chunk_multiplier("not-a-real-model-anywhere") is None
+    assert blended_rate("not-a-real-model-anywhere") is None
+
+
+def test_a_pricier_model_buys_a_bigger_budget():
+    """The ordering is the whole product. Sonnet over Haiku, Opus over Sonnet:
+    if this inverts, a premium turn is reserving less than a cheap one."""
+    haiku = chunk_multiplier("claude-haiku-4-5")
+    sonnet = chunk_multiplier("claude-sonnet-5")
+    opus = chunk_multiplier("claude-opus-5")
+    assert haiku is not None and sonnet is not None and opus is not None
+    assert haiku < sonnet < opus
+
+
+def test_an_hourly_card_is_cheaper_off_peak():
+    """A model priced by the clock genuinely costs less at some hours, and a
+    budget that ignores that over-reserves for most of the day."""
+    assert blended_rate(_SCHEDULED, at=_OFF_PEAK) < blended_rate(_SCHEDULED, at=_PEAK)
+
+
+def test_the_mix_weights_reads_far_above_input():
+    """Traffic is mostly cache reads, so the blended rate has to sit nearer the
+    read rate than the input rate. A blend that landed at or above input would
+    mean the mix was being ignored."""
+    from src.llms.pricing_utils import find_model_pricing
+
+    card = find_model_pricing("claude-sonnet-5", "anthropic")
+    rate = blended_rate("claude-sonnet-5")
+    assert rate is not None and card is not None
+    assert card["cached_input"] < rate < card["input"]
+
+
+@pytest.mark.parametrize("model", ["claude-opus-5", "deepseek-v4-pro", "gpt-5.6-sol"])
+def test_a_multiplier_is_a_coarse_figure(model):
+    """Snapped, because a budget is read by people. Anything below the baseline
+    lands on a tenth, anything above on a half — a rate that drifts by a cent
+    must not restate every reservation on the platform."""
+    m = chunk_multiplier(model)
+    assert m is not None
+    step = 0.1 if m < 1 else 0.5
+    assert round(m / step) == pytest.approx(m / step)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (0.32, 0.3),
+        (0.38, 0.4),
+        (1.20, 1.0),
+        (1.30, 1.5),
+        (2.74, 2.5),
+        (2.76, 3.0),
+        (8.24, 8.0),
+        (8.26, 8.5),
+    ],
+)
+def test_a_multiplier_lands_on_the_nearest_rung(monkeypatch, raw, expected):
+    """Nearest, not up and not down.
+
+    The granularity check above passes just as happily on a floor, so the
+    direction needs its own witness. Synthetic ratios rather than manifest
+    models: a repricing must never fail this. No case sits on an exact tie —
+    there both rungs are equally near, so the direction is free to change.
+    """
+    monkeypatch.setattr(
+        pricing_utils, "blended_rate", lambda *a, **k: raw * _BASELINE_BLENDED_RATE
+    )
+    assert chunk_multiplier("any-model") == pytest.approx(expected)

--- a/tests/unit/middleware/test_credit_gate.py
+++ b/tests/unit/middleware/test_credit_gate.py
@@ -1,0 +1,751 @@
+"""Runtime credit gate — the invariants the module promises in its docstring.
+
+Fail-open is the load-bearing one: mid-run, inability to check must never stop
+a run, so a metering read that raises has to be contained rather than escape
+the model-boundary hook. The rest pin the stop decision (own-spend vs
+own-ceiling, and only under a recorded denial), the monotone ceiling, the
+gate's lifetime under every way a stream can end, the two lane behaviours, and
+the pause payload's agreement with the status classifier that reads it.
+
+One reservation per turn is the other load-bearing one, and it is the fixed
+regression: a subagent must not be denied against its own parent's grant, and
+the lease must outlive the main run for as long as any subagent is still
+spending under it.
+
+The port is duck-typed by design, which is what makes all of this testable
+without a server; every test here fakes it and nothing touches a database.
+Spend is asserted by comparison, never against a credit figure — the USD rate
+and the infrastructure pricing table are configuration, not contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ptc_agent.agent.middleware import credit_gate as credit_gate_module
+from ptc_agent.agent.middleware.credit_gate import (
+    CreditGateMiddleware,
+    CreditGateState,
+    CreditLease,
+    CreditStopError,
+    LeaseVerdict,
+    build_pause_payload,
+    current_credit_gate,
+    run_with_credit_gate,
+)
+from langgraph.types import Interrupt
+
+from src.server.contracts.status import classify_interrupt_reason
+
+# Copy the platform would author; langalpha only ever relays it.
+_DENIAL_COPY = "Out of credits. Top up to keep this run going."
+
+
+class FakeTracker:
+    """Token-side meter. Raises from ``platform_usd_total`` once armed."""
+
+    def __init__(self, usd: float = 0.0) -> None:
+        self.usd = usd
+        self.boom = False
+
+    def platform_usd_total(self) -> float:
+        if self.boom:
+            raise RuntimeError("tracker read failed")
+        return self.usd
+
+
+class FakeToolTracker:
+    """Tool-usage meter. Armed, it fails the way a lock-free dict actually
+    fails when a running tool mutates it mid-read."""
+
+    def __init__(self, usage: dict | None = None) -> None:
+        self.usage = dict(usage or {})
+        self.boom = False
+
+    def get_summary(self) -> dict:
+        if self.boom:
+            raise RuntimeError("dictionary changed size during iteration")
+        return dict(self.usage)
+
+
+class FakePort:
+    """Records every call; answers with whatever verdicts the test queued
+    (exhausted queue = None, the service's "no verdict" / fail-open shape)."""
+
+    def __init__(
+        self,
+        verdicts: list | None = None,
+        heartbeat_results: list | None = None,
+    ) -> None:
+        self.verdicts = list(verdicts or [])
+        self.acquires: list[tuple] = []
+        self.multipliers: list[float] = []
+        self.byoks: list[bool] = []
+        self.releases: list[tuple] = []
+        self.heartbeats: list[tuple] = []
+        self.heartbeat_results = list(heartbeat_results or [])
+
+    async def acquire(
+        self,
+        user_id: str,
+        run_ref: str,
+        spent_credits: float,
+        rate_multiplier: float = 1.0,
+        byok: bool = False,
+    ):
+        self.acquires.append((user_id, run_ref, spent_credits))
+        self.multipliers.append(rate_multiplier)
+        self.byoks.append(byok)
+        return self.verdicts.pop(0) if self.verdicts else None
+
+    async def release(
+        self, user_id: str, run_ref: str, generation: int | None = None
+    ) -> None:
+        self.releases.append((user_id, run_ref, generation))
+
+    async def heartbeat(self, kind: str, run_ref: str, credits: float):
+        self.heartbeats.append((kind, run_ref, credits))
+        if not self.heartbeat_results:
+            return True
+        answer = self.heartbeat_results.pop(0)
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+
+async def join_quiet(lease: CreditLease, member: CreditGateState) -> None:
+    """Join, then stand the lease's refresher back down. Membership is what
+    every family-total assertion here needs; the loop is not — these tests
+    drive its tick by hand, and a live one would race every assertion about
+    what the port was asked."""
+    await lease.join(member)
+    await lease._stop_refresher()
+    lease._closed = False
+
+
+async def make_gate(**overrides) -> CreditGateState:
+    port = overrides.pop("port", None) or FakePort()
+    lease = overrides.pop("lease", None) or CreditLease(
+        user_id="user-1", run_ref="run-1", port=port
+    )
+    params = {"run_ref": "run-1", "kind": "run", "port": port, "lease": lease}
+    params.update(overrides)
+    gate = CreditGateState(**params)
+    await join_quiet(lease, gate)
+    return gate
+
+
+async def metered_gate(
+    **overrides,
+) -> tuple[CreditGateState, FakeTracker, FakeToolTracker]:
+    tracker = FakeTracker(usd=2.0)
+    tools = FakeToolTracker({"TavilySearchTool": 3})
+    gate = await make_gate(tracker=tracker, tool_tracker=tools, **overrides)
+    return gate, tracker, tools
+
+
+async def _run_boundary(gate: CreditGateState):
+    """Drive one model boundary through the middleware under the lane var."""
+    token = current_credit_gate.set(gate)
+    try:
+        return await CreditGateMiddleware().abefore_model({}, None)
+    finally:
+        current_credit_gate.reset(token)
+
+
+# -- fail open ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("failing", ["tracker", "tool_tracker"])
+@pytest.mark.asyncio
+async def test_spend_holds_the_last_good_value_when_a_meter_raises(failing):
+    gate, tracker, tools = await metered_gate()
+    good = gate.spend()
+    assert good > 0, "fixture must actually meter, or the test proves nothing"
+
+    setattr(tracker if failing == "tracker" else tools, "boom", True)
+
+    assert gate.spend() == good
+    assert gate.spend() == good, "the held value survives repeated failed reads"
+
+
+@pytest.mark.parametrize("failing", ["tracker", "tool_tracker"])
+@pytest.mark.asyncio
+async def test_a_broken_meter_never_stops_a_run(failing):
+    """The module's first-paragraph promise: inability to check fails open."""
+    gate, tracker, tools = await metered_gate()
+    good = gate.spend()
+    setattr(tracker if failing == "tracker" else tools, "boom", True)
+
+    assert await _run_boundary(gate) is None
+    assert gate.spend() == good
+
+
+# -- stop decision --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_recorded_verdict_never_stops():
+    lease = (await make_gate()).lease
+    lease.ceiling_credits = 100.0
+    assert lease.should_stop(1_000_000.0) is False
+
+
+@pytest.mark.asyncio
+async def test_spend_under_a_standing_grant_is_entitled_to_finish():
+    lease = (await make_gate()).lease
+    lease.ceiling_credits = 100.0
+    lease.denial = {"message": _DENIAL_COPY}
+    assert lease.should_stop(99.9) is False
+
+
+@pytest.mark.asyncio
+async def test_a_denial_stops_at_and_past_the_granted_ceiling():
+    lease = (await make_gate()).lease
+    lease.ceiling_credits = 100.0
+    lease.denial = {"message": _DENIAL_COPY}
+    assert lease.should_stop(100.0) is True
+    assert lease.should_stop(100.1) is True
+
+
+# -- verdict recording ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_stale_grant_never_lowers_the_ceiling():
+    lease = (await make_gate()).lease
+    lease._record(LeaseVerdict(granted=True, ceiling_credits=500.0, ttl_seconds=60))
+    assert lease.ceiling_credits == 500.0
+
+    # A response that overtook a newer one on the wire.
+    lease._record(LeaseVerdict(granted=True, ceiling_credits=200.0, ttl_seconds=60))
+    assert lease.ceiling_credits == 500.0
+
+
+@pytest.mark.asyncio
+async def test_no_verdict_leaves_the_previous_one_standing():
+    lease = (await make_gate()).lease
+    lease._record(LeaseVerdict(granted=False, quota={"message": _DENIAL_COPY}))
+    lease._record(None)
+    assert lease.denial == {"message": _DENIAL_COPY}
+
+
+# -- lifetime -------------------------------------------------------------
+
+
+def count_closes(gate: CreditGateState) -> list:
+    calls: list = []
+    original = gate.aclose
+
+    async def counted() -> None:
+        calls.append(1)
+        await original()
+
+    gate.aclose = counted
+    return calls
+
+
+async def _events(*items):
+    for item in items:
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_gate_closes_once_when_the_stream_completes():
+    gate = await make_gate()
+    closes = count_closes(gate)
+
+    seen = [e async for e in run_with_credit_gate(gate, _events("a", "b"))]
+
+    assert seen == ["a", "b"]
+    assert closes == [1]
+    assert gate.port.releases == [("user-1", "run-1", None)]
+
+
+@pytest.mark.asyncio
+async def test_gate_closes_once_when_the_stream_raises():
+    gate = await make_gate()
+    closes = count_closes(gate)
+
+    async def failing():
+        yield "a"
+        raise RuntimeError("upstream blew up")
+
+    with pytest.raises(RuntimeError, match="upstream blew up"):
+        async for _ in run_with_credit_gate(gate, failing()):
+            pass
+
+    assert closes == [1]
+    assert gate.port.releases == [("user-1", "run-1", None)]
+
+
+@pytest.mark.asyncio
+async def test_gate_closes_once_when_the_driving_task_is_cancelled():
+    gate = await make_gate()
+    closes = count_closes(gate)
+    started = asyncio.Event()
+
+    async def hanging():
+        yield "a"
+        started.set()
+        await asyncio.sleep(3600)
+
+    async def drive():
+        async for _ in run_with_credit_gate(gate, hanging()):
+            pass
+
+    task = asyncio.create_task(drive())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert closes == [1]
+    # The lease is retired even on the cancellation path — aclose shields
+    # each teardown step precisely so a cancel cannot strand a live lease.
+    assert gate.port.releases == [("user-1", "run-1", None)]
+
+
+@pytest.mark.asyncio
+async def test_no_gate_passes_the_stream_through_untouched():
+    assert [e async for e in run_with_credit_gate(None, _events("a", "b"))] == ["a", "b"]
+
+
+# -- lane behaviour -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_lane_raises_credit_stop_error():
+    gate = await make_gate(kind="task")
+    gate.lease.denial = {"message": _DENIAL_COPY}
+
+    with pytest.raises(CreditStopError) as excinfo:
+        await _run_boundary(gate)
+
+    assert str(excinfo.value) == _DENIAL_COPY
+
+
+@pytest.mark.asyncio
+async def test_run_lane_pauses_instead_of_raising(monkeypatch):
+    gate = await make_gate(kind="run")
+    gate.lease.denial = {"message": _DENIAL_COPY}
+    seen: list = []
+
+    class _Paused(Exception):
+        """Stands in for the interrupt langgraph raises on the first pass."""
+
+    def fake_interrupt(payload):
+        seen.append(payload)
+        raise _Paused()
+
+    monkeypatch.setattr(credit_gate_module, "interrupt", fake_interrupt)
+
+    with pytest.raises(_Paused):
+        await _run_boundary(gate)
+
+    assert seen == [build_pause_payload(gate.lease)]
+
+
+# -- one reservation per turn ---------------------------------------------
+
+
+async def child_of(parent: CreditGateState, usd: float = 0.0) -> CreditGateState:
+    child = parent.spawn_child(
+        run_ref="task-1", tracker=FakeTracker(usd=usd), tool_tracker=None
+    )
+    await join_quiet(parent.lease, child)
+    return child
+
+
+@pytest.mark.asyncio
+async def test_a_child_reserves_nothing_of_its_own():
+    """The regression. A subagent asking for its own lease was denied against
+    the parent's grant, because the parent's ceiling counts as reserved for
+    everyone but the parent. A child must never ask."""
+    port = FakePort([LeaseVerdict(granted=True, ceiling_credits=500.0, ttl_seconds=900)])
+    parent = await make_gate(port=port)
+    child = await child_of(parent)
+
+    assert child.lease is parent.lease
+
+    # Drive one refresh directly instead of starting the task. An acquire has
+    # to actually happen for any of this to mean anything: assert on an empty
+    # list and the test passes just as well against a gate that never asks.
+    await parent.lease._tick()
+    assert port.acquires, "the lease must actually ask, or this proves nothing"
+    assert {ref for _, ref, _ in port.acquires} == {"run-1"}
+
+    await child.aclose()
+    assert {ref for _, ref, _ in port.acquires} == {"run-1"}, "the child asked too"
+    assert port.releases == [], "a live parent still holds the lease"
+
+
+@pytest.mark.asyncio
+async def test_a_child_is_not_stopped_merely_for_having_no_ceiling_of_its_own():
+    """Fresh child state used to mean ceiling 0, so any denial stopped it at
+    spend 0 — before its first model call. It now answers to the family."""
+    parent = await make_gate()
+    child = await child_of(parent)
+    parent.lease.ceiling_credits = 100.0
+    parent.lease.denial = {"message": _DENIAL_COPY}
+
+    assert child.spend() == 0.0
+    assert parent.lease.should_stop(parent.lease.spend()) is False
+
+
+@pytest.mark.asyncio
+async def test_family_spend_sums_live_lanes_and_retains_retired_ones():
+    parent = await make_gate(tracker=FakeTracker(usd=2.0))
+    child = await child_of(parent, usd=3.0)
+    lease = parent.lease
+
+    both = lease.spend()
+    assert both > parent.spend() > 0, "the family total includes the child"
+    assert both > child.spend() > 0
+
+    await lease.leave(child)
+    assert lease.spend() == pytest.approx(both), "a finished lane's spend stays"
+
+
+@pytest.mark.asyncio
+async def test_the_lease_outlives_the_main_run_until_the_last_child_leaves():
+    """``auto_wait=False`` means subagent writers keep working after the main
+    stream ends. Releasing on the parent's close would leave them ungated."""
+    parent = await make_gate()
+    child = await child_of(parent)
+
+    await parent.aclose()
+    assert parent.port.releases == [], "a live child still holds the reservation"
+
+    await child.aclose()
+    assert parent.port.releases == [("user-1", "run-1", None)]
+
+
+@pytest.mark.asyncio
+async def test_a_lane_joining_during_a_release_never_waits_on_the_network():
+    """A subagent's first step is scheduled independently of its spawn, so it
+    can arrive after the last lane left and the release is already in flight.
+    The join must not wait that out — nothing in this gate makes a lane wait on
+    the network. The fence is what keeps the two apart: the release retires the
+    generation it was granted, not the one the latecomer just took out."""
+    port = FakePort(
+        [
+            LeaseVerdict(granted=True, ceiling_credits=500.0, generation=1),
+            LeaseVerdict(granted=True, ceiling_credits=500.0, generation=2),
+        ]
+    )
+    released = asyncio.Event()
+    let_release_finish = asyncio.Event()
+    real_release = port.release
+
+    async def slow_release(*args):
+        released.set()
+        await let_release_finish.wait()
+        await real_release(*args)
+
+    port.release = slow_release
+    parent = await make_gate(port=port)
+    lease = parent.lease
+    lease._record(await port.acquire("user-1", "run-1", 0.0))
+
+    leaving = asyncio.create_task(lease.leave(parent))
+    await released.wait()
+
+    latecomer = parent.spawn_child(
+        run_ref="task-late", tracker=FakeTracker(), tool_tracker=None
+    )
+    await asyncio.wait_for(lease.join(latecomer), timeout=1.0)
+    assert latecomer in lease._members
+    assert lease._refresher is not None, "the latecomer is spending under a dead lease"
+
+    let_release_finish.set()
+    await leaving
+    assert port.releases == [("user-1", "run-1", 1)], "retired the wrong grant"
+
+    # ...and the reopened lease is released on its own generation.
+    await lease.leave(latecomer)
+    assert port.releases[-1] == ("user-1", "run-1", 2)
+
+
+@pytest.mark.asyncio
+async def test_leaving_twice_does_not_double_count_or_double_release():
+    parent = await make_gate(tracker=FakeTracker(usd=2.0))
+    lease = parent.lease
+    spent = parent.spend()
+
+    await lease.leave(parent)
+    await lease.leave(parent)
+
+    assert lease._retired_credits == pytest.approx(spent)
+    assert parent.port.releases == [("user-1", "run-1", None)]
+
+
+@pytest.mark.asyncio
+async def test_release_is_fenced_on_the_generation_it_was_granted():
+    """Unfenced, a release retires whatever grant is current — including one a
+    lane that rejoined took out while this teardown was in flight."""
+    port = FakePort([LeaseVerdict(granted=True, ceiling_credits=10.0, generation=7)])
+    gate = await make_gate(port=port)
+    gate.lease._record(await port.acquire("user-1", "run-1", 0.0))
+
+    await gate.lease.leave(gate)
+
+    assert port.releases == [("user-1", "run-1", 7)]
+
+
+@pytest.mark.asyncio
+async def test_a_denial_still_refreshes_the_generation():
+    """A denial refreshes the reservation's reported spend on the service, so
+    its generation is newer than the last grant's — releasing on the older one
+    would no-op and leave the reservation standing."""
+    port = FakePort()
+    gate = await make_gate(port=port)
+    gate.lease._record(
+        LeaseVerdict(granted=True, ceiling_credits=10.0, generation=3)
+    )
+    gate.lease._record(
+        LeaseVerdict(granted=False, quota={"message": "no"}, generation=4)
+    )
+
+    await gate.lease.leave(gate)
+
+    assert port.releases == [("user-1", "run-1", 4)]
+
+
+# -- payload / classifier agreement ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pause_payload_classifies_as_a_credit_pause():
+    lease = (await make_gate()).lease
+    lease.denial = {"message": _DENIAL_COPY}
+    payload = build_pause_payload(lease)
+
+    assert classify_interrupt_reason([Interrupt(value=payload)]) == "credit_pause"
+    assert payload["action_requests"][0]["message"] == _DENIAL_COPY
+
+
+@pytest.mark.asyncio
+async def test_a_denial_without_copy_still_classifies_and_still_explains():
+    """``_record``'s no-copy denial shape. The classifier must still see a
+    credit pause, and the card must never get an explanation-less box."""
+    lease = (await make_gate()).lease
+    lease.denial = {"message": None}
+    payload = build_pause_payload(lease)
+
+    assert classify_interrupt_reason([Interrupt(value=payload)]) == "credit_pause"
+    assert payload["action_requests"][0]["message"]
+
+
+# -- what the family reserves against -------------------------------------
+
+@pytest.mark.asyncio
+async def test_the_lease_relays_whose_key_the_turn_runs_on():
+    """Relayed, never branched on here. The service folds the same billing row
+    for admission and for this, so a lease that cannot see an own-key turn
+    answers it out of a pool that does not apply to it."""
+    port = FakePort([LeaseVerdict(granted=True, ceiling_credits=50.0, ttl_seconds=60)])
+    lease = CreditLease(user_id="u", run_ref="r", port=port, is_byok=True)
+    await lease._acquire(0.0)
+    assert port.byoks == [True]
+
+    # Default off, so a build that never resolved a credential source sends the
+    # payload a platform-funded turn has always sent.
+    plain = CreditLease(user_id="u", run_ref="r", port=FakePort([]))
+    assert plain.is_byok is False
+
+
+
+@pytest.mark.asyncio
+async def test_the_family_reserves_for_its_priciest_live_lane():
+    """One reservation covers every lane, so it has to be sized for the most
+    expensive model running under it. A subagent pinned to a premium model
+    under a cheap main run is the case that matters: budget the turn at the
+    main run's rate and that lane spends the whole chunk on one call, then
+    comes back to the service at every boundary after it."""
+    port = FakePort([LeaseVerdict(granted=True, ceiling_credits=500.0, ttl_seconds=900)])
+    parent = await make_gate(port=port)
+    parent.rate_multiplier = 1.0
+    child = parent.spawn_child(
+        run_ref="task-1", tracker=None, tool_tracker=None, rate_multiplier=16.5
+    )
+    await join_quiet(parent.lease, child)
+
+    await parent.lease._tick()
+
+    assert port.multipliers == [16.5]
+    await child.aclose()
+
+
+@pytest.mark.asyncio
+async def test_a_lane_keeps_the_turn_s_rate_unless_given_its_own():
+    """The overwhelming majority of subagents run the model their turn does,
+    so inheriting is the default and an override is the exception."""
+    parent = await make_gate()
+    parent.rate_multiplier = 5.0
+    inherits = parent.spawn_child(run_ref="t1", tracker=None, tool_tracker=None)
+    overrides = parent.spawn_child(
+        run_ref="t2", tracker=None, tool_tracker=None, rate_multiplier=0.5
+    )
+    assert inherits.rate_multiplier == 5.0
+    assert overrides.rate_multiplier == 0.5
+
+
+@pytest.mark.asyncio
+async def test_a_retired_lane_stops_setting_the_family_s_rate():
+    """A lane that has finished is done spending, and holding its rate would
+    keep the whole turn reserving against a model no longer running."""
+    port = FakePort(
+        [LeaseVerdict(granted=True, ceiling_credits=500.0, ttl_seconds=900)] * 2
+    )
+    parent = await make_gate(port=port)
+    parent.rate_multiplier = 1.0
+    child = parent.spawn_child(
+        run_ref="task-1", tracker=None, tool_tracker=None, rate_multiplier=16.5
+    )
+    await join_quiet(parent.lease, child)
+    await parent.lease._tick()
+
+    await parent.lease.leave(child)
+    # Drive a renewal rather than a fresh ask: the standing grant is still
+    # inside its TTL, so a bare tick correctly declines to re-acquire, and
+    # asserting on that tick would pass against a lease that never re-rates.
+    parent.lease._next_acquire_at = 0.0
+    parent.lease._lease_deadline = 0.0
+    await parent.lease._tick()
+
+    assert port.multipliers == [16.5, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_a_run_denied_on_its_first_acquire_keeps_asking():
+    """A denial carries no ceiling, so a run refused on its very first acquire
+    still holds the 0.0 it started with. Reading that as "past its ceiling" and
+    giving up withheld the top-up window from the user most likely to want it:
+    the one who just ran out."""
+    port = FakePort(
+        [
+            LeaseVerdict(
+                granted=False,
+                ceiling_credits=0.0,
+                ttl_seconds=0,
+                quota={"message": _DENIAL_COPY},
+            ),
+            LeaseVerdict(granted=True, ceiling_credits=50.0, ttl_seconds=900),
+        ]
+    )
+    gate = await make_gate(port=port)
+    lease = gate.lease
+
+    await lease._tick()
+    assert lease.denial is not None
+    assert lease.ceiling_credits == 0.0
+
+    # The top-up lands between two model boundaries. Clear the spacing floor so
+    # the next tick is due; the point is whether it asks at all, not when.
+    lease._next_acquire_at = 0.0
+    await lease._tick()
+
+    assert len(port.acquires) == 2, "a run denied at ceiling 0 stopped asking"
+    assert lease.denial is None, "the green verdict has to clear the denial"
+    assert lease.ceiling_credits == 50.0
+
+
+# -- ledger heartbeat -----------------------------------------------------
+#
+# The cursor the unchanged-spend guard reads may only ever name spend the
+# ledger accepted. Advancing it on an attempt instead left an idle lane
+# (a long execute_code, a subagent waiting on a sandbox) absent from the
+# in-flight aggregate until it spent again or closed.
+
+
+def _make_due(gate: CreditGateState) -> None:
+    """Age the lane past the flush interval so the next poll is due."""
+    gate._last_flush_at -= credit_gate_module._FLUSH_INTERVAL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_a_failed_heartbeat_is_retried_on_the_next_due_poll():
+    port = FakePort(heartbeat_results=[RuntimeError("ledger write failed")])
+    gate, _, _ = await metered_gate(port=port)
+
+    await gate._flush_if_due()
+    assert len(port.heartbeats) == 1, "the first beat should have been attempted"
+
+    # Spend has not moved. The retry is owed to the failure, not to new spend.
+    _make_due(gate)
+    await gate._flush_if_due()
+
+    assert len(port.heartbeats) == 2, "a failed beat was never retried"
+    assert port.heartbeats[0][2] == port.heartbeats[1][2]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_heartbeat_does_not_retry_faster_than_the_interval():
+    """The retry owes its spacing to the attempt, not the last accepted write.
+
+    Keying the delta arm off the flush cursor would leave it permanently true
+    for any lane more than the delta past its last good write, turning every
+    poll into a database round trip for as long as the ledger stayed down.
+    """
+    port = FakePort(heartbeat_results=[RuntimeError("ledger write failed")])
+    gate, _, _ = await metered_gate(port=port)
+
+    await gate._flush_if_due()
+    await gate._flush_if_due()
+    await gate._flush_if_due()
+
+    assert len(port.heartbeats) == 1, "a failing lane retried on every poll"
+
+
+@pytest.mark.asyncio
+async def test_an_accepted_write_is_not_resent_while_spend_is_flat():
+    port = FakePort()
+    gate, _, _ = await metered_gate(port=port)
+
+    await gate._flush_if_due()
+    _make_due(gate)
+    await gate._flush_if_due()
+
+    assert len(port.heartbeats) == 1, "an accepted beat was rewritten unchanged"
+
+
+@pytest.mark.asyncio
+async def test_a_closed_row_stops_the_lane_without_new_spend():
+    port = FakePort(heartbeat_results=[False] * credit_gate_module._DEAD_ROW_STOPS)
+    gate, _, _ = await metered_gate(port=port)
+
+    for _ in range(credit_gate_module._DEAD_ROW_STOPS):
+        _make_due(gate)
+        await gate._flush_if_due()
+
+    assert gate._closed is True, "a closed row never reached the stop count"
+
+
+@pytest.mark.asyncio
+async def test_an_errored_beat_does_not_clear_the_dead_row_count():
+    """``None`` is the port's documented error shape, not an accepted write.
+
+    Reading it as success reset the count that decides a row is gone, so a
+    lane alternating error and refusal would never reach the stop.
+    """
+    port = FakePort(heartbeat_results=[False, None, False, False])
+    gate, _, _ = await metered_gate(port=port)
+
+    for _ in range(4):
+        _make_due(gate)
+        await gate._flush_if_due()
+
+    assert gate._closed is True
+
+
+@pytest.mark.asyncio
+async def test_aclose_flushes_the_final_absolute_spend():
+    port = FakePort()
+    gate, _, _ = await metered_gate(port=port)
+
+    await gate.aclose()
+
+    assert len(port.heartbeats) == 1, "teardown skipped the final flush"

--- a/tests/unit/middleware/test_registry_task_cancel.py
+++ b/tests/unit/middleware/test_registry_task_cancel.py
@@ -175,3 +175,48 @@ async def test_soft_cancel_leaves_the_handler_running():
         await task.asyncio_task
     assert not handler.done()
     handler.cancel()
+
+
+@pytest.mark.asyncio
+async def test_adopt_writer_outcome_honors_a_declared_terminal():
+    """``success: False`` alone reads as a failure; a writer that settled on a
+    neutral terminal says so and is believed.
+
+    The regression: a credit stop wrote ``cancelled`` to the ledger while this
+    mapped the same run to ``error`` in memory, so the durable row and the
+    agent-facing aggregate disagreed and the model was steered off the
+    resumable path.
+    """
+    registry = BackgroundTaskRegistry(thread_id="thread-x")
+    task = await _register(registry, "tc-stop")
+
+    async def _stopped() -> dict:
+        return {
+            "success": False,
+            "error": "out of credits",
+            "error_type": "credit_stop",
+            "status": "cancelled",
+        }
+
+    writer = asyncio.create_task(_stopped())
+    await writer
+
+    task.adopt_writer_outcome(writer)
+    assert task.terminal_status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_adopt_writer_outcome_ignores_an_unknown_declared_status():
+    """A declared status outside the vocabulary falls back to the failure
+    reading rather than writing an unknown terminal."""
+    registry = BackgroundTaskRegistry(thread_id="thread-x")
+    task = await _register(registry, "tc-bogus")
+
+    async def _bogus() -> dict:
+        return {"success": False, "error": "x", "status": "not-a-terminal"}
+
+    writer = asyncio.create_task(_bogus())
+    await writer
+
+    task.adopt_writer_outcome(writer)
+    assert task.terminal_status == "error"

--- a/tests/unit/middleware/test_subagent_run_ledger_admission.py
+++ b/tests/unit/middleware/test_subagent_run_ledger_admission.py
@@ -25,6 +25,8 @@ from ptc_agent.agent.middleware.background_subagent.registry import (
     TaskRunRejected,
     TransportLostError,
 )
+from ptc_agent.agent.middleware.credit_gate import CreditStopError
+from src.server.contracts.status import CREDIT_STOP_ERROR_TYPE
 
 
 class FakeOwner:
@@ -258,6 +260,27 @@ async def test_abort_path_normalizes_error_type_spelling():
     (_run_id, status, failure) = ledger.finalized[0]
     assert status == "error"
     assert failure["error_type"] == "transport_lost"
+
+
+@pytest.mark.asyncio
+async def test_a_credit_stop_settles_cancelled_with_the_resume_query_spelling():
+    """The gate stop is terminal-neutral, not a failure, and the resume query
+    selects rows on exactly this pair. Were the status to drift back to
+    "error", ``list_credit_stopped_for_resume`` would match nothing and every
+    gate-stopped subagent would be stranded with no visible symptom."""
+    ledger = FakeLedger()
+    mw = _middleware(FakeOwner(), ledger)
+    mw.registry.write_task_meta = AsyncMock()
+
+    async def _stopped(_request):
+        raise CreditStopError("You have run out of credits.")
+
+    await mw.awrap_tool_call(_request({"description": "d", "prompt": "p"}), _stopped)
+    await mw.registry._tasks["tc-1"].asyncio_task
+
+    (_run_id, status, failure) = ledger.finalized[0]
+    assert status == "cancelled"  # not "error" — the resume query filters on it
+    assert failure["error_type"] == CREDIT_STOP_ERROR_TYPE
 
 
 @pytest.mark.asyncio

--- a/tests/unit/middleware/test_subagent_token_forwarder.py
+++ b/tests/unit/middleware/test_subagent_token_forwarder.py
@@ -292,6 +292,30 @@ async def test_forward_error_appends_error_record():
 
 
 @pytest.mark.asyncio
+async def test_forward_error_uses_the_declared_spelling_not_the_class_name():
+    """A credit stop reaches the frontend as ``credit_stop``, never
+    ``CreditStopError``.
+
+    The regression: this frame was built with ``type(exc).__name__``, so the
+    wire carried the class name while the frontend matched the contract
+    spelling. Nothing failed - the stop just rendered as a failure, and the
+    "task stopped" copy was unreachable in every locale.
+    """
+    from ptc_agent.agent.middleware.credit_gate import CreditStopError
+    from src.server.contracts.status import CREDIT_STOP_ERROR_TYPE
+
+    registry = BackgroundTaskRegistry()
+    task = await _register(registry)
+    fw = _SubagentTokenForwarder(registry, task.tool_call_id, "task:abc")
+
+    await fw.forward_error(CreditStopError("out of credits"))
+
+    record = next(e for e in task._test_records if e["event"] == "error")
+    assert record["data"]["error_type"] == CREDIT_STOP_ERROR_TYPE
+    assert record["data"]["error_type"] != "CreditStopError"
+
+
+@pytest.mark.asyncio
 async def test_forward_error_absorbs_registry_failure():
     """If append_captured_event raises (degraded Redis), forward_error must
     not propagate — it is always called inside an existing exception flow

--- a/tests/unit/ptc_agent/middleware/test_task_output_cancelled.py
+++ b/tests/unit/ptc_agent/middleware/test_task_output_cancelled.py
@@ -16,6 +16,9 @@ from ptc_agent.agent.middleware.background_subagent.registry import (
     BackgroundTaskRegistry,
 )
 from ptc_agent.agent.middleware.background_subagent import tools as tools_module
+from ptc_agent.agent.middleware.background_subagent.outcomes import (
+    CREDIT_STOP_ERROR_TYPE,
+)
 from ptc_agent.agent.middleware.background_subagent.tools import (
     _delivered_result_text,
     create_task_output_tool,
@@ -237,3 +240,61 @@ class TestRegistryResolveResultText:
         registry = BackgroundTaskRegistry(thread_id="t1")
         registry.result_resolver = AsyncMock(side_effect=RuntimeError("db down"))
         assert await registry.resolve_result_text("k7Xm2p") is None
+
+
+def _ledger_middleware(run: dict) -> MagicMock:
+    """A registry whose ONLY authority is the durable ledger — the shape every
+    worker but the one holding the task sees."""
+    middleware = MagicMock()
+    registry = MagicMock()
+    ledger = MagicMock()
+    ledger.get_latest_run = AsyncMock(return_value=run)
+    ledger.mark_result_delivered = AsyncMock(return_value=None)
+    registry.run_ledger = ledger
+    registry.get_by_task_id = AsyncMock(return_value=None)
+    registry.resolve_result_text = AsyncMock(return_value=None)
+    registry.resolve_archived_result_text = AsyncMock(return_value=None)
+    middleware.registry = registry
+    return middleware
+
+
+@pytest.mark.asyncio
+async def test_a_credit_stopped_task_reads_as_resumable_from_the_ledger():
+    """The advice must not depend on which worker answers.
+
+    A credit stop spells itself 'cancelled' exactly like a timeout kill does,
+    so the generic cancelled copy ("cannot be resumed") would talk the model
+    out of the one path this stop is designed to leave open. The live task
+    already branches on it; the ledger is what answers on every worker but the
+    one still holding the task in memory, which multi-worker makes a coin flip.
+    """
+    run = {
+        "status": "cancelled",
+        "task_run_id": "run-1",
+        "failure": {"error_type": CREDIT_STOP_ERROR_TYPE, "error": "out of credits"},
+    }
+    tool = create_task_output_tool(_ledger_middleware(run))
+
+    result = await tool.coroutine(task_id="k7Xm2p")
+
+    assert "ran out of credits" in result
+    assert 'Task(action="resume"' in result
+    assert "cannot be resumed" not in result
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_cancel_still_reads_as_unresumable():
+    """The complement, and the reason the branch is on the error type rather
+    than on the status: telling the model to resume a timeout kill would be
+    the opposite error, made just as silently."""
+    run = {
+        "status": "cancelled",
+        "task_run_id": "run-1",
+        "failure": {"error": "killed by timeout"},
+    }
+    tool = create_task_output_tool(_ledger_middleware(run))
+
+    result = await tool.coroutine(task_id="k7Xm2p")
+
+    assert "cannot be resumed" in result
+    assert 'Task(action="resume"' not in result

--- a/tests/unit/server/app/test_users.py
+++ b/tests/unit/server/app/test_users.py
@@ -622,7 +622,7 @@ async def test_fetch_platform_membership_oss_mode_short_circuits():
     with (
         patch(f"{LIMITS}.HOST_MODE", "oss"),
         patch(f"{LIMITS}.AUTH_SERVICE_URL", "http://localhost:8003"),
-        patch(f"{LIMITS}._get_http_client", return_value=mock_client),
+        patch(f"{LIMITS}.get_http_client", return_value=mock_client),
     ):
         from src.server.dependencies.usage_limits import _fetch_platform_membership
 
@@ -646,7 +646,7 @@ async def test_fetch_platform_tier_returns_tier():
         patch(f"{LIMITS}.HOST_MODE", "platform"),
         patch(f"{LIMITS}.AUTH_SERVICE_URL", "http://localhost:8003"),
         patch(
-            f"{LIMITS}._get_http_client",
+            f"{LIMITS}.get_http_client",
             return_value=mock_client,
         ),
         patch("src.utils.cache.redis_cache.get_cache_client", return_value=cache),
@@ -672,7 +672,7 @@ async def test_fetch_platform_tier_cache_hit():
         patch(f"{LIMITS}.HOST_MODE", "platform"),
         patch(f"{LIMITS}.AUTH_SERVICE_URL", "http://localhost:8003"),
         patch(
-            f"{LIMITS}._get_http_client",
+            f"{LIMITS}.get_http_client",
             return_value=mock_client,
         ),
         patch("src.utils.cache.redis_cache.get_cache_client", return_value=cache),
@@ -698,7 +698,7 @@ async def test_fetch_platform_membership_caches_tier_and_plan_display_name_toget
     with (
         patch(f"{LIMITS}.HOST_MODE", "platform"),
         patch(f"{LIMITS}.AUTH_SERVICE_URL", "http://localhost:8003"),
-        patch(f"{LIMITS}._get_http_client", return_value=mock_client),
+        patch(f"{LIMITS}.get_http_client", return_value=mock_client),
         patch("src.utils.cache.redis_cache.get_cache_client", return_value=cache),
         patch("os.getenv", return_value="token"),
     ):
@@ -726,7 +726,7 @@ async def test_fetch_platform_tier_platform_error():
         patch(f"{LIMITS}.HOST_MODE", "platform"),
         patch(f"{LIMITS}.AUTH_SERVICE_URL", "http://localhost:8003"),
         patch(
-            f"{LIMITS}._get_http_client",
+            f"{LIMITS}.get_http_client",
             return_value=mock_client,
         ),
         patch("src.utils.cache.redis_cache.get_cache_client", return_value=cache),
@@ -750,7 +750,7 @@ async def test_fetch_platform_tier_network_error():
         patch(f"{LIMITS}.HOST_MODE", "platform"),
         patch(f"{LIMITS}.AUTH_SERVICE_URL", "http://localhost:8003"),
         patch(
-            f"{LIMITS}._get_http_client",
+            f"{LIMITS}.get_http_client",
             return_value=mock_client,
         ),
         patch("src.utils.cache.redis_cache.get_cache_client", return_value=cache),
@@ -775,7 +775,7 @@ async def test_fetch_platform_tier_missing_field():
         patch(f"{LIMITS}.HOST_MODE", "platform"),
         patch(f"{LIMITS}.AUTH_SERVICE_URL", "http://localhost:8003"),
         patch(
-            f"{LIMITS}._get_http_client",
+            f"{LIMITS}.get_http_client",
             return_value=mock_client,
         ),
         patch("src.utils.cache.redis_cache.get_cache_client", return_value=cache),

--- a/tests/unit/server/contracts/test_credit_contract_mirrors.py
+++ b/tests/unit/server/contracts/test_credit_contract_mirrors.py
@@ -1,0 +1,57 @@
+"""The credit-gate spellings that exist once per language.
+
+Both are relied on across the wire and compared by nobody at runtime. The web
+app decides a subagent stopped for money rather than failed by matching
+``CREDIT_STOP_ERROR_TYPE`` against the ``error_type`` this service wrote, and
+it routes a pause interrupt by matching the action type this service classified
+it as. A drift in either fails silently and in the user's favour-losing
+direction: a gate stop renders as a subagent error, or a pause never renders as
+a card at all. Neither side's type checker can see the other's constant.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.server.contracts.status import (
+    CREDIT_STOP_ERROR_TYPE,
+    INTERRUPT_REASON_CREDIT_PAUSE,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+_SSE_TYPES = REPO_ROOT / "web/src/types/sse.ts"
+_PROJECTIONS = (
+    REPO_ROOT / "web/src/pages/ChatAgent/session/interrupts/fromLiveEvent.ts",
+    REPO_ROOT / "web/src/pages/ChatAgent/session/interrupts/fromHistoryEvent.ts",
+)
+
+
+def _ts_const(path: Path, name: str) -> str:
+    assert path.is_file(), f"{path} is missing; the contract has no other end"
+    match = re.search(
+        rf"^export const {name} = '([^']*)'", path.read_text(), re.MULTILINE
+    )
+    assert match, f"{name} is no longer a plain string const in {path.name}"
+    return match.group(1)
+
+
+def test_the_web_app_mirrors_the_credit_stop_spelling():
+    """status.py names this file as the mirror; this is the only thing checking.
+
+    The pin is textual, so ``_ts_const`` asserts the literal is still findable
+    rather than letting a refactor that hides it pass against nothing."""
+    assert _ts_const(_SSE_TYPES, "CREDIT_STOP_ERROR_TYPE") == CREDIT_STOP_ERROR_TYPE
+
+
+@pytest.mark.parametrize("path", _PROJECTIONS, ids=lambda p: p.name)
+def test_both_interrupt_projections_match_the_classified_action_type(path: Path):
+    """Live and history project the same interrupt; a pause the projection does
+    not recognise reaches the transcript as no card at all."""
+    assert path.is_file(), f"{path} is missing; the contract has no other end"
+    assert (
+        f"actionType === '{INTERRUPT_REASON_CREDIT_PAUSE}'" in path.read_text()
+    ), f"{path.name} no longer routes on the action type this service writes"

--- a/tests/unit/server/contracts/test_status.py
+++ b/tests/unit/server/contracts/test_status.py
@@ -10,13 +10,17 @@ default unit suite — no live database required.
 import re
 from pathlib import Path
 
+from langgraph.types import Interrupt
+
 from src.server.contracts.status import (
+    INTERRUPT_REASONS,
     LIVE_PUBLIC_STATUSES,
     PUBLIC_STATUSES,
     RAW_LIVE_STATUSES,
     RAW_TERMINAL_SNAPSHOT_STATUSES,
     TERMINAL_PUBLIC_STATUSES,
     TERMINAL_STATUSES,
+    classify_interrupt_reason,
     is_live,
     is_terminal,
     to_public,
@@ -108,6 +112,79 @@ class TestPartitions:
             assert to_public(status) in TERMINAL_PUBLIC_STATUSES
 
 
+def _pause(*requests):
+    """One interrupt payload, in the shape the graph actually raises.
+
+    A real ``Interrupt`` and not its dict form: that is what every caller hands
+    the classifier, and it is the shape the checkpointer's msgpack serde
+    reconstructs on the recovery path.
+    """
+    return [Interrupt(value={"action_requests": list(requests)})]
+
+
+class TestInterruptReason:
+    """The reason column is the run ledger's classification of a pause.
+
+    It is read back by the resume query, which selects on one exact spelling,
+    and relayed on the lifecycle feed, so a wrong value strands stopped tasks
+    and tells the client the wrong thing about a live thread. What is pinned
+    here is that the classifier never invents specificity it does not have."""
+
+    def test_credit_pause_keeps_its_exact_spelling(self):
+        # Load-bearing, not cosmetic: the subagent resume query selects on this
+        # literal, so a rename here silently strands stopped tasks.
+        assert classify_interrupt_reason(
+            _pause({"type": "credit_pause", "message": "out of credits"})
+        ) == "credit_pause"
+
+    def test_a_question_reads_as_a_question(self):
+        assert classify_interrupt_reason(
+            _pause({"type": "ask_user_question", "question": "which ticker?"})
+        ) == "user_question"
+
+    def test_only_an_actual_plan_claims_plan_review(self):
+        assert classify_interrupt_reason(
+            _pause({"name": "SubmitPlan", "args": {}, "description": "a plan"})
+        ) == "plan_review_required"
+
+    def test_a_proposal_is_an_approval_not_a_plan_review(self):
+        # The regression this class exists for: every proposal used to land on
+        # 'plan_review_required' because it was the catch-all, so the lifecycle
+        # feed announced a plan review for a workspace confirmation.
+        for kind in ("create_workspace", "delete_workspace", "delete_thread"):
+            assert classify_interrupt_reason(
+                _pause({"type": kind, "workspace_id": "w-1"})
+            ) == "approval_required"
+
+    def test_an_unknown_action_generalizes_instead_of_guessing(self):
+        assert classify_interrupt_reason(
+            _pause({"type": "some_future_action", "detail": "x"})
+        ) == "approval_required"
+
+    def test_an_unreadable_payload_is_unclassified_rather_than_labelled(self):
+        assert classify_interrupt_reason(_pause({"detail": "no discriminator"})) is None
+        assert classify_interrupt_reason([Interrupt(value="not a dict")]) is None
+        assert classify_interrupt_reason([]) is None
+
+    def test_credit_pause_outranks_a_proposal_buffered_ahead_of_it(self):
+        # A pause can carry several payloads; the one with behaviour attached
+        # has to win regardless of the order they were buffered in.
+        assert classify_interrupt_reason(
+            _pause({"type": "create_workspace", "workspace_name": "scratch"})
+            + _pause({"type": "credit_pause", "message": "out of credits"})
+        ) == "credit_pause"
+
+    def test_a_batched_approval_set_is_read_whole(self):
+        # The approval middleware puts a turn's whole approval set in ONE
+        # payload, so precedence has to hold within a payload and not just
+        # across them — reading only the leading request made the answer depend
+        # on which tool the model happened to call first.
+        assert classify_interrupt_reason(
+            _pause({"name": "run_backtest", "args": {}},
+                   {"name": "SubmitPlan", "args": {}})
+        ) == "plan_review_required"
+
+
 class TestMigrationCheckBinding:
     def test_subagent_runs_check_matches_constant(self):
         sql = (MIGRATIONS_DIR / "020_subagent_run_ledger.py").read_text()
@@ -115,3 +192,31 @@ class TestMigrationCheckBinding:
         assert match, "status CHECK not found in migration 020"
         check_values = set(re.findall(r"'(\w+)'", match.group(1)))
         assert check_values == {"in_progress", *TERMINAL_STATUSES}
+
+
+class TestInterruptReasonVocabulary:
+    """No schema CHECK backs this column, so the binding is enforced here.
+
+    ``conversation_responses.interrupt_reason`` predates the vocabulary and
+    still holds spellings from retired writers, so a CHECK could not be
+    validated against the existing rows and would fail any later UPDATE of one.
+    The constant is the authority instead: every producer returns a member, and
+    every SQL literal is bound from it rather than typed out.
+    """
+
+    def test_the_classifier_only_ever_returns_a_member(self):
+        for request in (
+            {"type": "credit_pause"},
+            {"type": "ask_user_question"},
+            {"type": "some_future_action"},
+            {"name": "SubmitPlan", "args": {}},
+            {"name": "any_approved_tool", "args": {}},
+        ):
+            assert classify_interrupt_reason(_pause(request)) in INTERRUPT_REASONS
+
+    def test_the_resume_query_binds_the_constant_not_a_literal(self):
+        from src.server.database.runs import credit_ledger
+
+        source = Path(credit_ledger.__file__).read_text()
+        assert "interrupt_reason = 'credit_pause'" not in source
+        assert "INTERRUPT_REASON_CREDIT_PAUSE" in source

--- a/tests/unit/server/database/test_credit_ledger.py
+++ b/tests/unit/server/database/test_credit_ledger.py
@@ -297,6 +297,29 @@ async def test_a_task_sweep_leaves_rows_whose_parent_turn_is_still_live(
 
 
 @pytest.mark.asyncio
+async def test_a_task_sweep_waits_out_the_grace_from_the_parent_going_terminal(
+    mock_connection, mock_cursor
+):
+    """The parent's STATUS is not enough, only the instant it changed.
+
+    A child that finished long before its parent has already served its own
+    grace, so a bare "parent is not in_progress" opens the instant the parent
+    commits — which is before the collector that commit spawns has inserted
+    anything. The sweep would stamp the row settled out from under a collector
+    about to bill it. The parent's ``usage_settled_at`` is the terminal instant
+    (the finalize CAS stamps it in the same statement) and NULL on a parent
+    finalized by pre-gate code, which must read as "chance not started" rather
+    than as "chance over".
+    """
+    with _pool_of(mock_connection):
+        await credit_ledger.settle_abandoned("task")
+
+    sql = " ".join(_executable(_sql(mock_cursor)).split())
+    assert "r.usage_settled_at IS NULL" in sql
+    assert "r.usage_settled_at > NOW() - INTERVAL '30 minutes'" in sql
+
+
+@pytest.mark.asyncio
 async def test_a_response_sweep_has_no_parent_to_wait_on(
     mock_connection, mock_cursor
 ):

--- a/tests/unit/server/database/test_credit_ledger.py
+++ b/tests/unit/server/database/test_credit_ledger.py
@@ -1,0 +1,309 @@
+"""The credit gate's SQL surface — the guards that keep a live spend figure honest.
+
+Every statement here runs against rows that are also being written by finalize,
+by the collector, and by the recovery sweep, so each one carries guards that are
+the whole reason it is safe to run concurrently with them. None of those guards
+has a runtime assertion behind it: drop one and the query still executes, just
+against the wrong rows. What is pinned:
+
+- the heartbeat is monotone, and refuses a row that is terminal or already
+  billed — a late beat racing finalize must not resurrect billed spend;
+- the degraded sweep waits out a grace interval for task runs and not for
+  responses, because only one of the two lanes can prove no settle is coming;
+- both sweeps keep the predicate that matches the partial in-flight index,
+  since they run every scan interval on every worker;
+- the predecessor walk terminates and settles inside the caller's transaction;
+- the resume query keeps all four filters that make it mean "stopped for money,
+  under the attempt being resumed".
+
+SQL is asserted by substring against the mocked cursor — the house pattern for
+this layer; whole-query equality is whitespace-brittle.
+"""
+
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.server.contracts.status import (
+    CREDIT_STOP_ERROR_TYPE,
+    INTERRUPT_REASON_CREDIT_PAUSE,
+)
+from src.server.database.runs import credit_ledger, subagent_runs
+
+THREAD_ID = "11111111-1111-1111-1111-111111111111"
+RUN_ID = "22222222-2222-2222-2222-222222222222"
+TASK_RUN_ID = "33333333-3333-3333-3333-333333333333"
+
+POOL = "src.server.database.pool.get_db_connection"
+
+
+def _pool_of(connection):
+    @asynccontextmanager
+    async def _fake():
+        yield connection
+
+    return patch(POOL, new=_fake)
+
+
+def _sql(cursor):
+    return cursor.execute.call_args_list[-1][0][0]
+
+
+def _params(cursor):
+    return cursor.execute.call_args_list[-1][0][1]
+
+
+def _executable(sql: str) -> str:
+    """SQL with its -- comments stripped, for assertions about what actually
+    runs. These statements carry comments that quote the very spellings some
+    of the assertions below rule out."""
+    return "\n".join(line.split("--")[0] for line in sql.splitlines())
+
+
+# ------------------------------------------------------------------ heartbeat
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind,table,key",
+    [
+        ("run", "conversation_responses", "conversation_response_id"),
+        ("task", "subagent_runs", "task_run_id"),
+    ],
+)
+async def test_the_heartbeat_is_monotone_and_guarded(
+    mock_connection, mock_cursor, kind, table, key
+):
+    mock_cursor.rowcount = 1
+    with _pool_of(mock_connection):
+        assert await credit_ledger.heartbeat(kind, RUN_ID, 12.5) is True
+
+    sql = _sql(mock_cursor)
+    assert f"UPDATE {table}" in sql
+    assert f"{key} = %s" in sql
+    # Monotone: a reordered or duplicate flush must never lower the figure.
+    assert "GREATEST(in_flight_credits" in sql
+    # ...and a beat that arrives after finalize must not revive billed spend.
+    assert "status = 'in_progress'" in sql
+    assert "usage_settled_at IS NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_the_heartbeat_reports_a_row_it_could_not_write(
+    mock_connection, mock_cursor
+):
+    """False is what tells the lane its ledger row is closed, so it can stop."""
+    mock_cursor.rowcount = 0
+    with _pool_of(mock_connection):
+        assert await credit_ledger.heartbeat("run", RUN_ID, 12.5) is False
+
+
+@pytest.mark.asyncio
+async def test_the_heartbeat_binds_exact_decimal_not_float(
+    mock_connection, mock_cursor
+):
+    """GREATEST(numeric, float8) resolves in double precision: a float here
+    would round the stored column value through binary float on every beat."""
+    mock_cursor.rowcount = 1
+    with _pool_of(mock_connection):
+        await credit_ledger.heartbeat("run", RUN_ID, 0.07999999999999999)
+
+    bound = _params(mock_cursor)[0]
+    assert isinstance(bound, Decimal)
+    assert bound == Decimal("0.07999999999999999")
+
+
+# ------------------------------------------------------------ degraded sweep
+
+
+@pytest.mark.asyncio
+async def test_a_task_sweep_waits_out_the_grace_and_a_response_sweep_does_not(
+    mock_connection, mock_cursor
+):
+    """A terminal response proves no settle is coming; a terminal task run does
+    not, because the collector may still be about to claim it."""
+    with _pool_of(mock_connection):
+        await credit_ledger.settle_abandoned("task")
+        task_sql = _sql(mock_cursor)
+        await credit_ledger.settle_abandoned("run")
+        run_sql = _sql(mock_cursor)
+
+    assert "finalized_at < NOW() - INTERVAL '30 minutes'" in task_sql
+    assert "INTERVAL" not in run_sql
+    assert "UPDATE subagent_runs" in task_sql
+    assert "UPDATE conversation_responses" in run_sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["run", "task"])
+async def test_both_sweeps_match_the_partial_in_flight_index(
+    mock_connection, mock_cursor, kind
+):
+    """These fire on every worker every scan interval; off the index they are
+    sequential scans of the two hottest tables in the schema."""
+    with _pool_of(mock_connection):
+        await credit_ledger.settle_abandoned(kind)
+
+    sql = _sql(mock_cursor)
+    assert "usage_settled_at IS NULL" in sql
+    assert "in_flight_credits > 0" in sql
+    assert "status != 'in_progress'" in sql
+    # The one the planner needs to prove the index covers every matching row.
+    # Without it the other three still read as a match and the sweep still
+    # scans: verified on Postgres, where it will not pick the index even with
+    # enable_seqscan off.
+    assert "user_id IS NOT NULL" in sql
+
+
+# -------------------------------------------------------------- chain settle
+
+
+@pytest.mark.asyncio
+async def test_the_predecessor_walk_terminates_and_uses_the_callers_transaction(
+    mock_connection, mock_cursor
+):
+    """The stamp has to commit with the usage row or not at all, so it must
+    never open a connection of its own."""
+    mock_cursor.rowcount = 1
+
+    def _explode():
+        raise AssertionError("settle_task_run opened its own connection")
+
+    with patch(POOL, new=_explode):
+        assert await credit_ledger.settle_task_run(TASK_RUN_ID, conn=mock_connection)
+
+    sql = _sql(mock_cursor)
+    assert "WITH RECURSIVE chain" in sql
+    assert "predecessor_run_id" in sql
+    # UNION, never UNION ALL: dedup is what stops the walk if a predecessor
+    # ever points back into the chain, and it runs inside an open write txn.
+    assert "UNION" in _executable(sql)
+    assert "UNION ALL" not in _executable(sql)
+    assert "usage_settled_at IS NULL" in sql
+
+
+# ------------------------------------------------------ terminal vs settled
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["error", "cancelled", "completed"])
+async def test_finalizing_a_task_run_never_stamps_it_billed(
+    mock_connection, mock_cursor, status
+):
+    """Terminating is not being billed, whatever the terminal is.
+
+    Settling here would drop the run's heartbeated spend out of the in-flight
+    aggregate before the collector inserts its usage row, and a turn admitted
+    in that window is measured against an understated balance. A credit stop
+    settles ``cancelled`` and lands in that window by construction, which is
+    exactly when a resume is about to be admitted.
+    """
+    mock_cursor.fetchone = AsyncMock(
+        return_value={"status": status, "task_run_id": TASK_RUN_ID}
+    )
+
+    with _pool_of(mock_connection):
+        await subagent_runs.finalize_task_run(
+            task_run_id=TASK_RUN_ID, status=status
+        )
+
+    sql = _executable(_sql(mock_cursor))
+    assert "finalized_at = NOW()" in sql
+    assert "usage_settled_at" not in sql, (
+        "finalize stamped the settle; only the collector's usage transaction "
+        "and the abandoned sweep may do that"
+    )
+
+
+# -------------------------------------------------------------- resume query
+
+
+@pytest.mark.asyncio
+async def test_the_resume_query_keeps_every_filter_that_gives_it_meaning(
+    mock_connection, mock_cursor
+):
+    with _pool_of(mock_connection):
+        await credit_ledger.list_credit_stopped_for_resume(THREAD_ID, RUN_ID)
+
+    sql = _sql(mock_cursor)
+    # Anchored on the thread's latest run, not the newest pause: a resume opens
+    # a new run, so "newest pause" would re-announce the same stops forever.
+    assert "ORDER BY run_seq DESC" in sql
+    assert "LIMIT 1" in sql
+    assert "r.status = 'interrupted'" in sql
+    assert "r.interrupt_reason = %s" in sql
+    assert "s.status = 'cancelled'" in sql
+    assert "s.failure->>'error_type' = %s" in sql
+    # Redundant against the join, but it is what keeps this an index scan.
+    assert "s.thread_id = %s" in sql
+
+    params = _params(mock_cursor)
+    assert INTERRUPT_REASON_CREDIT_PAUSE in params
+    assert CREDIT_STOP_ERROR_TYPE in params
+
+
+@pytest.mark.asyncio
+async def test_the_resume_query_excludes_the_whole_attempt_chain(
+    mock_connection, mock_cursor
+):
+    """The regression. The resuming run's row is inserted in the START
+    transaction, long before this runs, so "the thread's latest run" is that
+    row — in_progress, never the pause — and every later predicate misses.
+    Excluding it is what makes the announcement land at all.
+
+    The CHAIN rather than the one id, because a resume that fails retryably is
+    retried as a NEW row chained by ``retry_of_run_id`` while the pause stays
+    two rows back. Excluding only the resuming run would then anchor on the
+    failed attempt, whose status is 'error', and the retry that finally
+    succeeds would announce no stopped subagents at all.
+    """
+    with _pool_of(mock_connection):
+        await credit_ledger.list_credit_stopped_for_resume(THREAD_ID, RUN_ID)
+
+    sql = _executable(_sql(mock_cursor))
+    assert "WITH RECURSIVE attempt_chain" in sql
+    assert "retry_of_run_id" in sql
+    assert "conversation_response_id NOT IN" in sql
+    # Terminates: dedup is what stops the walk if a retry ever points back
+    # into its own chain.
+    assert "UNION" in sql
+    assert "UNION ALL" not in sql
+    # The chain is anchored on the resuming run, so it must be bound first.
+    assert _params(mock_cursor)[0] == RUN_ID
+
+
+@pytest.mark.asyncio
+async def test_a_task_sweep_leaves_rows_whose_parent_turn_is_still_live(
+    mock_connection, mock_cursor
+):
+    """Age alone cannot prove no settle is coming for a task run.
+
+    The collector is spawned only once the PARENT turn goes terminal, so a
+    subagent that finished early under a long turn is stamped billed 30
+    minutes in and drops out of the in-flight aggregate for the rest of that
+    turn — understating the balance every admission in that window is
+    measured against, which is the one thing this ledger exists to prevent.
+    """
+    with _pool_of(mock_connection):
+        await credit_ledger.settle_abandoned("task")
+
+    sql = _executable(_sql(mock_cursor))
+    assert "NOT EXISTS" in sql
+    assert "conversation_responses r" in sql
+    assert "subagent_runs.parent_run_id" in sql
+    assert "r.status = 'in_progress'" in sql
+
+
+@pytest.mark.asyncio
+async def test_a_response_sweep_has_no_parent_to_wait_on(
+    mock_connection, mock_cursor
+):
+    """The complement: responses ARE the parents, so the guard would be
+    nonsense there — and a correlated subquery on the hottest table in the
+    schema is not something to add for nothing."""
+    with _pool_of(mock_connection):
+        await credit_ledger.settle_abandoned("run")
+
+    assert "NOT EXISTS" not in _executable(_sql(mock_cursor))

--- a/tests/unit/server/dependencies/test_usage_limits.py
+++ b/tests/unit/server/dependencies/test_usage_limits.py
@@ -244,7 +244,7 @@ async def test_call_validate_for_user_uses_x_service_token_header():
     with (
         patch(f"{MODULE}.HOST_MODE", "platform"),
         patch(f"{MODULE}.AUTH_SERVICE_URL", "http://localhost:8003"),
-        patch(f"{MODULE}._get_http_client", return_value=mock_client),
+        patch(f"{MODULE}.get_http_client", return_value=mock_client),
         patch("os.getenv", return_value="my-secret-token"),
     ):
         from src.server.dependencies.usage_limits import _call_validate_for_user
@@ -274,7 +274,7 @@ async def test_call_validate_for_user_no_token_omits_service_header():
     with (
         patch(f"{MODULE}.HOST_MODE", "platform"),
         patch(f"{MODULE}.AUTH_SERVICE_URL", "http://localhost:8003"),
-        patch(f"{MODULE}._get_http_client", return_value=mock_client),
+        patch(f"{MODULE}.get_http_client", return_value=mock_client),
         patch("os.getenv", return_value=""),
     ):
         from src.server.dependencies.usage_limits import _call_validate_for_user
@@ -310,7 +310,7 @@ async def test_call_validate_for_user_sends_check_quota_in_body():
     with (
         patch(f"{MODULE}.HOST_MODE", "platform"),
         patch(f"{MODULE}.AUTH_SERVICE_URL", "http://localhost:8003"),
-        patch(f"{MODULE}._get_http_client", return_value=mock_client),
+        patch(f"{MODULE}.get_http_client", return_value=mock_client),
         patch("os.getenv", return_value="token"),
     ):
         from src.server.dependencies.usage_limits import _call_validate_for_user
@@ -350,7 +350,7 @@ def _unreachable_service(mock_client):
     stack = ExitStack()
     stack.enter_context(patch(f"{MODULE}.HOST_MODE", "platform"))
     stack.enter_context(patch(f"{MODULE}.AUTH_SERVICE_URL", "http://localhost:8003"))
-    stack.enter_context(patch(f"{MODULE}._get_http_client", return_value=mock_client))
+    stack.enter_context(patch(f"{MODULE}.get_http_client", return_value=mock_client))
     stack.enter_context(patch(f"{MODULE}._VALIDATE_RETRY_BACKOFF", 0))
     stack.enter_context(patch("os.getenv", return_value="token"))
     return stack
@@ -551,7 +551,7 @@ class TestCreditGateFailsClosed:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
 
-        with patch(f"{MODULE}.HOST_MODE", "oss"), patch(f"{MODULE}._get_http_client", return_value=mock_client):
+        with patch(f"{MODULE}.HOST_MODE", "oss"), patch(f"{MODULE}.get_http_client", return_value=mock_client):
             from src.server.dependencies.usage_limits import enforce_credit_limit
 
             await enforce_credit_limit("user-1", byok=False)
@@ -779,9 +779,9 @@ class TestGetCapacityStatus:
     async def test_unlimited_with_omitted_used(self):
         """Platform omits capacity_used on unlimited tiers — still report limit -1.
 
-        Regression: ginlix-platform's capacity counter returns
-        ``QuotaInfo(allowed=True, capacity_limit=-1)`` with no ``capacity_used`` for
-        unlimited plans, so requiring ``used`` would hide the "Unlimited" hint.
+        Regression: an unlimited tier answers with ``capacity_limit=-1`` and no
+        ``capacity_used`` at all, so requiring ``used`` would hide the
+        "Unlimited" hint.
         """
         quota_response = {"quota": {"allowed": True, "capacity_limit": -1}}
         with (

--- a/tests/unit/server/services/test_cancel_dispatch.py
+++ b/tests/unit/server/services/test_cancel_dispatch.py
@@ -683,4 +683,4 @@ async def test_a_cancel_failure_does_not_put_infrastructure_text_on_the_wire():
     assert secret not in str(caught.value.detail)
     assert "db-prod-7" not in str(caught.value.detail)
     # Still says which operation failed — a fixed string, not a bare 500.
-    assert "Failed to cancel workflow" in str(caught.value.detail)
+    assert "Failed to cancel the turn" in str(caught.value.detail)

--- a/tests/unit/server/services/test_credit_gate_port.py
+++ b/tests/unit/server/services/test_credit_gate_port.py
@@ -1,0 +1,365 @@
+"""The lease adapter's own decisions: what it sends, and what it does with an
+answer it did not want.
+
+Every one of these is a place where the honest move is to say nothing rather
+than say something wrong — the gate keeps enforcing its last trusted verdict,
+which is the whole fail-open promise.
+"""
+
+import asyncio
+
+import pytest
+
+from src.server.services import credit_gate_port as port_module
+from src.server.services.credit_gate_port import PlatformCreditGatePort
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload=None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no body")
+        return self._payload
+
+
+class FakeClient:
+    """Answers with a queued script; records what it was asked."""
+
+    def __init__(self, responses=None):
+        self.responses = list(responses or [])
+        self.posts: list[tuple] = []
+        self.gets: list[tuple] = []
+
+    def _next(self):
+        return self.responses.pop(0) if self.responses else FakeResponse(200, {})
+
+    async def post(self, url, json=None, headers=None, **kw):
+        self.posts.append((url, json))
+        return self._next()
+
+    async def get(self, url, headers=None, **kw):
+        self.gets.append((url, kw))
+        return self._next()
+
+
+@pytest.fixture
+def client(monkeypatch):
+    fake = FakeClient()
+
+    async def _get_client():
+        return fake
+
+    monkeypatch.setattr(port_module.usage_limits, "get_http_client", _get_client)
+    monkeypatch.setattr(port_module.usage_limits, "service_headers", lambda *a: {})
+    monkeypatch.setattr(port_module.usage_limits, "service_token_missing", lambda: False)
+    return fake
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    slept: list[float] = []
+
+    async def _sleep(delay):
+        slept.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+    return slept
+
+
+# -- what we are willing to report ----------------------------------------
+
+
+@pytest.mark.parametrize("spent", [float("nan"), float("inf"), 2_000_000.0])
+@pytest.mark.asyncio
+async def test_an_unreportable_spend_never_reaches_the_service(client, spent):
+    """A number we do not believe is worse than no number: the gate keeps its
+    last trusted verdict for a tick, and the next heartbeat corrects it."""
+    assert await PlatformCreditGatePort().acquire("u", "run-1", spent) is None
+    assert client.posts == []
+
+
+@pytest.mark.parametrize("credits", [float("nan"), float("inf"), 2_000_000.0])
+@pytest.mark.asyncio
+async def test_an_unreportable_spend_never_reaches_the_ledger(monkeypatch, credits):
+    """The beat is the write that has to hold the line. The ledger's write is
+    monotone and Postgres ranks NaN above every real numeric, so one bad beat is
+    permanent — no later correct value lowers it, and the per-user sum carries
+    it to every other run that user has open."""
+    wrote: list = []
+
+    async def _heartbeat(kind, run_ref, value):
+        wrote.append(value)
+        return True
+
+    monkeypatch.setattr(port_module.credit_ledger, "heartbeat", _heartbeat)
+    assert await PlatformCreditGatePort().heartbeat("run", "r-1", credits) is None
+    assert wrote == []
+
+
+@pytest.mark.asyncio
+async def test_a_believable_spend_reaches_the_ledger_and_its_answer_comes_back(
+    monkeypatch,
+):
+    async def _heartbeat(kind, run_ref, value):
+        return False
+
+    monkeypatch.setattr(port_module.credit_ledger, "heartbeat", _heartbeat)
+    assert await PlatformCreditGatePort().heartbeat("run", "r-1", 12.5) is False
+
+
+@pytest.mark.asyncio
+async def test_a_small_negative_is_clamped_rather_than_refused(client):
+    client.responses = [FakeResponse(200, {"granted": True, "ceiling_credits": 5.0})]
+    await PlatformCreditGatePort().acquire("u", "run-1", -0.0000001)
+    assert client.posts[0][1]["spent_credits"] == 0.0
+
+
+# -- the fence ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_grant_generation_is_carried_out_of_the_verdict(client):
+    client.responses = [
+        FakeResponse(200, {"granted": True, "ceiling_credits": 5.0, "generation": 9})
+    ]
+    verdict = await PlatformCreditGatePort().acquire("u", "run-1", 1.0)
+    assert verdict.generation == 9
+
+
+@pytest.mark.parametrize("raw", [True, "9", 9.5, None])
+@pytest.mark.asyncio
+async def test_a_generation_that_is_not_an_integer_leaves_the_release_unfenced(
+    client, raw
+):
+    """Unfenced is the pre-fence behaviour, which is a worse race but a working
+    release. A bogus fence would silently retire nothing at all."""
+    client.responses = [
+        FakeResponse(200, {"granted": True, "ceiling_credits": 5.0, "generation": raw})
+    ]
+    verdict = await PlatformCreditGatePort().acquire("u", "run-1", 1.0)
+    assert verdict.generation is None
+
+
+@pytest.mark.asyncio
+async def test_release_sends_the_generation_only_when_it_has_one(client):
+    await PlatformCreditGatePort().release("u", "run-1", 4)
+    await PlatformCreditGatePort().release("u", "run-1")
+    assert client.posts[0][1]["generation"] == 4
+    assert "generation" not in client.posts[1][1]
+
+
+# -- giving up on a release, and not too early ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_release_retries_a_server_error_and_stops_on_success(
+    client, no_sleep
+):
+    client.responses = [FakeResponse(503), FakeResponse(200, {"released": True})]
+    await PlatformCreditGatePort().release("u", "run-1", 1)
+    assert len(client.posts) == 2
+    assert no_sleep == [0.5]
+
+
+@pytest.mark.asyncio
+async def test_release_does_not_retry_an_answer(client, no_sleep):
+    """A 4xx is the service answering, 404 included — there was no lease, which
+    is the idempotent case and not a failure."""
+    client.responses = [FakeResponse(404)]
+    await PlatformCreditGatePort().release("u", "run-1", 1)
+    assert len(client.posts) == 1
+    assert no_sleep == []
+
+
+@pytest.mark.asyncio
+async def test_release_gives_up_after_a_bounded_number_of_attempts(
+    client, no_sleep
+):
+    client.responses = [FakeResponse(500) for _ in range(10)]
+    await PlatformCreditGatePort().release("u", "run-1", 1)
+    assert len(client.posts) == port_module._RELEASE_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_a_hanging_service_costs_one_timeout_not_three(
+    client, no_sleep, monkeypatch
+):
+    """The attempt count bounds the tries, not the wait. This runs from the
+    lane's teardown, so its total is what the user's stream waits out after
+    output has already stopped."""
+    now = [0.0]
+    monkeypatch.setattr(port_module.time, "monotonic", lambda: now[0])
+
+    async def hang(url, json=None, headers=None, timeout=None, **kw):
+        client.posts.append((url, json))
+        now[0] += timeout  # accepts the connection, then never answers
+        raise TimeoutError("read timeout")
+
+    monkeypatch.setattr(client, "post", hang)
+    await PlatformCreditGatePort().release("u", "run-1", 1)
+
+    assert len(client.posts) == 1
+    assert now[0] == pytest.approx(port_module._RELEASE_BUDGET_SECONDS)
+
+
+# -- the startup check ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capability_reports_nothing_when_the_route_is_not_there(client):
+    client.responses = [FakeResponse(404, text="Not Found")]
+    assert await PlatformCreditGatePort().capability() is None
+
+
+@pytest.mark.asyncio
+async def test_the_wiring_check_is_silent_without_platform_gating(
+    client, monkeypatch
+):
+    """OSS builds have no service to ask, and a boot-time GET at a URL that
+    means nothing to them is noise, not a check."""
+    monkeypatch.setattr(port_module.usage_limits, "platform_gating_active", lambda: False)
+    await port_module.verify_credit_gate_wiring()
+    assert client.gets == []
+
+
+@pytest.mark.parametrize(
+    "ttl", [port_module.LEASE_RENEW_MARGIN_SECONDS, 30, port_module.LEASE_RENEW_MARGIN_SECONDS + 1]
+)
+@pytest.mark.asyncio
+async def test_the_wiring_check_never_raises_on_any_ttl(client, monkeypatch, ttl):
+    """It runs inside the lifespan. Whatever it finds, the server still boots —
+    the gate is an extra guard, not an availability dependency."""
+    monkeypatch.setattr(port_module.usage_limits, "platform_gating_active", lambda: True)
+    client.responses = [FakeResponse(200, {"enabled": True, "lease_ttl_seconds": ttl})]
+    await port_module.verify_credit_gate_wiring()
+    assert len(client.gets) == 1
+
+
+# -- what the reservation is sized in -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_rate_reaches_the_service(client):
+    client.responses = [FakeResponse(200, {"granted": True, "ceiling_credits": 5.0})]
+    await PlatformCreditGatePort().acquire("u", "run-1", 1.0, 8.5)
+    assert client.posts[0][1]["rate_multiplier"] == 8.5
+
+
+@pytest.mark.asyncio
+async def test_the_billing_source_reaches_the_service(client):
+    """Admission forwards it, so the lease must too: the service folds the same
+    billing row for both, and without this it answers the run's own admission
+    verdict with the opposite one."""
+    client.responses = [
+        FakeResponse(200, {"granted": True, "ceiling_credits": 5.0}),
+        FakeResponse(200, {"granted": True, "ceiling_credits": 5.0}),
+    ]
+    await PlatformCreditGatePort().acquire("u", "run-1", 1.0, 1.0, True)
+    assert client.posts[0][1]["byok"] is True
+
+    # Absent, not false, for a platform-funded turn: the payload a service that
+    # has never heard of the field still reads exactly as it did before.
+    await PlatformCreditGatePort().acquire("u", "run-1", 1.0)
+    assert "byok" not in client.posts[1][1]
+
+
+@pytest.mark.parametrize(
+    "sent, expected",
+    [
+        (0.0, port_module._MIN_RATE_MULTIPLIER),
+        (1e9, port_module._MAX_RATE_MULTIPLIER),
+        (float("nan"), 1.0),
+        (float("inf"), 1.0),
+        (None, 1.0),
+        ("eight", 1.0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_rate_we_cannot_use_is_clamped_not_refused(client, sent, expected):
+    """Unlike an unreportable spend, a bad rate never withholds the ask. The
+    spend is the figure the verdict is computed from, so a wrong one is worse
+    than none; the rate only sizes the headroom, and the honest fallback is to
+    ask at the baseline rather than leave the turn without a ceiling."""
+    client.responses = [FakeResponse(200, {"granted": True, "ceiling_credits": 5.0})]
+    await PlatformCreditGatePort().acquire("u", "run-1", 1.0, sent)
+    assert client.posts[0][1]["rate_multiplier"] == expected
+
+
+@pytest.mark.asyncio
+async def test_an_unpriced_model_reserves_at_the_baseline(monkeypatch):
+    """A model the manifest cannot price leaves the reservation where it was,
+    which is the same thing every OSS build gets."""
+    monkeypatch.setattr(port_module.usage_limits, "platform_gating_active", lambda: True)
+    gate = port_module.build_run_credit_gate(
+        "u", "run-1", None, None, "not-a-real-model-anywhere"
+    )
+    assert gate.rate_multiplier == 1.0
+
+
+# -- the numbers the service publishes so this build can check them --------
+
+
+def test_ttl_prefers_the_service_differenced_remainder():
+    """Skew lives entirely in the subtraction. ``expires_in_seconds`` is
+    differenced on one clock, so a stamp this host reads as long past still
+    yields the real remaining TTL."""
+    body = {"expires_at": "2000-01-01T00:00:00+00:00", "expires_in_seconds": 300}
+    assert port_module._ttl_seconds(body) == 300.0
+
+
+def test_ttl_falls_back_to_the_stamp_then_to_the_stand_in():
+    assert port_module._ttl_seconds({"expires_at": "2000-01-01T00:00:00+00:00"}) == 0.0
+    assert port_module._ttl_seconds({}) == port_module._UNKNOWN_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_the_wiring_check_reports_a_bounds_disagreement(
+    client, monkeypatch, caplog
+):
+    """A multiplier the service rejects comes back 422, which reads as no
+    verdict and leaves the turn ungated. Boot is the only place that can see
+    that coming."""
+    monkeypatch.setattr(
+        port_module.usage_limits, "platform_gating_active", lambda: True
+    )
+    client.responses = [
+        FakeResponse(
+            200,
+            {
+                "enabled": True,
+                "lease_ttl_seconds": port_module.LEASE_RENEW_MARGIN_SECONDS + 60,
+                "rate_multiplier_min": port_module._MIN_RATE_MULTIPLIER * 5,
+                "rate_multiplier_max": port_module._MAX_RATE_MULTIPLIER,
+            },
+        )
+    ]
+    with caplog.at_level("ERROR"):
+        await port_module.verify_credit_gate_wiring()
+    assert "bounds disagree" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_the_wiring_check_is_quiet_when_the_bounds_agree(
+    client, monkeypatch, caplog
+):
+    monkeypatch.setattr(
+        port_module.usage_limits, "platform_gating_active", lambda: True
+    )
+    client.responses = [
+        FakeResponse(
+            200,
+            {
+                "enabled": True,
+                "lease_ttl_seconds": port_module.LEASE_RENEW_MARGIN_SECONDS + 60,
+                "rate_multiplier_min": port_module._MIN_RATE_MULTIPLIER,
+                "rate_multiplier_max": port_module._MAX_RATE_MULTIPLIER,
+            },
+        )
+    ]
+    with caplog.at_level("ERROR"):
+        await port_module.verify_credit_gate_wiring()
+    assert caplog.text == ""

--- a/tests/unit/server/services/test_history_task_status.py
+++ b/tests/unit/server/services/test_history_task_status.py
@@ -74,10 +74,11 @@ class TestLegacyStatusFallback:
                 "t", ["live1", "canc1", "done1", "gone1"]
             )
         assert details == {
-            "live1": {"status": "running", "error": None},
-            "canc1": {"status": "cancelled", "error": None},
-            "done1": {"status": "completed", "error": None},
-            "gone1": {"status": "completed", "error": None},  # no meta -> terminal default
+            "live1": {"status": "running", "error": None, "error_type": None},
+            "canc1": {"status": "cancelled", "error": None, "error_type": None},
+            "done1": {"status": "completed", "error": None, "error_type": None},
+            # no meta -> terminal default
+            "gone1": {"status": "completed", "error": None, "error_type": None},
         }
 
     @pytest.mark.asyncio
@@ -93,9 +94,9 @@ class TestLegacyStatusFallback:
             details = await resolve_task_details("t", ["run1", "done1", "gone1"])
         # Availability over precision: meta says running, probe unknown.
         assert details == {
-            "run1": {"status": "running", "error": None},
-            "done1": {"status": "completed", "error": None},
-            "gone1": {"status": "completed", "error": None},
+            "run1": {"status": "running", "error": None, "error_type": None},
+            "done1": {"status": "completed", "error": None, "error_type": None},
+            "gone1": {"status": "completed", "error": None, "error_type": None},
         }
 
 
@@ -136,6 +137,39 @@ class TestStamping:
         )
         assert "error" not in stamped["payload"]
 
+    def test_stamp_carries_the_reason_type_with_the_reason(self):
+        data = _artifact("aaa")["data"]
+        stamped = stamp_task_artifact_data(
+            data,
+            {
+                "aaa": {
+                    "status": "cancelled",
+                    "error": "Monthly credit limit reached.",
+                    "error_type": "credit_stop",
+                }
+            },
+        )
+        assert stamped["payload"]["error_type"] == "credit_stop"
+
+    def test_status_only_withholds_the_reason_type_too(self):
+        # It classifies failure text, so it travels under the same gate: a
+        # public viewer learns the task stopped, never that money stopped it.
+        data = _artifact("aaa")["data"]
+        stamped = stamp_task_artifact_data(
+            data,
+            {
+                "aaa": {
+                    "status": "cancelled",
+                    "error": "Monthly credit limit reached.",
+                    "error_type": "credit_stop",
+                }
+            },
+            status_only=True,
+        )
+        assert stamped["payload"]["status"] == "cancelled"
+        assert "error" not in stamped["payload"]
+        assert "error_type" not in stamped["payload"]
+
     def test_non_task_and_unknown_ids_pass_through_identically(self):
         chunk = {"content_type": "text"}
         details = {"aaa": {"status": "completed", "error": None}}
@@ -172,26 +206,42 @@ class TestResolveTaskDetails:
     @pytest.mark.asyncio
     async def test_error_reason_only_on_error_status(self):
         ledger = {
-            "err1": {"status": "error", "error": "transport_lost: boom"},
-            "done1": {"status": "completed", "error": None},
+            "err1": {
+                "status": "error",
+                "error": "transport_lost: boom",
+                "error_type": "transport_lost",
+            },
+            "done1": {"status": "completed", "error": None, "error_type": None},
         }
         with patch(
             "src.server.database.runs.subagent_runs.get_latest_run_details",
             new=AsyncMock(return_value=ledger),
         ):
             details = await resolve_task_details("t", ["err1", "done1"])
-        assert details["err1"] == {"status": "error", "error": "transport_lost: boom"}
-        assert details["done1"] == {"status": "completed", "error": None}
+        assert details["err1"] == {
+            "status": "error",
+            "error": "transport_lost: boom",
+            "error_type": "transport_lost",
+        }
+        assert details["done1"] == {
+            "status": "completed",
+            "error": None,
+            "error_type": None,
+        }
 
     @pytest.mark.asyncio
     async def test_interrupted_maps_to_error_without_reason(self):
-        ledger = {"int1": {"status": "interrupted", "error": None}}
+        ledger = {"int1": {"status": "interrupted", "error": None, "error_type": None}}
         with patch(
             "src.server.database.runs.subagent_runs.get_latest_run_details",
             new=AsyncMock(return_value=ledger),
         ):
             details = await resolve_task_details("t", ["int1"])
-        assert details["int1"] == {"status": "error", "error": None}
+        assert details["int1"] == {
+            "status": "error",
+            "error": None,
+            "error_type": None,
+        }
 
 
 class TestResolveTaskLiveness:
@@ -221,3 +271,58 @@ class TestResolveTaskLiveness:
             new=AsyncMock(return_value=None),
         ):
             assert await resolve_task_liveness("t", ["x"]) is None
+
+
+class TestLedgerReasonCarry:
+    """A terminal that is not ``error`` still carries its failure reason.
+
+    The regression: the projection handed the client a reason only when the
+    status was ``error``. A credit stop settles ``cancelled`` by design, so
+    its denial copy - the entire explanation the user gets - was nulled on
+    every reload, and the card showed a bare "Stopped" chip.
+    """
+
+    @staticmethod
+    def _ledger(rows: dict):
+        return patch(
+            "src.server.database.runs.subagent_runs.get_latest_run_details",
+            new=AsyncMock(return_value=rows),
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancelled_run_keeps_its_reason(self):
+        with self._ledger(
+            {
+                "stopped1": {
+                    "status": "cancelled",
+                    "error": "You are out of credits.",
+                    "error_type": "credit_stop",
+                }
+            }
+        ):
+            details = await resolve_task_details("t", ["stopped1"])
+        # The type travels with the message: it is what lets the client offer
+        # the remedy for the one stop that has one, rather than only reporting.
+        assert details["stopped1"] == {
+            "status": "cancelled",
+            "error": "You are out of credits.",
+            "error_type": "credit_stop",
+        }
+
+    @pytest.mark.asyncio
+    async def test_completed_run_carries_no_reason(self):
+        with self._ledger(
+            {
+                "done1": {
+                    "status": "completed",
+                    "error": "stale",
+                    "error_type": "stale",
+                }
+            }
+        ):
+            details = await resolve_task_details("t", ["done1"])
+        assert details["done1"] == {
+            "status": "completed",
+            "error": None,
+            "error_type": None,
+        }

--- a/tests/unit/utils/tracking/test_platform_usd_agreement.py
+++ b/tests/unit/utils/tracking/test_platform_usd_agreement.py
@@ -1,0 +1,117 @@
+"""The mid-run spend figure and the billed figure are one arithmetic.
+
+``platform_usd_total`` gates a live run; ``calculate_cost_from_per_call_records``
+bills it. They read the same buffer, so any divergence is the gate stopping a
+run over money the turn was never charged, or failing to stop one it was. The
+tracker used to reimplement the pricing walk to keep the read O(1); it now
+prices the tail through the billing pass itself, and these pin that they agree
+across the shapes that made the two paths differ at all — the ``billing_type``
+default, a non-platform call, and a manifest miss — under the append-then-read
+interleave the credit gate actually produces.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.utils.tracking.core import calculate_cost_from_per_call_records
+from src.utils.tracking.per_call_token_tracker import PerCallTokenTracker
+
+_BASE = datetime(2026, 1, 2, 9, 0, tzinfo=timezone.utc)
+
+
+def _record(i, model, *, billing_type="platform"):
+    # Five hours apart so the series straddles any peak/off-peak window a
+    # scheduled card names, rather than landing entirely inside one.
+    started = _BASE + timedelta(hours=i * 5)
+    record = {
+        "model_name": model,
+        "served_model": model,
+        "pricing_model_id": model,
+        "pricing_provider": "anthropic",
+        "usage": {
+            "input_tokens": 3_000 + i * 71,
+            "output_tokens": 400 + i * 13,
+            "cached_tokens": i * 29,
+            "cache_5m_tokens": i * 7,
+            "cache_1h_tokens": 0,
+        },
+        "started_at": started.isoformat(),
+        "timestamp": (started + timedelta(seconds=4)).isoformat(),
+        "run_id": f"run-{i}",
+        "parent_run_id": None,
+    }
+    if billing_type is not None:
+        record["billing_type"] = billing_type
+    return record
+
+
+def test_the_platform_fixture_actually_prices():
+    """Positive control. Two of the cases below assert that a priced total and
+    a billed total agree, and two assert a total is zero; if the fixture model
+    ever leaves the manifest, the first pair silently becomes 0 == 0 and stops
+    telling "byok was excluded" apart from "nothing priced at all". No value is
+    pinned here, only that pricing happened."""
+    priced = calculate_cost_from_per_call_records(
+        [_record(i, "claude-opus-5") for i in range(6)]
+    )
+    assert priced["platform_cost"] > 0
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        pytest.param(
+            [_record(i, "claude-opus-5") for i in range(6)],
+            id="stamped-platform",
+        ),
+        pytest.param(
+            [_record(i, "claude-opus-5", billing_type=None) for i in range(6)],
+            id="billing-type-absent-defaults-to-platform",
+        ),
+        pytest.param(
+            [_record(i, "claude-opus-5", billing_type="byok") for i in range(6)],
+            id="own-key-call-contributes-nothing",
+        ),
+        pytest.param(
+            [_record(i, "no-such-model-anywhere") for i in range(4)],
+            id="manifest-miss-prices-zero-both-ways",
+        ),
+    ],
+)
+def test_the_running_total_matches_the_billed_pass(records):
+    tracker = PerCallTokenTracker()
+    for record in records:
+        # Read between appends: the cursor has to survive the interleaving,
+        # not just a single pass at the end.
+        tracker.per_call_records.append(record)
+        tracker.platform_usd_total()
+
+    assert tracker.platform_usd_total() == pytest.approx(
+        calculate_cost_from_per_call_records(records)["platform_cost"], rel=1e-12
+    )
+
+
+def test_reset_clears_the_running_total_and_its_cursor():
+    tracker = PerCallTokenTracker()
+    tracker.per_call_records.append(_record(0, "claude-opus-5"))
+    assert tracker.platform_usd_total() > 0
+
+    tracker.reset()
+    assert tracker.platform_usd_total() == 0.0
+
+
+def test_a_record_that_cannot_be_priced_is_skipped_rather_than_freezing_the_meter():
+    """Mid-run, inability to price must not stop the metering.
+
+    The cursor advances past a failed tail instead of retrying it: a record
+    that raises here raises in the billing pass too, so retrying would hold
+    this figure at its last good value for the rest of the turn and quietly
+    ungate a run that is still spending.
+    """
+    tracker = PerCallTokenTracker()
+    tracker.per_call_records.append({"no": "model_name here"})
+    assert tracker.platform_usd_total() == 0.0
+
+    tracker.per_call_records.append(_record(1, "claude-opus-5"))
+    assert tracker.platform_usd_total() > 0

--- a/web/src/components/ui/error-banner.tsx
+++ b/web/src/components/ui/error-banner.tsx
@@ -11,8 +11,9 @@ interface ErrorBannerProps {
   style?: React.CSSProperties;
 }
 
-function ErrorLink({ url, label, external }: ErrorLinkSpec) {
+export function ErrorLink({ url, label, labelKey, external }: ErrorLinkSpec): React.ReactElement {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   // A leading slash is not enough to claim a URL as ours: with a path-shaped
   // VITE_PLATFORM_URL the account portal answers on /account/*, same origin but
   // a different app, and routing to it lands on our catch-all with no network
@@ -40,7 +41,7 @@ function ErrorLink({ url, label, external }: ErrorLinkSpec) {
         }}
         style={{ textDecoration: 'underline', fontWeight: 500 }}
       >
-        {label}
+        {labelKey ? t(labelKey) : label}
       </a>
   );
 }

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -1279,6 +1279,8 @@
     "errorHintModelAccess": "Confirm your plan or subscription allows access to this model.",
     "errorHintProviderStatus": "Check the provider's status page for ongoing incidents.",
     "errorHintTryAnotherModel": "Try switching to a different model in the model picker.",
+    "errorLinkManagePlan": "Manage plan",
+    "errorLinkViewUsage": "View usage",
     "errorUpstreamHeadlineModel": "{{model}} returned an error",
     "errorUpstreamHeadlineModelStatus": "{{model}} returned an error ({{status}})",
     "errorAttemptedModels": "Also tried:",
@@ -1315,11 +1317,21 @@
     "taskReportBackPending": "Waiting for subagent results to report back",
     "taskCard": {
       "statusRunning": "Running",
+      "statusPausing": "Finishing current step",
       "statusCompleted": "Completed",
       "statusStopped": "Stopped",
       "statusFailed": "Failed",
       "statusUpdated": "Updated",
       "statusResumed": "Resumed"
+    },
+    "creditPause": {
+      "title": "Run paused",
+      "resume": "Resume",
+      "resuming": "Resuming…",
+      "resumedLabel": "Resumed"
+    },
+    "creditStop": {
+      "title": "Out of credits"
     },
     "subagentCard": {
       "titleFallback": "Subagent Task",
@@ -1339,6 +1351,7 @@
       "initializing": "Initializing",
       "instruct": "Instruct",
       "errorHeading": "This agent stopped with an error",
+      "stoppedHeading": "This agent stopped",
       "inputPlaceholder": "Add instruction for this agent...",
       "avatarAlt": "Agent"
     },
@@ -1467,6 +1480,7 @@
     },
     "compactedNotification": "Context compacted · {{from}} messages → summary",
     "taskErrorNotification": "Subagent run failed",
+    "taskStoppedNotification": "Subagent run stopped",
     "taskSteeringReturnedNotification": "Steering message returned — the run ended before it was delivered",
     "viewSummary": "View summary",
     "hideSummary": "Hide summary",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -1279,6 +1279,8 @@
     "errorHintModelAccess": "请确认您的套餐或订阅允许访问此模型。",
     "errorHintProviderStatus": "请查看提供商状态页，了解是否存在服务中断。",
     "errorHintTryAnotherModel": "请尝试在模型选择器中切换到其他模型。",
+    "errorLinkManagePlan": "管理套餐",
+    "errorLinkViewUsage": "查看用量",
     "errorUpstreamHeadlineModel": "{{model}} 返回错误",
     "errorUpstreamHeadlineModelStatus": "{{model}} 返回错误 ({{status}})",
     "errorAttemptedModels": "还尝试了：",
@@ -1314,11 +1316,21 @@
     "taskReportBackPending": "等待子代理结果汇报",
     "taskCard": {
       "statusRunning": "运行中",
+      "statusPausing": "完成当前步骤",
       "statusCompleted": "已完成",
       "statusStopped": "已停止",
       "statusFailed": "失败",
       "statusUpdated": "已更新",
       "statusResumed": "已恢复"
+    },
+    "creditPause": {
+      "title": "运行已暂停",
+      "resume": "继续",
+      "resuming": "继续中…",
+      "resumedLabel": "已继续"
+    },
+    "creditStop": {
+      "title": "额度已用尽"
     },
     "subagentCard": {
       "titleFallback": "子智能体任务",
@@ -1338,6 +1350,7 @@
       "initializing": "初始化中",
       "instruct": "指示",
       "errorHeading": "该智能体因错误而停止",
+      "stoppedHeading": "该智能体已停止",
       "inputPlaceholder": "为该智能体添加指令…",
       "avatarAlt": "智能体"
     },
@@ -1466,6 +1479,7 @@
     },
     "compactedNotification": "上下文已压缩 · {{from}} 条消息 → 摘要",
     "taskErrorNotification": "子任务运行失败",
+    "taskStoppedNotification": "子任务运行已停止",
     "taskSteeringReturnedNotification": "引导消息已退回 · 运行在送达前已结束",
     "viewSummary": "查看摘要",
     "hideSummary": "隐藏摘要",

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -270,6 +270,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     handleRejectPTCAgent,
     handleApproveSecretaryAction,
     handleRejectSecretaryAction,
+    handleResumeCreditPause,
     tokenUsage,
     threadId: currentThreadId,
     threadModels,
@@ -862,6 +863,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const stableRejectPTCAgent = useStableHandler(handleRejectPTCAgent);
   const stableApproveSecretaryAction = useStableHandler(handleApproveSecretaryAction);
   const stableRejectSecretaryAction = useStableHandler(handleRejectSecretaryAction);
+  const stableResumeCreditPause = useStableHandler(handleResumeCreditPause);
   const stableEditMessage = useStableHandler((id: string, content: string) =>
     handleEditMessage(id, content, chatInputRef.current?.getModelOptions?.()));
   const stableRegenerate = useStableHandler((id: string) =>
@@ -897,6 +899,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     onRejectPTCAgent: stableRejectPTCAgent,
     onApproveSecretaryAction: stableApproveSecretaryAction,
     onRejectSecretaryAction: stableRejectSecretaryAction,
+    onResumeCreditPause: stableResumeCreditPause,
     onEditMessage: stableEditMessage,
     onRegenerate: stableRegenerate,
     onRetry: stableRetry,
@@ -910,7 +913,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     stableAnswerQuestion, stableSkipQuestion, stableApproveCreateWorkspace,
     stableRejectCreateWorkspace, stableApproveStartQuestion, stableRejectStartQuestion,
     stableApprovePTCAgent, stableRejectPTCAgent, stableApproveSecretaryAction,
-    stableRejectSecretaryAction, stableEditMessage, stableRegenerate, stableRetry,
+    stableRejectSecretaryAction, stableResumeCreditPause, stableEditMessage, stableRegenerate, stableRetry,
     stableThumbUp, stableThumbDown, stableReportWithAgent, stableSendMessage,
   ]);
 

--- a/web/src/pages/ChatAgent/components/CreditPauseCard.tsx
+++ b/web/src/pages/ChatAgent/components/CreditPauseCard.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import { Check, PauseCircle, Play } from 'lucide-react';
+import { Loader } from '@/components/ui/loader';
+import { ErrorLink } from '@/components/ui/error-banner';
+import type { CreditPauseState } from '@/types/chat';
+
+interface CreditPauseCardProps {
+  pauseData: CreditPauseState;
+  /** Absent in read-only transcripts — the card then informs without offering resume. */
+  onResume?: () => void;
+}
+
+// The denial copy is the platform's and arrives unbounded: nothing on the path
+// caps its length, and a single long unbroken token would push the card past
+// its container. Wrapping handles the token, this handles the length.
+const DENIAL_COPY_MAX_CHARS = 600;
+
+function clampDenialCopy(message: string): string {
+  return message.length > DENIAL_COPY_MAX_CHARS
+    ? `${message.slice(0, DENIAL_COPY_MAX_CHARS).trimEnd()}\u2026`
+    : message;
+}
+
+/**
+ * HITL card for a credit-pause interrupt: the turn is checkpointed, not lost.
+ * Three states: pending (platform's denial copy + links + Resume), resuming
+ * (same copy, button disabled while admission decides), and resumed (quiet
+ * collapsed line). Resume re-runs admission server-side, which refuses with a
+ * 429 when the gate still denies — so the card only claims "Resumed" once a run
+ * actually opened, and returns to pending otherwise.
+ */
+function CreditPauseCard({ pauseData, onResume }: CreditPauseCardProps) {
+  const { t } = useTranslation();
+
+  const isResuming = pauseData.status === 'resuming';
+
+  // --- Resolved (resumed) ---
+  if (pauseData.status === 'resumed') {
+    return (
+      <div className="flex items-center gap-2 py-1">
+        <Check className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-accent-light)' }} />
+        <span className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>
+          {t('chat.creditPause.resumedLabel')}
+        </span>
+      </div>
+    );
+  }
+
+  // --- Pending: interactive ---
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 pb-3">
+        <PauseCircle className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-accent-light)' }} />
+        <span className="text-[0.9375rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>
+          {t('chat.creditPause.title')}
+        </span>
+      </div>
+
+      {/* Details: the platform's message plus where to act on it */}
+      <div
+        className="rounded-lg px-4 py-3 space-y-2"
+        style={{ border: '1px solid var(--color-border-muted)' }}
+      >
+        {pauseData.message && (
+          <div
+            className="text-sm break-words whitespace-pre-wrap"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            {clampDenialCopy(pauseData.message)}
+          </div>
+        )}
+        {pauseData.links && pauseData.links.length > 0 && (
+          <div className="flex items-center gap-4 text-sm" style={{ color: 'var(--color-accent-light)' }}>
+            {pauseData.links.map((l) => (
+              <ErrorLink key={`${l.url}|${l.label}`} {...l} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      {onResume && (
+        <div className="pt-3 flex items-center gap-2">
+          <motion.button
+            onClick={(e: React.MouseEvent) => { e.stopPropagation(); if (!isResuming) onResume(); }}
+            disabled={isResuming}
+            className="flex items-center gap-1.5 text-sm px-4 py-2 rounded-md font-medium transition-colors hover:brightness-110 disabled:cursor-default disabled:opacity-60 disabled:hover:brightness-100"
+            style={{ backgroundColor: 'var(--color-btn-primary-bg)', color: 'var(--color-btn-primary-text)' }}
+            whileHover={isResuming ? undefined : { scale: 1.02 }}
+            whileTap={isResuming ? undefined : { scale: 0.98 }}
+          >
+            {isResuming
+              ? <Loader size={14} className="flex-shrink-0" style={{ color: 'inherit' }} />
+              : <Play className="h-3.5 w-3.5 stroke-[2.5]" />}
+            {isResuming ? t('chat.creditPause.resuming') : t('chat.creditPause.resume')}
+          </motion.button>
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+export default CreditPauseCard;

--- a/web/src/pages/ChatAgent/components/CreditPausePendingContext.tsx
+++ b/web/src/pages/ChatAgent/components/CreditPausePendingContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import type { CreditPauseState } from '@/types/chat';
+
+// Consumed at the leaf (SubagentTaskMessageContent) so the task cards read the
+// message's pause state without every block in between carrying a prop for it.
+// Same pattern as SubagentTelemetryContext.
+const CreditPausePendingContext = createContext(false);
+
+export function useCreditPausePending(): boolean {
+  return useContext(CreditPausePendingContext);
+}
+
+/** `resuming` still counts as pending: the request is in flight and no run has
+ *  opened, so the tasks really are stopped until admission answers. */
+export function CreditPausePendingProvider({
+  creditPauses,
+  children,
+}: {
+  creditPauses?: Record<string, CreditPauseState>;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const pending = useMemo(
+    () => Object.values(creditPauses ?? {}).some((p) => p.status !== 'resumed'),
+    [creditPauses],
+  );
+  return (
+    <CreditPausePendingContext.Provider value={pending}>
+      {children}
+    </CreditPausePendingContext.Provider>
+  );
+}

--- a/web/src/pages/ChatAgent/components/SubagentStatusBar.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentStatusBar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertCircle, MessageSquarePlus, Send, X } from 'lucide-react';
+import { MessageSquarePlus, Send, X } from 'lucide-react';
 import { Loader } from '@/components/ui/loader';
 import { cn } from '../../../lib/utils';
 import iconRobo from '../../../assets/img/icon-robo.png';
@@ -241,20 +241,24 @@ function SubagentStatusBar({ agent, threadId, onInstructionSent }: SubagentStatu
         </div>
       </div>
 
-      {/* Failure reason — the "clue inside" for a Failed card. The status chip
-          alone said Failed with no cause; the ledger's reason lands here. */}
-      {isError && (
+      {/* The "clue inside": the status chip names the outcome, this carries the
+          ledger's reason. A failure shows the box either way; a stop only when
+          it has a reason to show. */}
+      {(isError || (isCancelled && !!agent.error)) && (
         <div
           className="flex items-start gap-2 px-4 py-2.5 rounded-lg"
           style={{
-            backgroundColor: 'var(--color-loss-soft)',
-            border: '1px solid var(--color-border-loss)',
+            backgroundColor: isError ? 'var(--color-loss-soft)' : 'var(--color-bg-tool-card)',
+            border: `1px solid ${isError ? 'var(--color-border-loss)' : 'var(--color-border-muted)'}`,
           }}
         >
-          <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" style={{ color: 'var(--color-icon-danger)' }} />
+          <SubagentStatusIcon status={effectiveStatus} className="h-4 w-4 flex-shrink-0 mt-0.5" />
           <div className="min-w-0">
-            <div className="text-xs font-medium" style={{ color: 'var(--color-icon-danger)' }}>
-              {t('chat.subagentBar.errorHeading')}
+            <div
+              className="text-xs font-medium"
+              style={{ color: isError ? 'var(--color-icon-danger)' : 'var(--color-text-secondary)' }}
+            >
+              {t(isError ? 'chat.subagentBar.errorHeading' : 'chat.subagentBar.stoppedHeading')}
             </div>
             {agent.error && (
               <div className="text-xs mt-0.5 break-words" style={{ color: 'var(--color-text-tertiary)' }}>

--- a/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/SubagentTaskMessageContent.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, PauseCircle } from 'lucide-react';
 import { compactNumber } from '@/lib/format';
+import { ErrorLink } from '@/components/ui/error-banner';
+import { CREDIT_STOP_ERROR_TYPE } from '@/types/sse';
+import { buildRateLimitError } from '@/utils/rateLimitError';
 import { type SubagentTokenUsage } from '../utils/tokenUsage';
+import { useCreditPausePending } from './CreditPausePendingContext';
 import { useSubagentTelemetry } from './SubagentTelemetryContext';
 import TaskCardShell, { MONO_STACK } from './TaskCardShell';
 import { taskCardStatusKind, type TaskCardStatusKind } from './taskStatusUi';
@@ -17,6 +21,97 @@ function summarize(text: string | undefined, maxLen = 100): string {
   const cleaned = firstLine.replace(/:$/, '');
   if (cleaned.length <= maxLen) return cleaned;
   return cleaned.slice(0, maxLen).replace(/\s+\S*$/, '') + '…';
+}
+
+// Neither reason is bounded: the credit denial is the platform's copy and the
+// rest are exception text, so one long enough would push a card's own content
+// out of shape.
+const STOP_REASON_MAX_CHARS = 180;
+
+function clampReason(text: string): string {
+  return text.length > STOP_REASON_MAX_CHARS
+    ? `${text.slice(0, STOP_REASON_MAX_CHARS).trimEnd()}\u2026`
+    : text;
+}
+
+function accountLinks(reason: string) {
+  // Same builder the pause card uses, so the two surfaces send the user to the
+  // same pages with the same wording rather than growing a second answer.
+  return buildRateLimitError(
+    { message: reason },
+    (import.meta.env.VITE_PLATFORM_URL as string | undefined) || '/account',
+  ).links;
+}
+
+/**
+ * A reason the user cannot act on, as a line inside the card: transport lost,
+ * a handler that raised. Worth saying, not worth interrupting for.
+ */
+function TaskStopReason({ reason }: { reason: string }): React.ReactElement {
+  return (
+    <div
+      data-testid="subagent-stop-reason"
+      style={{
+        marginTop: 8,
+        fontSize: '0.6875rem',
+        lineHeight: 1.5,
+        color: 'var(--color-text-tertiary)',
+        minWidth: 0,
+        wordBreak: 'break-word',
+      }}
+    >
+      {clampReason(reason)}
+    </div>
+  );
+}
+
+/**
+ * A credit stop, as a notice at the foot of the message in the MAIN transcript.
+ *
+ * A background task can outlive the turn that spawned it, and when the credit
+ * gate stops one the turn is already finished: there is no model boundary left
+ * to interrupt, so no pause card is ever raised in the thread. The denial then
+ * reaches only the task's own transcript, behind a click, while the thread
+ * shows a "Stopped" chip indistinguishable from a task the user ended.
+ *
+ * Deliberately outside the card rather than a line within it. Inside, it reads
+ * as a footnote on one task; the thing that actually happened is that the
+ * account ran out of money, which is the turn's news and the user's to act on.
+ * It borrows the pause card's layout for that reason - the same event should
+ * not look like two different kinds of event depending on when it landed. The
+ * placement is MessageContentSegments' call, and the reason it is last is
+ * written there.
+ */
+export function SubagentStopNotice({ subagentId }: { subagentId: string | undefined }): React.ReactElement | null {
+  const { t } = useTranslation();
+  const telemetry = useSubagentTelemetry(subagentId);
+  const reason = telemetry?.stopReason;
+  if (!reason || telemetry?.stopReasonType !== CREDIT_STOP_ERROR_TYPE) return null;
+  const links = accountLinks(reason);
+  return (
+    <div
+      data-testid="subagent-credit-stop-notice"
+      className="mt-2 rounded-lg px-4 py-3 space-y-2"
+      style={{ border: '1px solid var(--color-border-muted)' }}
+    >
+      <div className="flex items-center gap-2">
+        <PauseCircle className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-accent-light)' }} />
+        <span className="text-[0.9375rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>
+          {t('chat.creditStop.title')}
+        </span>
+      </div>
+      <div className="text-sm break-words" style={{ color: 'var(--color-text-secondary)' }}>
+        {clampReason(reason)}
+      </div>
+      {links && links.length > 0 && (
+        <div className="flex items-center gap-4 text-sm" style={{ color: 'var(--color-accent-light)' }}>
+          {links.map((l) => (
+            <ErrorLink key={`${l.url}|${l.label}`} {...l} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export interface ToolCallProcess {
@@ -78,6 +173,12 @@ function SubagentTaskMessageContent({
   const ctxTelemetry = useSubagentTelemetry(subagentId);
   const toolCalls = toolCallsProp ?? ctxTelemetry?.toolCalls ?? 0;
   const tokenUsage = tokenUsageProp ?? ctxTelemetry?.tokenUsage;
+  const stopReason = ctxTelemetry?.stopReason;
+  const stopReasonType = ctxTelemetry?.stopReasonType;
+  // A still-running task keeps working until its own gate stops it at the next
+  // model boundary, so while this turn holds an unanswered credit pause the
+  // card says it is finishing rather than promising more.
+  const pausing = useCreditPausePending();
   const { t } = useTranslation();
 
   if (!subagentId && !description) {
@@ -99,7 +200,7 @@ function SubagentTaskMessageContent({
   const statusKind: TaskCardStatusKind =
     action === 'update' ? 'updated'
     : action === 'resume' ? 'resumed'
-    : action === 'init' ? taskCardStatusKind(status)
+    : action === 'init' ? taskCardStatusKind(status, pausing)
     : 'unknown';
 
   const handleOpen = (): void => {
@@ -179,6 +280,17 @@ function SubagentTaskMessageContent({
             </span>
           )}
         </div>
+      )}
+      {/* Terminal only: a reason on a card still claiming to run would read as
+          a prediction. `running` covers `pausing`, which is a running task.
+          A credit stop is excluded here because it gets the notice at the foot
+          of the message instead; saying it twice would make the notice look
+          optional. */}
+      {stopReason
+        && stopReasonType !== CREDIT_STOP_ERROR_TYPE
+        && statusKind !== 'running'
+        && statusKind !== 'pausing' && (
+        <TaskStopReason reason={stopReason} />
       )}
     </TaskCardShell>
   );

--- a/web/src/pages/ChatAgent/components/__tests__/MessageList.chartAnnotation.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/MessageList.chartAnnotation.test.tsx
@@ -94,7 +94,6 @@ const baseProps = {
   subagentTasks: {},
   hasError: false,
   isAssistant: true,
-  textOnly: true,
 } satisfies Partial<SegmentsProps>;
 
 // `cumulative` is the full annotation set returned by that draw — each draw is a

--- a/web/src/pages/ChatAgent/components/__tests__/MessageList.lifecycle.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/MessageList.lifecycle.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Partition-timing coverage for the live → accordion lifecycle in
- * MessageContentSegments (textOnly mode).
+ * MessageContentSegments.
  *
  * The partition memo in MessageList.tsx decides whether each reasoning /
  * tool-call item renders in the live zone (`active` / `completing` /
@@ -129,7 +129,6 @@ const baseProps = {
   subagentTasks: {},
   hasError: false,
   isAssistant: true,
-  textOnly: true,
 } satisfies Partial<SegmentsProps>;
 
 const SUMMARY_BUTTON_RE = /toolArtifact/i;

--- a/web/src/pages/ChatAgent/components/__tests__/MessageList.modelFallback.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/MessageList.modelFallback.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Model-fallback divider rendering in MessageContentSegments (textOnly mode):
+ * Model-fallback divider rendering in MessageContentSegments:
  * the expandable error detail — a "View error" toggle (not "View summary")
  * reveals the failed model's error text in the panel below the divider.
  * (The switch-to-working-model action lives in ChatView's suggestion pill,
@@ -100,7 +100,6 @@ const baseProps = {
   subagentTasks: {},
   hasError: false,
   isAssistant: true,
-  textOnly: true,
 } satisfies Partial<SegmentsProps>;
 
 function fallbackSeg(order: number, toModel: string, over: Record<string, unknown> = {}) {

--- a/web/src/pages/ChatAgent/components/__tests__/SubagentStatusBar.errorReason.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SubagentStatusBar.errorReason.test.tsx
@@ -3,6 +3,11 @@
  * "Failed" with no cause. These lock that an errored agent renders the reason
  * banner (with the ledger message when present), and that a non-errored agent
  * never does.
+ *
+ * A credit stop is the one terminal that is neither: it settles ``cancelled``
+ * because nothing malfunctioned, but it still carries a reason, so it keeps
+ * the banner in neutral dress rather than losing the explanation along with
+ * the danger styling. A plain cancel has no reason and grows no banner.
  */
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
@@ -40,6 +45,26 @@ describe('SubagentStatusBar — failure reason banner', () => {
   it('shows the banner headline even when no ledger reason is available', () => {
     render(<SubagentStatusBar agent={{ ...baseAgent, status: 'error' }} threadId="t-1" />);
     expect(screen.getByText('This agent stopped with an error')).toBeInTheDocument();
+  });
+
+  it('shows a stopped task its reason, without calling it an error', () => {
+    const denial = 'Not enough credits to continue.';
+    render(
+      <SubagentStatusBar
+        agent={{ ...baseAgent, status: 'cancelled', error: denial }}
+        threadId="t-1"
+      />,
+    );
+    expect(screen.getByText('This agent stopped')).toBeInTheDocument();
+    expect(screen.getByText(denial)).toBeInTheDocument();
+    expect(screen.queryByText('This agent stopped with an error')).toBeNull();
+    expect(screen.queryByText('Failed')).toBeNull();
+  });
+
+  it('renders no banner for a plain cancel, which carries no reason', () => {
+    render(<SubagentStatusBar agent={{ ...baseAgent, status: 'cancelled' }} threadId="t-1" />);
+    expect(screen.queryByText('This agent stopped')).toBeNull();
+    expect(screen.queryByText('This agent stopped with an error')).toBeNull();
   });
 
   it('renders no error banner for a completed task', () => {

--- a/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/SubagentTaskMessageContent.test.tsx
@@ -11,8 +11,10 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import SubagentTaskMessageContent from '../SubagentTaskMessageContent';
+import { MemoryRouter } from 'react-router-dom';
+import SubagentTaskMessageContent, { SubagentStopNotice } from '../SubagentTaskMessageContent';
 import { SubagentTelemetryContext } from '../SubagentTelemetryContext';
+import type { SubagentTelemetry } from '../../session/subagents/resolveSubagentTelemetry';
 
 const baseProps = {
   subagentId: 'tc-abc',
@@ -352,5 +354,100 @@ describe('SubagentTaskMessageContent — accessibility', () => {
     const card = screen.getByRole('button');
     fireEvent.keyDown(card, { key: 'Enter' });
     expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The reason a settled task stopped, on the card in the MAIN transcript.
+ *
+ * A background task can outlive its turn. When the credit gate stops one the
+ * turn is already finished, so no pause card is ever raised in the thread and
+ * the denial reaches only the task's own transcript — behind a click. What the
+ * thread showed was a bare "Stopped" chip, which is exactly what a task the
+ * user ended on purpose shows.
+ */
+describe('SubagentTaskMessageContent — stop reason', () => {
+  const ZERO = { input: 0, output: 0, total: 0 };
+
+  const withTelemetry = (
+    telemetry: Partial<SubagentTelemetry>,
+    props: Record<string, unknown> = {},
+  ) =>
+    render(
+      <MemoryRouter>
+        <SubagentTelemetryContext.Provider
+          value={() => ({ toolCalls: 13, tokenUsage: ZERO, ...telemetry })}
+        >
+          <SubagentTaskMessageContent {...baseProps} status="cancelled" {...props} />
+        </SubagentTelemetryContext.Provider>
+      </MemoryRouter>,
+    );
+
+  it('states the reason a stopped task stopped', () => {
+    withTelemetry({ stopReason: 'transport_lost: the stream tore mid-run' });
+    expect(screen.getByTestId('subagent-stop-reason')).toHaveTextContent('transport_lost');
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('leaves a credit stop to the notice below, so it is not said twice', () => {
+    withTelemetry({
+      stopReason: 'Monthly credit limit reached (50/50 credits)',
+      stopReasonType: 'credit_stop',
+    });
+    expect(screen.queryByTestId('subagent-stop-reason')).toBeNull();
+  });
+
+  it('says nothing while the task is still running — a reason there would be a prediction', () => {
+    withTelemetry({ stopReason: 'transport_lost' }, { status: 'running' });
+    expect(screen.queryByTestId('subagent-stop-reason')).toBeNull();
+  });
+
+  it('clamps an unbounded reason so it cannot push the card open', () => {
+    withTelemetry({ stopReason: 'x'.repeat(400) });
+    const text = screen.getByTestId('subagent-stop-reason').textContent || '';
+    expect(text.length).toBeLessThan(400);
+    expect(text.endsWith('…')).toBe(true);
+  });
+});
+
+describe('SubagentStopNotice', () => {
+  const ZERO = { input: 0, output: 0, total: 0 };
+
+  const withTelemetry = (telemetry: Partial<SubagentTelemetry> | undefined) =>
+    render(
+      <MemoryRouter>
+        <SubagentTelemetryContext.Provider
+          value={() => (telemetry ? { toolCalls: 0, tokenUsage: ZERO, ...telemetry } : undefined)}
+        >
+          <SubagentStopNotice subagentId="sub-1" />
+        </SubagentTelemetryContext.Provider>
+      </MemoryRouter>,
+    );
+
+  it('surfaces a credit stop in the main transcript, with the account pages', () => {
+    withTelemetry({
+      stopReason: 'Monthly credit limit reached (50/50 credits)',
+      stopReasonType: 'credit_stop',
+    });
+    const notice = screen.getByTestId('subagent-credit-stop-notice');
+    expect(notice).toHaveTextContent('Monthly credit limit reached (50/50 credits)');
+    expect(screen.getByRole('link', { name: 'Manage plan' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View usage' })).toBeInTheDocument();
+  });
+
+  it('stays out of the way for a stop the user cannot act on', () => {
+    withTelemetry({ stopReason: 'transport_lost: the stream tore mid-run' });
+    expect(screen.queryByTestId('subagent-credit-stop-notice')).toBeNull();
+  });
+
+  it('renders nothing when no reason reached the client, as on a shared replay', () => {
+    withTelemetry(undefined);
+    expect(screen.queryByTestId('subagent-credit-stop-notice')).toBeNull();
+  });
+
+  it('clamps an unbounded reason', () => {
+    withTelemetry({ stopReason: 'x'.repeat(400), stopReasonType: 'credit_stop' });
+    const text = screen.getByTestId('subagent-credit-stop-notice').textContent || '';
+    expect(text.length).toBeLessThan(400);
   });
 });

--- a/web/src/pages/ChatAgent/components/chatView/types.ts
+++ b/web/src/pages/ChatAgent/components/chatView/types.ts
@@ -70,8 +70,11 @@ export interface AgentInfo {
   prompt?: string;
   type: string;
   status: string;
-  /** Ledger failure reason for an errored task (shown in the detail header). */
+  /** Ledger failure reason for a task that settled with one (shown in the
+   *  detail header). */
   error?: string;
+  /** That reason's machine spelling (``credit_stop``, ``transport_lost``, …). */
+  errorType?: string;
   toolCalls: number;
   tokenUsage: SubagentTokenUsage;
   currentTool: string;
@@ -96,6 +99,7 @@ export interface SubagentUpdateData {
   isActive: boolean;
   status?: string;
   error?: string;
+  errorType?: string;
   currentTool?: string;
   messages?: SubagentMessage[];
   tokenUsage?: SubagentTokenUsage;
@@ -109,6 +113,7 @@ export interface SubagentInfo {
   type?: string;
   status?: string;
   error?: string;
+  errorType?: string;
   /** Owning workflow run's agent id (`task:<id>`) when opened via its drill-in. */
   ownerTaskId?: string;
 }

--- a/web/src/pages/ChatAgent/components/chatView/useSubagentTabs.ts
+++ b/web/src/pages/ChatAgent/components/chatView/useSubagentTabs.ts
@@ -284,6 +284,7 @@ export function useSubagentTabs({
       ? existingStatus!
       : (history?.status || overrides.status || 'completed');
     const finalError = history?.error || overrides.error;
+    const finalErrorType = history?.errorType || overrides.errorType;
 
     // Check if card is currently live (active with an open stream). A card
     // whose own status already settled is not live however its flag reads.
@@ -313,6 +314,7 @@ export function useSubagentTabs({
       updateData.status = finalStatus;
       updateData.currentTool = '';
       if (finalError) updateData.error = finalError;
+      if (finalErrorType) updateData.errorType = finalErrorType;
     }
     if (history) {
       updateData.messages = (history.messages || []) as SubagentMessage[];

--- a/web/src/pages/ChatAgent/components/messageList/MessageActionsContext.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/MessageActionsContext.tsx
@@ -35,6 +35,7 @@ export interface MessageActions {
   onRejectPTCAgent?: (proposalData: Record<string, unknown>, proposalId: string, interruptId: string) => void;
   onApproveSecretaryAction?: (proposalData: Record<string, unknown>) => void;
   onRejectSecretaryAction?: (proposalData: Record<string, unknown>) => void;
+  onResumeCreditPause?: (pauseId: string, interruptId: string) => void;
   onEditMessage?: (messageId: string, content: string) => void;
   onRegenerate?: (messageId: string) => void;
   onRetry?: () => void;

--- a/web/src/pages/ChatAgent/components/messageList/MessageBubble.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/MessageBubble.tsx
@@ -8,8 +8,9 @@ import { useTheme } from '../../../../contexts/ThemeContext';
 import LissajousLoading from '@/components/ui/lissajous-loading';
 import { useUser } from '@/hooks/useUser';
 import { CitationMetadataProvider } from '../CitationMetadataContext';
+import { CreditPausePendingProvider } from '../CreditPausePendingContext';
 import TextMessageContent from '../TextMessageContent';
-import { countDedupedSources, type ProvenanceRecord, type SubagentTaskRecord } from '@/types/chat';
+import { countDedupedSources, type CreditPauseState, type ProvenanceRecord, type SubagentTaskRecord } from '@/types/chat';
 import { TextShimmer } from '@/components/ui/text-shimmer';
 import type { SelectionPreviewShape } from '../SelectionContextPreview';
 import { AttachmentCard, InlineSelectionCards, InlineWidgetDeck } from './attachments';
@@ -295,6 +296,7 @@ export const MessageBubble = memo(function MessageBubble({ message, turnIndex, i
           {/* Render content segments in chronological order */}
           {(message.contentSegments as ContentSegmentRecord[] | undefined) && (message.contentSegments as ContentSegmentRecord[]).length > 0 ? (
             <CitationMetadataProvider toolCallProcesses={(message.toolCallProcesses as Record<string, Record<string, unknown>>) || EMPTY_OBJ}>
+            <CreditPausePendingProvider creditPauses={message.creditPauses as Record<string, CreditPauseState> | undefined}>
             <MessageContentSegments
               segments={message.contentSegments as ContentSegmentRecord[]}
               reasoningProcesses={(message.reasoningProcesses as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
@@ -314,12 +316,13 @@ export const MessageBubble = memo(function MessageBubble({ message, turnIndex, i
               isSubagentView={isSubagentView}
               ptcAgentProposals={(message.ptcAgentProposals as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
               secretaryActionProposals={(message.secretaryActionProposals as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
+              creditPauses={(message.creditPauses as Record<string, CreditPauseState>) || EMPTY_OBJ}
               htmlWidgetProcesses={(message.htmlWidgetProcesses as Record<string, Record<string, unknown>>) || EMPTY_OBJ}
-              textOnly={true}
               readOnly={readOnly}
               allowFiles={allowFiles}
               flashContext={flashContext}
             />
+            </CreditPausePendingProvider>
             </CitationMetadataProvider>
           ) : (
             // Fallback for messages without segments (backward compatibility) - main chat shows text only

--- a/web/src/pages/ChatAgent/components/messageList/MessageContentSegments.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/MessageContentSegments.tsx
@@ -10,8 +10,10 @@ import CreateWorkspaceCard from '../CreateWorkspaceCard';
 import StartQuestionCard from '../StartQuestionCard';
 import PTCAgentCard from '../PTCAgentCard';
 import SecretaryConfirmCard from '../SecretaryConfirmCard';
+import CreditPauseCard from '../CreditPauseCard';
 import TaskSegmentCard from './TaskSegmentCard';
-import type { SubagentTaskRecord } from '@/types/chat';
+import { SubagentStopNotice } from '../SubagentTaskMessageContent';
+import type { CreditPauseState, SubagentTaskRecord } from '@/types/chat';
 import TextMessageContent from '../TextMessageContent';
 import InlineWidget from '../viewers/InlineWidget';
 import ToolCallMessageContent from '../ToolCallMessageContent';
@@ -25,15 +27,14 @@ import type { ContentSegmentRecord, ToolCallProcessRecord } from './types';
 import {
   buildRenderBlocks,
   groupSegments,
-  HIDDEN_TOOL_CALL_NAMES,
   type ActivityRenderBlock,
   type CompactArtifactRenderBlock,
   type CreateWorkspaceRenderBlock,
+  type CreditPauseRenderBlock,
   type HtmlWidgetRenderBlock,
   type NotificationRenderBlock,
   type PlanApprovalRenderBlock,
   type PTCAgentRenderBlock,
-  type RenderBlock,
   type SecretaryActionRenderBlock,
   type StartQuestionRenderBlock,
   type SubagentTaskRenderBlock,
@@ -66,8 +67,8 @@ interface MessageContentSegmentsProps {
   allowFiles?: boolean;
   ptcAgentProposals?: Record<string, Record<string, unknown>>;
   secretaryActionProposals?: Record<string, Record<string, unknown>>;
+  creditPauses?: Record<string, CreditPauseState>;
   htmlWidgetProcesses?: Record<string, Record<string, unknown>>;
-  textOnly?: boolean;
   flashContext?: { threadId: string; workspaceId: string } | null;
 }
 
@@ -113,7 +114,7 @@ function TextBlock({ block, isFirst, isStreaming, hasError, structuredError, isS
   return isFirst && textContent ? <div className="-mt-1">{textEl}</div> : textEl;
 }
 
-export const MessageContentSegments = memo(function MessageContentSegments({ segments, reasoningProcesses, toolCallProcesses, todoListProcesses: _todoListProcesses, subagentTasks, planApprovals = EMPTY_OBJ, userQuestions = EMPTY_OBJ, workspaceProposals = EMPTY_OBJ, questionProposals = EMPTY_OBJ, pendingToolCallChunks = EMPTY_OBJ, isStreaming, hasError, structuredError, isAssistant = false, compactToolCalls = false, isSubagentView = false, readOnly = false, allowFiles = false, ptcAgentProposals = EMPTY_OBJ, secretaryActionProposals = EMPTY_OBJ, htmlWidgetProcesses = EMPTY_OBJ, textOnly = false, flashContext }: MessageContentSegmentsProps): React.ReactElement {
+export const MessageContentSegments = memo(function MessageContentSegments({ segments, reasoningProcesses, toolCallProcesses, todoListProcesses: _todoListProcesses, subagentTasks, planApprovals = EMPTY_OBJ, userQuestions = EMPTY_OBJ, workspaceProposals = EMPTY_OBJ, questionProposals = EMPTY_OBJ, pendingToolCallChunks = EMPTY_OBJ, isStreaming, hasError, structuredError, isAssistant = false, compactToolCalls = false, isSubagentView = false, readOnly = false, allowFiles = false, ptcAgentProposals = EMPTY_OBJ, secretaryActionProposals = EMPTY_OBJ, creditPauses = EMPTY_OBJ, htmlWidgetProcesses = EMPTY_OBJ, flashContext }: MessageContentSegmentsProps): React.ReactElement {
   const {
     onOpenSubagentTask, onOpenFile, onOpenDir, onToolCallDetailClick,
     onApprovePlan, onRejectPlan, onPlanDetailClick,
@@ -122,6 +123,7 @@ export const MessageContentSegments = memo(function MessageContentSegments({ seg
     onApproveStartQuestion, onRejectStartQuestion,
     onApprovePTCAgent, onRejectPTCAgent,
     onApproveSecretaryAction, onRejectSecretaryAction,
+    onResumeCreditPause,
     onWidgetSendPrompt,
   } = useMessageActions();
 
@@ -131,7 +133,7 @@ export const MessageContentSegments = memo(function MessageContentSegments({ seg
   const nextExpiryRef = useRef<number | null>(null);
 
   // Schedule timer for next expiry — runs after every render since nextExpiryRef
-  // is set during render (from memoized renderBlocks or non-textOnly path).
+  // is set during render, from the memoized renderBlocks below.
   useEffect(() => {
     if (expiryTimerRef.current) clearTimeout(expiryTimerRef.current);
     expiryTimerRef.current = null;
@@ -152,410 +154,294 @@ export const MessageContentSegments = memo(function MessageContentSegments({ seg
   // Reset expiry for this render pass (set by memoized renderBlocks below)
   nextExpiryRef.current = null;
 
-  // Memoize the expensive renderBlocks construction (only meaningful in textOnly mode).
-  // Always call useMemo to satisfy rules-of-hooks; short-circuit when not textOnly.
+  // Memoize the expensive renderBlocks construction.
   // tick is included so timer-driven live→completed transitions recompute correctly.
-  const { blocks: renderBlocks, nextExpiry } = useMemo(() => {
-    if (!textOnly) return { blocks: [] as RenderBlock[], nextExpiry: null };
-    return buildRenderBlocks(groupedSegments, { reasoningProcesses, toolCallProcesses, isStreaming, isSubagentView });
+  const { blocks: renderBlocks, nextExpiry } = useMemo(
+    () => buildRenderBlocks(groupedSegments, { reasoningProcesses, toolCallProcesses, isStreaming, isSubagentView }),
   // eslint-disable-next-line react-hooks/exhaustive-deps -- tick is a semantic dep: forces recomputation when timer fires for live→completed transitions
-  }, [groupedSegments, tick, reasoningProcesses, toolCallProcesses, isStreaming, isSubagentView, textOnly]);
+    [groupedSegments, tick, reasoningProcesses, toolCallProcesses, isStreaming, isSubagentView],
+  );
 
   // Apply side effect: schedule timer for next expiry transition
   nextExpiryRef.current = nextExpiry;
 
-  // textOnly mode: use inline ActivityBlock groups
-  if (textOnly) {
-    // Derived values
-    const chunkEntries = Object.values(pendingToolCallChunks);
-    const preparingToolCall = chunkEntries.length > 0 ? {
-      toolName: (chunkEntries.find((c) => (c as Record<string, unknown>).toolName)?.toolName as string | undefined) ?? undefined,
-      chunkCount: chunkEntries.reduce((sum, c) => sum + ((c as Record<string, unknown>).chunkCount as number || 0), 0),
-      argsLength: chunkEntries.reduce((sum, c) => sum + ((c as Record<string, unknown>).argsLength as number || 0), 0),
-    } : null;
+  // Derived values
+  const chunkEntries = Object.values(pendingToolCallChunks);
+  const preparingToolCall = chunkEntries.length > 0 ? {
+    toolName: (chunkEntries.find((c) => (c as Record<string, unknown>).toolName)?.toolName as string | undefined) ?? undefined,
+    chunkCount: chunkEntries.reduce((sum, c) => sum + ((c as Record<string, unknown>).chunkCount as number || 0), 0),
+    argsLength: chunkEntries.reduce((sum, c) => sum + ((c as Record<string, unknown>).argsLength as number || 0), 0),
+  } : null;
 
-    let lastTextBlockIdx = -1;
-    let lastActivityBlockIdx = -1;
-    let hasAnyTrulyInProgress = false;
-    for (let i = 0; i < renderBlocks.length; i++) {
-      const b = renderBlocks[i];
-      if (b.type === 'text') lastTextBlockIdx = i;
-      if (b.type === 'activity') {
-        lastActivityBlockIdx = i;
-        if ((b as ActivityRenderBlock).items.some(item => item._liveState === 'active' && item.type === 'tool_call')) {
-          hasAnyTrulyInProgress = true;
-        }
+  let lastTextBlockIdx = -1;
+  let lastActivityBlockIdx = -1;
+  let hasAnyTrulyInProgress = false;
+  // Task ids in this message, for the stop notices rendered after the prose.
+  const taskSubagentIds: string[] = [];
+  for (let i = 0; i < renderBlocks.length; i++) {
+    const b = renderBlocks[i];
+    if (b.type === 'text') lastTextBlockIdx = i;
+    if (b.type === 'subagent_task') {
+      const id = (b as SubagentTaskRenderBlock).segment.subagentId;
+      if (id) taskSubagentIds.push(id);
+    }
+    if (b.type === 'activity') {
+      lastActivityBlockIdx = i;
+      if ((b as ActivityRenderBlock).items.some(item => item._liveState === 'active' && item.type === 'tool_call')) {
+        hasAnyTrulyInProgress = true;
       }
     }
+  }
 
-    const detectedFiles = isAssistant && !isStreaming
-      ? extractFilePaths(normalizeFileRefs(renderBlocks.filter(b => b.type === 'text').map(b => (b as TextRenderBlock).segment.content || '').join('\n')))
-      : [];
+  const detectedFiles = isAssistant && !isStreaming
+    ? extractFilePaths(normalizeFileRefs(renderBlocks.filter(b => b.type === 'text').map(b => (b as TextRenderBlock).segment.content || '').join('\n')))
+    : [];
 
-    return (
-      <div className="space-y-1">
-        {renderBlocks.map((block, blockIdx) => {
-          if (block.type === 'activity') {
-            if (compactToolCalls) {
-              // Show all items in compact mode (not just completed)
-              const items = (block as ActivityRenderBlock).items;
-              return (
-                <div key={block.key}>
-                  {items.map((item) => {
-                    if (item.type === 'tool_call') {
-                      return (
-                        <ToolCallMessageContent
-                          key={`tool-call-${item.toolCallId}`}
-                          toolCallId={item.toolCallId as string}
-                          toolName={item.toolName as string}
-                          toolCall={item.toolCall as any} // TODO: type properly
-                          toolCallResult={item.toolCallResult as any} // TODO: type properly
-                          isInProgress={(item.isInProgress as boolean) || false}
-                          isComplete={(item.isComplete as boolean) || false}
-                          isFailed={(item.isFailed as boolean) || false}
-                          onOpenFile={onOpenFile}
-                        />
-                      );
-                    }
-                    if (item.type === 'reasoning') {
-                      return (
-                        <ReasoningMessageContent
-                          key={`reasoning-${item.id}`}
-                          reasoningContent={(item.content as string) || ''}
-                          isReasoning={item._liveState === 'active'}
-                          reasoningComplete={(item.reasoningComplete as boolean) || item._liveState === 'completed'}
-                          reasoningTitle={(item.reasoningTitle as string) ?? undefined}
-                        />
-                      );
-                    }
-                    return null;
-                  })}
-                </div>
-              );
-            }
-
+  return (
+    <div className="space-y-1">
+      {renderBlocks.map((block, blockIdx) => {
+        if (block.type === 'activity') {
+          if (compactToolCalls) {
+            // Show all items in compact mode (not just completed)
+            const items = (block as ActivityRenderBlock).items;
             return (
-              <ActivityBlock
-                key={block.key}
-                items={(block as ActivityRenderBlock).items as any} // TODO: type properly — ActivityItem[] not exported
-                preparingToolCall={blockIdx === lastActivityBlockIdx ? preparingToolCall : null}
-                isStreaming={isStreaming ?? false}
-                onToolCallClick={onToolCallDetailClick as any} // TODO: type properly
-                onOpenFile={onOpenFile}
-              />
-            );
-          }
-
-          if (block.type === 'compact_artifact') {
-            const artifact = ((block as CompactArtifactRenderBlock).proc.toolCallResult as Record<string, unknown> | undefined)?.artifact as Record<string, unknown> | undefined;
-            const ChartComponent = artifact ? INLINE_ARTIFACT_MAP[artifact.type as string] : null;
-            if (!ChartComponent) return null;
-            return (
-              <div key={block.key} className="mt-1 mb-1">
-                <ChartComponent
-                  artifact={artifact!}
-                  onClick={() => onToolCallDetailClick?.((block as CompactArtifactRenderBlock).proc)}
-                />
+              <div key={block.key}>
+                {items.map((item) => {
+                  if (item.type === 'tool_call') {
+                    return (
+                      <ToolCallMessageContent
+                        key={`tool-call-${item.toolCallId}`}
+                        toolCallId={item.toolCallId as string}
+                        toolName={item.toolName as string}
+                        toolCall={item.toolCall as any} // TODO: type properly
+                        toolCallResult={item.toolCallResult as any} // TODO: type properly
+                        isInProgress={(item.isInProgress as boolean) || false}
+                        isComplete={(item.isComplete as boolean) || false}
+                        isFailed={(item.isFailed as boolean) || false}
+                        onOpenFile={onOpenFile}
+                      />
+                    );
+                  }
+                  if (item.type === 'reasoning') {
+                    return (
+                      <ReasoningMessageContent
+                        key={`reasoning-${item.id}`}
+                        reasoningContent={(item.content as string) || ''}
+                        isReasoning={item._liveState === 'active'}
+                        reasoningComplete={(item.reasoningComplete as boolean) || item._liveState === 'completed'}
+                        reasoningTitle={(item.reasoningTitle as string) ?? undefined}
+                      />
+                    );
+                  }
+                  return null;
+                })}
               </div>
             );
           }
 
-          if (block.type === 'notification') {
-            const notifSeg = (block as NotificationRenderBlock).segment;
-            return (
-              <NotificationDivider key={block.key} content={notifSeg.content} detail={notifSeg.detail} detailKind={notifSeg.detailKind} />
-            );
-          }
-
-          if (block.type === 'text') {
-            return (
-              <TextBlock
-                key={block.key}
-                block={block as TextRenderBlock}
-                isFirst={blockIdx === 0}
-                isStreaming={!!(isStreaming && blockIdx === lastTextBlockIdx && !hasAnyTrulyInProgress)}
-                hasError={!!hasError}
-                structuredError={structuredError}
-                isSubagentView={isSubagentView}
-                onOpenFile={onOpenFile}
-              />
-            );
-          }
-
-          if (block.type === 'html_widget') {
-            const widgetSeg = (block as HtmlWidgetRenderBlock).segment;
-            const widgetData = (htmlWidgetProcesses as Record<string, { html: string; title: string; data?: Record<string, string> }> | undefined)?.[widgetSeg.widgetId!];
-            if (!widgetData) return null;
-            return (
-              <InlineWidget
-                key={block.key}
-                html={widgetData.html}
-                title={widgetData.title}
-                onSendPrompt={onWidgetSendPrompt}
-                data={widgetData.data}
-              />
-            );
-          }
-
-          if (block.type === 'subagent_task') {
-            const subId = (block as SubagentTaskRenderBlock).segment.subagentId!;
-            return (
-              <TaskSegmentCard
-                key={block.key}
-                subagentId={subId}
-                task={subagentTasks[subId]}
-                toolCallProcess={toolCallProcesses[subId] || undefined}
-                onOpen={readOnly ? undefined : onOpenSubagentTask}
-                onDetailOpen={readOnly ? undefined : onToolCallDetailClick}
-              />
-            );
-          }
-
-          if (block.type === 'plan_approval') {
-            const pd = planApprovals[(block as PlanApprovalRenderBlock).segment.planApprovalId!];
-            if (!pd) return null;
-            return (
-              <PlanApprovalCard
-                key={block.key}
-                planData={pd as any} // TODO: type properly — PlanData not exported
-                onApprove={readOnly ? undefined : onApprovePlan}
-                onReject={readOnly ? undefined : onRejectPlan}
-                onDetailClick={readOnly ? undefined : () => onPlanDetailClick?.(pd)}
-              />
-            );
-          }
-
-          if (block.type === 'user_question') {
-            const qd = userQuestions[(block as UserQuestionRenderBlock).segment.questionId!];
-            if (!qd) return null;
-            return (
-              <UserQuestionCard
-                key={block.key}
-                questionData={qd as any} // TODO: type properly — QuestionData not exported
-                onAnswer={readOnly ? undefined : (answer: string) => onAnswerQuestion!(answer, (block as UserQuestionRenderBlock).segment.questionId!, qd.interruptId as string)}
-                onSkip={readOnly ? undefined : () => onSkipQuestion!((block as UserQuestionRenderBlock).segment.questionId!, qd.interruptId as string)}
-              />
-            );
-          }
-
-          if (block.type === 'create_workspace') {
-            if (readOnly) return null;
-            const wd = workspaceProposals[(block as CreateWorkspaceRenderBlock).segment.proposalId!];
-            if (!wd) return null;
-            return (
-              <CreateWorkspaceCard
-                key={block.key}
-                proposalData={wd as any} // TODO: type properly — ProposalData not exported
-                onApprove={onApproveCreateWorkspace ? () => onApproveCreateWorkspace(wd) : undefined}
-                onReject={onRejectCreateWorkspace ? () => onRejectCreateWorkspace(wd) : undefined}
-              />
-            );
-          }
-
-          if (block.type === 'start_question') {
-            if (readOnly) return null;
-            const sqd = questionProposals[(block as StartQuestionRenderBlock).segment.proposalId!];
-            if (!sqd) return null;
-            return (
-              <StartQuestionCard
-                key={block.key}
-                proposalData={sqd as any} // TODO: type properly — ProposalData not exported
-                onApprove={onApproveStartQuestion ? () => onApproveStartQuestion(sqd) : undefined}
-                onReject={onRejectStartQuestion ? () => onRejectStartQuestion(sqd) : undefined}
-              />
-            );
-          }
-
-          if (block.type === 'ptc_agent') {
-            if (readOnly) return null;
-            const pad = ptcAgentProposals[(block as PTCAgentRenderBlock).segment.proposalId!];
-            if (!pad) return null;
-            return (
-              <PTCAgentCard
-                key={block.key}
-                proposalData={pad as any}
-                onApprove={onApprovePTCAgent ? (overrides?: { report_back?: boolean }) => onApprovePTCAgent(pad, overrides, (block as PTCAgentRenderBlock).segment.proposalId!, pad.interruptId as string) : undefined}
-                onReject={onRejectPTCAgent ? () => onRejectPTCAgent(pad, (block as PTCAgentRenderBlock).segment.proposalId!, pad.interruptId as string) : undefined}
-                flashContext={flashContext}
-              />
-            );
-          }
-
-          if (block.type === 'delete_workspace' || block.type === 'stop_workspace' || block.type === 'delete_thread') {
-            if (readOnly) return null;
-            const sad = secretaryActionProposals[(block as SecretaryActionRenderBlock).segment.proposalId!];
-            if (!sad) return null;
-            return (
-              <SecretaryConfirmCard
-                key={block.key}
-                proposalData={sad as any}
-                onApprove={onApproveSecretaryAction ? () => onApproveSecretaryAction(sad) : undefined}
-                onReject={onRejectSecretaryAction ? () => onRejectSecretaryAction(sad) : undefined}
-              />
-            );
-          }
-
-          return null;
-        })}
-        {/* Standalone preparingToolCall when no activity blocks exist yet */}
-        {preparingToolCall && lastActivityBlockIdx === -1 && (
-          <ActivityBlock
-            items={[]}
-            preparingToolCall={preparingToolCall}
-            isStreaming={isStreaming ?? false}
-            onToolCallClick={onToolCallDetailClick as any} // TODO: type properly
-            onOpenFile={onOpenFile}
-          />
-        )}
-        {detectedFiles.length > 0 && (!readOnly || allowFiles) && (
-          <FileMentionCards filePaths={detectedFiles} onOpenFile={((readOnly && !allowFiles) ? undefined : onOpenFile)!} onOpenDir={(readOnly && !allowFiles) ? undefined : onOpenDir} />
-        )}
-      </div>
-    );
-  }
-
-  // Non-textOnly mode (agent panel): render all segments individually
-  return (
-    <div className="space-y-2">
-      {groupedSegments.map((segment, index) => {
-        if (segment.type === 'text') {
-          const isLastSegment = index === groupedSegments.length - 1;
           return (
-            <div key={`text-${segment.order}-${index}`}>
-              <TextMessageContent
-                content={segment.content ?? ''}
-                isStreaming={!!(isStreaming && isLastSegment)}
-                hasError={!!hasError}
-                structuredError={structuredError}
-                onOpenFile={onOpenFile}
-              />
-            </div>
-          );
-        } else if (segment.type === 'reasoning') {
-          const proc = reasoningProcesses[segment.reasoningId!];
-          if (!proc) return null;
-          return (
-            <ReasoningMessageContent
-              key={`reasoning-${segment.reasoningId}`}
-              reasoningContent={(proc.content as string) || ''}
-              isReasoning={(proc.isReasoning as boolean) || false}
-              reasoningComplete={(proc.reasoningComplete as boolean) || false}
-              reasoningTitle={(proc.reasoningTitle as string) ?? undefined}
-            />
-          );
-        } else if (segment.type === 'tool_call') {
-          const proc = toolCallProcesses[segment.toolCallId!];
-          if (!proc || HIDDEN_TOOL_CALL_NAMES.has(proc.toolName as string)) return null;
-          return (
-            <ToolCallMessageContent
-              key={`tool-call-${segment.toolCallId}`}
-              toolCallId={segment.toolCallId!}
-              toolName={proc.toolName as string}
-              toolCall={proc.toolCall as any} // TODO: type properly
-              toolCallResult={proc.toolCallResult as any} // TODO: type properly
-              isInProgress={(proc.isInProgress as boolean) || false}
-              isComplete={(proc.isComplete as boolean) || false}
-              isFailed={(proc.isFailed as boolean) || false}
+            <ActivityBlock
+              key={block.key}
+              items={(block as ActivityRenderBlock).items as any} // TODO: type properly — ActivityItem[] not exported
+              preparingToolCall={blockIdx === lastActivityBlockIdx ? preparingToolCall : null}
+              isStreaming={isStreaming ?? false}
+              onToolCallClick={onToolCallDetailClick as any} // TODO: type properly
               onOpenFile={onOpenFile}
             />
           );
-        } else if (segment.type === 'subagent_task') {
-          const subId = segment.subagentId!;
+        }
+
+        if (block.type === 'compact_artifact') {
+          const artifact = ((block as CompactArtifactRenderBlock).proc.toolCallResult as Record<string, unknown> | undefined)?.artifact as Record<string, unknown> | undefined;
+          const ChartComponent = artifact ? INLINE_ARTIFACT_MAP[artifact.type as string] : null;
+          if (!ChartComponent) return null;
           return (
-            <TaskSegmentCard
-              key={`subagent-task-${subId}`}
-              subagentId={subId}
-              task={subagentTasks[subId]}
-              onOpen={onOpenSubagentTask}
-            />
-          );
-        } else if (segment.type === 'plan_approval') {
-          const pd = planApprovals[segment.planApprovalId!];
-          if (pd) {
-            return (
-              <PlanApprovalCard
-                key={`plan-${segment.planApprovalId}`}
-                planData={pd as any} // TODO: type properly — PlanData not exported
-                onApprove={onApprovePlan}
-                onReject={onRejectPlan}
-                onDetailClick={() => onPlanDetailClick?.(pd)}
+            <div key={block.key} className="mt-1 mb-1">
+              <ChartComponent
+                artifact={artifact!}
+                onClick={() => onToolCallDetailClick?.((block as CompactArtifactRenderBlock).proc)}
               />
-            );
-          }
-          return null;
-        } else if (segment.type === 'user_question') {
-          const qd = userQuestions[segment.questionId!];
-          if (qd) {
-            return (
-              <UserQuestionCard
-                key={`question-${segment.questionId}`}
-                questionData={qd as any} // TODO: type properly — QuestionData not exported
-                onAnswer={(answer: string) => onAnswerQuestion!(answer, segment.questionId!, qd.interruptId as string)}
-                onSkip={() => onSkipQuestion!(segment.questionId!, qd.interruptId as string)}
-              />
-            );
-          }
-          return null;
-        } else if (segment.type === 'create_workspace') {
-          const wd = workspaceProposals[segment.proposalId!];
-          if (wd) {
-            return (
-              <CreateWorkspaceCard
-                key={`workspace-${segment.proposalId}`}
-                proposalData={wd as any} // TODO: type properly — ProposalData not exported
-                onApprove={onApproveCreateWorkspace ? () => onApproveCreateWorkspace(wd) : undefined}
-                onReject={onRejectCreateWorkspace ? () => onRejectCreateWorkspace(wd) : undefined}
-              />
-            );
-          }
-          return null;
-        } else if (segment.type === 'start_question') {
-          const sqd = questionProposals[segment.proposalId!];
-          if (sqd) {
-            return (
-              <StartQuestionCard
-                key={`start-question-${segment.proposalId}`}
-                proposalData={sqd as any} // TODO: type properly — ProposalData not exported
-                onApprove={onApproveStartQuestion ? () => onApproveStartQuestion(sqd) : undefined}
-                onReject={onRejectStartQuestion ? () => onRejectStartQuestion(sqd) : undefined}
-              />
-            );
-          }
-          return null;
-        } else if (segment.type === 'ptc_agent') {
-          const pad = ptcAgentProposals[segment.proposalId!];
-          if (pad) {
-            return (
-              <PTCAgentCard
-                key={`ptc-agent-${segment.proposalId}`}
-                proposalData={pad as any}
-                onApprove={onApprovePTCAgent ? (overrides?: { report_back?: boolean }) => onApprovePTCAgent(pad, overrides, segment.proposalId!, pad.interruptId as string) : undefined}
-                onReject={onRejectPTCAgent ? () => onRejectPTCAgent(pad, segment.proposalId!, pad.interruptId as string) : undefined}
-                flashContext={flashContext}
-              />
-            );
-          }
-          return null;
-        } else if (segment.type === 'delete_workspace' || segment.type === 'stop_workspace' || segment.type === 'delete_thread') {
-          const sad = secretaryActionProposals[segment.proposalId!];
-          if (sad) {
-            return (
-              <SecretaryConfirmCard
-                key={`secretary-${segment.type}-${segment.proposalId}`}
-                proposalData={sad as any}
-                onApprove={onApproveSecretaryAction ? () => onApproveSecretaryAction(sad) : undefined}
-                onReject={onRejectSecretaryAction ? () => onRejectSecretaryAction(sad) : undefined}
-              />
-            );
-          }
-          return null;
-        } else if (segment.type === 'notification') {
-          return (
-            <NotificationDivider key={`notification-${segment.order}-${index}`} content={segment.content} detail={segment.detail} detailKind={segment.detailKind} />
+            </div>
           );
         }
+
+        if (block.type === 'notification') {
+          const notifSeg = (block as NotificationRenderBlock).segment;
+          return (
+            <NotificationDivider key={block.key} content={notifSeg.content} detail={notifSeg.detail} detailKind={notifSeg.detailKind} />
+          );
+        }
+
+        if (block.type === 'text') {
+          return (
+            <TextBlock
+              key={block.key}
+              block={block as TextRenderBlock}
+              isFirst={blockIdx === 0}
+              isStreaming={!!(isStreaming && blockIdx === lastTextBlockIdx && !hasAnyTrulyInProgress)}
+              hasError={!!hasError}
+              structuredError={structuredError}
+              isSubagentView={isSubagentView}
+              onOpenFile={onOpenFile}
+            />
+          );
+        }
+
+        if (block.type === 'html_widget') {
+          const widgetSeg = (block as HtmlWidgetRenderBlock).segment;
+          const widgetData = (htmlWidgetProcesses as Record<string, { html: string; title: string; data?: Record<string, string> }> | undefined)?.[widgetSeg.widgetId!];
+          if (!widgetData) return null;
+          return (
+            <InlineWidget
+              key={block.key}
+              html={widgetData.html}
+              title={widgetData.title}
+              onSendPrompt={onWidgetSendPrompt}
+              data={widgetData.data}
+            />
+          );
+        }
+
+        if (block.type === 'subagent_task') {
+          const subId = (block as SubagentTaskRenderBlock).segment.subagentId!;
+          return (
+            <TaskSegmentCard
+              key={block.key}
+              subagentId={subId}
+              task={subagentTasks[subId]}
+              toolCallProcess={toolCallProcesses[subId] || undefined}
+              onOpen={readOnly ? undefined : onOpenSubagentTask}
+              onDetailOpen={readOnly ? undefined : onToolCallDetailClick}
+            />
+          );
+        }
+
+        if (block.type === 'plan_approval') {
+          const pd = planApprovals[(block as PlanApprovalRenderBlock).segment.planApprovalId!];
+          if (!pd) return null;
+          return (
+            <PlanApprovalCard
+              key={block.key}
+              planData={pd as any} // TODO: type properly — PlanData not exported
+              onApprove={readOnly ? undefined : onApprovePlan}
+              onReject={readOnly ? undefined : onRejectPlan}
+              onDetailClick={readOnly ? undefined : () => onPlanDetailClick?.(pd)}
+            />
+          );
+        }
+
+        if (block.type === 'user_question') {
+          const qd = userQuestions[(block as UserQuestionRenderBlock).segment.questionId!];
+          if (!qd) return null;
+          return (
+            <UserQuestionCard
+              key={block.key}
+              questionData={qd as any} // TODO: type properly — QuestionData not exported
+              onAnswer={readOnly ? undefined : (answer: string) => onAnswerQuestion!(answer, (block as UserQuestionRenderBlock).segment.questionId!, qd.interruptId as string)}
+              onSkip={readOnly ? undefined : () => onSkipQuestion!((block as UserQuestionRenderBlock).segment.questionId!, qd.interruptId as string)}
+            />
+          );
+        }
+
+        if (block.type === 'create_workspace') {
+          if (readOnly) return null;
+          const wd = workspaceProposals[(block as CreateWorkspaceRenderBlock).segment.proposalId!];
+          if (!wd) return null;
+          return (
+            <CreateWorkspaceCard
+              key={block.key}
+              proposalData={wd as any} // TODO: type properly — ProposalData not exported
+              onApprove={onApproveCreateWorkspace ? () => onApproveCreateWorkspace(wd) : undefined}
+              onReject={onRejectCreateWorkspace ? () => onRejectCreateWorkspace(wd) : undefined}
+            />
+          );
+        }
+
+        if (block.type === 'start_question') {
+          if (readOnly) return null;
+          const sqd = questionProposals[(block as StartQuestionRenderBlock).segment.proposalId!];
+          if (!sqd) return null;
+          return (
+            <StartQuestionCard
+              key={block.key}
+              proposalData={sqd as any} // TODO: type properly — ProposalData not exported
+              onApprove={onApproveStartQuestion ? () => onApproveStartQuestion(sqd) : undefined}
+              onReject={onRejectStartQuestion ? () => onRejectStartQuestion(sqd) : undefined}
+            />
+          );
+        }
+
+        if (block.type === 'ptc_agent') {
+          if (readOnly) return null;
+          const pad = ptcAgentProposals[(block as PTCAgentRenderBlock).segment.proposalId!];
+          if (!pad) return null;
+          return (
+            <PTCAgentCard
+              key={block.key}
+              proposalData={pad as any}
+              onApprove={onApprovePTCAgent ? (overrides?: { report_back?: boolean }) => onApprovePTCAgent(pad, overrides, (block as PTCAgentRenderBlock).segment.proposalId!, pad.interruptId as string) : undefined}
+              onReject={onRejectPTCAgent ? () => onRejectPTCAgent(pad, (block as PTCAgentRenderBlock).segment.proposalId!, pad.interruptId as string) : undefined}
+              flashContext={flashContext}
+            />
+          );
+        }
+
+        if (block.type === 'delete_workspace' || block.type === 'stop_workspace' || block.type === 'delete_thread') {
+          if (readOnly) return null;
+          const sad = secretaryActionProposals[(block as SecretaryActionRenderBlock).segment.proposalId!];
+          if (!sad) return null;
+          return (
+            <SecretaryConfirmCard
+              key={block.key}
+              proposalData={sad as any}
+              onApprove={onApproveSecretaryAction ? () => onApproveSecretaryAction(sad) : undefined}
+              onReject={onRejectSecretaryAction ? () => onRejectSecretaryAction(sad) : undefined}
+            />
+          );
+        }
+
+        if (block.type === 'credit_pause') {
+          const pauseId = (block as CreditPauseRenderBlock).segment.proposalId!;
+          const cpd = creditPauses[pauseId];
+          if (!cpd) return null;
+          // Renders even read-only in this app (it explains why the turn
+          // stopped); only the resume affordance needs an interactive host.
+          // Shared transcripts are a different reader and never reach here:
+          // SharedChatView projects plan approvals only, so a pause never
+          // lands in a link anyone can open.
+          return (
+            <CreditPauseCard
+              key={block.key}
+              pauseData={cpd}
+              onResume={!readOnly && onResumeCreditPause ? () => onResumeCreditPause(pauseId, cpd.interruptId) : undefined}
+            />
+          );
+        }
+
         return null;
       })}
+      {/* Standalone preparingToolCall when no activity blocks exist yet */}
+      {preparingToolCall && lastActivityBlockIdx === -1 && (
+        <ActivityBlock
+          items={[]}
+          preparingToolCall={preparingToolCall}
+          isStreaming={isStreaming ?? false}
+          onToolCallClick={onToolCallDetailClick as any} // TODO: type properly
+          onOpenFile={onOpenFile}
+        />
+      )}
+      {detectedFiles.length > 0 && (!readOnly || allowFiles) && (
+        <FileMentionCards filePaths={detectedFiles} onOpenFile={((readOnly && !allowFiles) ? undefined : onOpenFile)!} onOpenDir={(readOnly && !allowFiles) ? undefined : onOpenDir} />
+      )}
+      {/* At the foot of the message, not beside the card that stopped. The
+          agent's closing prose was written before the gate fired and still
+          promises a result, so a notice above it is read first and contradicted
+          second. Last is where the turn's outcome belongs. Each self-hides
+          unless its task was stopped for credits, so ordinary turns render
+          nothing here. */}
+      {taskSubagentIds.map((id) => (
+        <SubagentStopNotice key={`stop-${id}`} subagentId={id} />
+      ))}
     </div>
   );
 });

--- a/web/src/pages/ChatAgent/components/messageList/__tests__/MessageContentSegments.creditPause.test.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/__tests__/MessageContentSegments.creditPause.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * The "finishing current step" task state is DERIVED from the message's own
+ * credit pauses at render time, never written onto the task record. These pin
+ * the two properties that choice buys: a still-running task reads as finishing
+ * while its turn holds an unanswered pause, and it goes back to running the
+ * moment the pause resolves — with no second write, and nothing for history
+ * replay to reproduce.
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { CreditPauseState, SubagentTaskRecord } from '@/types/chat';
+import { MessageContentSegments } from '../MessageContentSegments';
+import { CreditPausePendingProvider } from '../../CreditPausePendingContext';
+
+// The status chip paints its word twice (the ascii liveness glyph carries it as
+// its screen-reader label, the chip renders it visibly), so count instead of
+// asserting a single node.
+const shows = (label: string): boolean => screen.queryAllByText(label).length > 0;
+
+type SegmentsProps = React.ComponentProps<typeof MessageContentSegments>;
+
+/** MessageBubble wraps every message in this provider; the cards read it. */
+function Segments(p: SegmentsProps): React.ReactElement {
+  return (
+    <CreditPausePendingProvider creditPauses={p.creditPauses}>
+      <MessageContentSegments {...p} />
+    </CreditPausePendingProvider>
+  );
+}
+
+const RUNNING_TASK: Record<string, SubagentTaskRecord> = {
+  'tc-1': {
+    subagentId: 'tc-1',
+    description: 'Research the filing',
+    prompt: 'Research the filing',
+    type: 'research',
+    action: 'init',
+    status: 'running',
+  },
+};
+
+function props(creditPauses: Record<string, CreditPauseState>): SegmentsProps {
+  return {
+    segments: [
+      { type: 'subagent_task', order: 0, subagentId: 'tc-1' },
+      ...(Object.keys(creditPauses).length
+        ? [{ type: 'credit_pause', order: 1, proposalId: 'int-1' }]
+        : []),
+    ] as SegmentsProps['segments'],
+    reasoningProcesses: {},
+    toolCallProcesses: {},
+    todoListProcesses: {},
+    subagentTasks: RUNNING_TASK,
+    creditPauses,
+    isStreaming: false,
+    isAssistant: true,
+  };
+}
+
+const PENDING: Record<string, CreditPauseState> = {
+  'int-1': { status: 'pending', message: 'Out of credits.', interruptId: 'int-1' },
+};
+const RESUMED: Record<string, CreditPauseState> = {
+  'int-1': { status: 'resumed', message: 'Out of credits.', interruptId: 'int-1' },
+};
+
+describe('MessageContentSegments — credit pause and task status', () => {
+  it('leaves a running task alone when the message has no pause', () => {
+    render(<Segments {...props({})} />);
+    expect(shows('Running')).toBe(true);
+    expect(shows('Finishing current step')).toBe(false);
+  });
+
+  it('reads a running task as finishing while a pause on this message is pending', () => {
+    render(<Segments {...props(PENDING)} />);
+    expect(shows('Finishing current step')).toBe(true);
+    expect(shows('Running')).toBe(false);
+  });
+
+  it('reverts to running when the pause resolves, with no write to the task record', () => {
+    const view = render(<Segments {...props(PENDING)} />);
+    expect(shows('Finishing current step')).toBe(true);
+
+    view.rerender(<Segments {...props(RESUMED)} />);
+
+    expect(shows('Running')).toBe(true);
+    expect(shows('Finishing current step')).toBe(false);
+    // The record the projection wrote is still exactly what it wrote — the
+    // pausing state never touched it, which is why nothing has to undo it.
+    expect(RUNNING_TASK['tc-1'].status).toBe('running');
+  });
+
+  it('does not touch a task that is not running', () => {
+    const completed: Record<string, SubagentTaskRecord> = {
+      'tc-1': { ...RUNNING_TASK['tc-1'], status: 'completed' },
+    };
+    render(<Segments {...props(PENDING)} subagentTasks={completed} />);
+    expect(shows('Completed')).toBe(true);
+    expect(shows('Finishing current step')).toBe(false);
+  });
+});

--- a/web/src/pages/ChatAgent/components/messageList/__tests__/MessageContentSegments.stopNotice.test.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/__tests__/MessageContentSegments.stopNotice.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Where the credit-stop notice sits, and why it sits there.
+ *
+ * The agent's closing prose was written before the gate fired and still
+ * promises a result ("I'll surface the summary as soon as it completes"), so a
+ * notice rendered beside the task card is read first and contradicted second.
+ * It belongs at the foot of the message, after the prose, where the turn's
+ * outcome goes.
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import type { SubagentTaskRecord } from '@/types/chat';
+import { MessageContentSegments } from '../MessageContentSegments';
+import { SubagentTelemetryContext } from '../../SubagentTelemetryContext';
+import type { SubagentTelemetry } from '../../../session/subagents/resolveSubagentTelemetry';
+
+type SegmentsProps = React.ComponentProps<typeof MessageContentSegments>;
+
+const PROSE = "I'll surface the summary as soon as it completes.";
+
+const STOPPED_TASK: Record<string, SubagentTaskRecord> = {
+  'tc-1': {
+    subagentId: 'tc-1',
+    description: 'Analyze NVDA recent technical setup',
+    prompt: 'Analyze NVDA recent technical setup',
+    type: 'equity-analyst',
+    action: 'init',
+    status: 'cancelled',
+  },
+};
+
+const props: SegmentsProps = {
+  segments: [
+    { type: 'subagent_task', order: 0, subagentId: 'tc-1' },
+    { type: 'text', order: 1, content: PROSE },
+  ] as SegmentsProps['segments'],
+  reasoningProcesses: {},
+  toolCallProcesses: {},
+  todoListProcesses: {},
+  subagentTasks: STOPPED_TASK,
+  isStreaming: false,
+  isAssistant: true,
+};
+
+function renderWith(telemetry: Partial<SubagentTelemetry> | undefined) {
+  return render(
+    <MemoryRouter>
+      <SubagentTelemetryContext.Provider
+        value={() =>
+          telemetry
+            ? { toolCalls: 13, tokenUsage: { input: 0, output: 0, total: 0 }, ...telemetry }
+            : undefined
+        }
+      >
+        <MessageContentSegments {...props} />
+      </SubagentTelemetryContext.Provider>
+    </MemoryRouter>,
+  );
+}
+
+const CREDIT_STOP = {
+  stopReason: 'Monthly credit limit reached (50/50 credits)',
+  stopReasonType: 'credit_stop',
+};
+
+describe('MessageContentSegments — credit-stop notice placement', () => {
+  it('renders the notice after the closing prose, not beside the task card', () => {
+    const { container } = renderWith(CREDIT_STOP);
+    const notice = screen.getByTestId('subagent-credit-stop-notice');
+    const prose = screen.getByText(PROSE, { exact: false });
+    expect(notice).toBeInTheDocument();
+    expect(
+      prose.compareDocumentPosition(notice) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(container.querySelectorAll('[data-testid="subagent-credit-stop-notice"]')).toHaveLength(1);
+  });
+
+  it('renders nothing at the foot for a stop the user cannot act on', () => {
+    renderWith({ stopReason: 'transport_lost: the stream tore mid-run' });
+    expect(screen.queryByTestId('subagent-credit-stop-notice')).toBeNull();
+  });
+
+  it('renders nothing at the foot for an ordinary turn', () => {
+    renderWith(undefined);
+    expect(screen.queryByTestId('subagent-credit-stop-notice')).toBeNull();
+  });
+});

--- a/web/src/pages/ChatAgent/components/messageList/buildRenderBlocks.ts
+++ b/web/src/pages/ChatAgent/components/messageList/buildRenderBlocks.ts
@@ -8,9 +8,9 @@ const MAX_IN_PROGRESS_MS = 15000; // max time a tool call can stay in-progress i
 /** Tools that should stay in the live zone for their entire duration (no MAX_IN_PROGRESS_MS cap) */
 const ALWAYS_LIVE_TOOLS = new Set(['TaskOutput', 'WebFetch']);
 /** Tool calls that are never rendered as visible activity items — they have dedicated UI or are internal */
-export const HIDDEN_TOOL_CALL_NAMES = new Set(['TodoWrite', 'task', 'Task', 'SubmitPlan', 'AskUserQuestion', 'manage_workspaces', 'ptc_agent', 'agent_output', 'manage_threads', 'ShowWidget']);
+const HIDDEN_TOOL_CALL_NAMES = new Set(['TodoWrite', 'task', 'Task', 'SubmitPlan', 'AskUserQuestion', 'manage_workspaces', 'ptc_agent', 'agent_output', 'manage_threads', 'ShowWidget']);
 
-/** Render block types for the textOnly activity grouping */
+/** Render block types for the inline activity grouping */
 export interface ActivityRenderBlock {
   type: 'activity';
   key: string;
@@ -62,6 +62,11 @@ export interface SecretaryActionRenderBlock {
   key: string;
   segment: ContentSegmentRecord;
 }
+export interface CreditPauseRenderBlock {
+  type: 'credit_pause';
+  key: string;
+  segment: ContentSegmentRecord;
+}
 export interface NotificationRenderBlock {
   type: 'notification';
   key: string;
@@ -84,6 +89,7 @@ export type RenderBlock =
   | StartQuestionRenderBlock
   | PTCAgentRenderBlock
   | SecretaryActionRenderBlock
+  | CreditPauseRenderBlock
   | NotificationRenderBlock
   | HtmlWidgetRenderBlock;
 
@@ -121,7 +127,7 @@ export function groupSegments(segments: ContentSegmentRecord[]): ContentSegmentR
     return groups;
 }
 
-/** The textOnly-mode reducer: folds grouped segments into render blocks (live
+/** The transcript reducer: folds grouped segments into render blocks (live
  * activity zone vs archived accordion) and reports the next live→completed
  * expiry so the caller can schedule a recompute timer. */
 export function buildRenderBlocks(
@@ -150,6 +156,7 @@ export function buildRenderBlocks(
         if (s.type === 'delete_workspace') return true;
         if (s.type === 'stop_workspace') return true;
         if (s.type === 'delete_thread') return true;
+        if (s.type === 'credit_pause') return true;
         if (s.type === 'html_widget') return true;
         if (s.type === 'tool_call') {
           const toolName = toolCallProcesses[s.toolCallId!]?.toolName as string | undefined;
@@ -352,6 +359,9 @@ export function buildRenderBlocks(
         } else if (seg.type === 'delete_workspace' || seg.type === 'stop_workspace' || seg.type === 'delete_thread') {
           flushActivity();
           blocks.push({ type: seg.type, key: `secretary-${seg.type}-${seg.proposalId}`, segment: seg });
+        } else if (seg.type === 'credit_pause') {
+          flushActivity();
+          blocks.push({ type: 'credit_pause', key: `credit-pause-${seg.proposalId}`, segment: seg });
         } else if (seg.type === 'html_widget') {
           flushActivity();
           blocks.push({ type: 'html_widget', key: `widget-${seg.widgetId}`, segment: seg });

--- a/web/src/pages/ChatAgent/components/taskStatusUi.tsx
+++ b/web/src/pages/ChatAgent/components/taskStatusUi.tsx
@@ -22,6 +22,7 @@ import type { SubagentDisplayStatus } from '../session/subagents/subagentStatus'
 
 export type TaskCardStatusKind =
   | 'running'
+  | 'pausing'
   | 'completed'
   | 'cancelled'
   | 'error'
@@ -49,6 +50,15 @@ interface TaskCardStatusUi {
 export const STATUS_UI: Record<TaskCardStatusKind, TaskCardStatusUi> = {
   running: {
     labelKey: 'chat.taskCard.statusRunning',
+    color: 'var(--color-warning)',
+    Icon: null,
+    live: true,
+  },
+  // Client-only state during a credit pause: the parent is interrupted but the
+  // task's own gate only stops it at its next model boundary, so the card
+  // stays live while promising a stop rather than more work.
+  pausing: {
+    labelKey: 'chat.taskCard.statusPausing',
     color: 'var(--color-warning)',
     Icon: null,
     live: true,
@@ -90,12 +100,21 @@ export const STATUS_UI: Record<TaskCardStatusKind, TaskCardStatusUi> = {
  * verb (`updated`/`resumed`) overrides it. Anything the vocabulary doesn't
  * name falls to `unknown`, which renders the wire value verbatim rather than
  * guessing an outcome.
+ *
+ * `pausing` is the one kind no wire status can produce: it is a view of a
+ * running task while its turn holds an unresolved credit pause, so the caller
+ * that knows about the pause passes `pausing` and this maps it. Deriving it
+ * here rather than writing it onto the record is what makes it revert on its
+ * own when the pause resolves, and keeps it out of anything replay must
+ * reproduce.
  */
 export function taskCardStatusKind(
   status: string | null | undefined,
+  pausing: boolean = false,
 ): TaskCardStatusKind {
   switch (status) {
     case 'running':
+      return pausing ? 'pausing' : 'running';
     case 'completed':
     case 'cancelled':
     case 'error':

--- a/web/src/pages/ChatAgent/hooks/__tests__/useCardState.resumeClearsReason.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useCardState.resumeClearsReason.test.ts
@@ -1,0 +1,69 @@
+/**
+ * A resume retracts why the task stopped.
+ *
+ * Card state is keyed by task, and the resume's card shares that key with the
+ * one that stopped — so a stale reason would render the credit-stop notice on a
+ * task actively working. The retraction rides the reactivation write as an
+ * explicit `undefined`, which only clears because the merge is a spread; a
+ * refactor to field-by-field copying would silently drop it, which is what this
+ * pins.
+ */
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useCardState } from '../useCardState';
+
+const AGENT_ID = 'task:F092rQ';
+const CARD_ID = `subagent-${AGENT_ID}`;
+
+/** The card as the credit gate leaves it: settled, carrying the denial. */
+function seedStoppedCard(update: ReturnType<typeof useCardState>['updateSubagentCard']): void {
+  update(AGENT_ID, {
+    agentId: AGENT_ID,
+    taskId: AGENT_ID,
+    type: 'equity-analyst',
+    status: 'cancelled',
+    isActive: false,
+    messages: [{ role: 'assistant', content: 'partial work' }],
+    error: 'Monthly credit limit reached (50/50 credits)',
+    errorType: 'credit_stop',
+  });
+}
+
+/** The reactivation write the `action === 'resume'` branch makes. */
+function resumeWrite(update: ReturnType<typeof useCardState>['updateSubagentCard']): void {
+  update(AGENT_ID, {
+    agentId: AGENT_ID,
+    taskId: AGENT_ID,
+    type: 'equity-analyst',
+    status: 'active',
+    isActive: true,
+    error: undefined,
+    errorType: undefined,
+  });
+}
+
+describe('useCardState — a resume clears the stop reason', () => {
+  it('drops the reason and its type when the task goes live again', () => {
+    const { result } = renderHook(() => useCardState());
+
+    act(() => seedStoppedCard(result.current.updateSubagentCard));
+    expect(result.current.cards[CARD_ID].subagentData?.error).toBe(
+      'Monthly credit limit reached (50/50 credits)',
+    );
+
+    act(() => resumeWrite(result.current.updateSubagentCard));
+    const sd = result.current.cards[CARD_ID].subagentData;
+    expect(sd?.error).toBeUndefined();
+    expect(sd?.errorType).toBeUndefined();
+    expect(sd?.isActive).toBe(true);
+  });
+
+  it('keeps the work the stopped run produced, so the resume appends rather than restarts', () => {
+    const { result } = renderHook(() => useCardState());
+
+    act(() => seedStoppedCard(result.current.updateSubagentCard));
+    act(() => resumeWrite(result.current.updateSubagentCard));
+
+    expect(result.current.cards[CARD_ID].subagentData?.messages).toHaveLength(1);
+  });
+});

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.interruptDedup.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.interruptDedup.test.ts
@@ -275,6 +275,41 @@ describe('useChatMessages — interrupt card de-dup by interrupt_id', () => {
     expect(countSegments(result.current.messages, 'ptc_agent')).toBe(1);
   });
 
+  it('thread switch clears the pending interrupt, so it cannot act on the next thread', async () => {
+    // `pendingInterrupt` disables the composer outright (ChatView), and its only
+    // other clears are answering and rejecting — neither of which a thread
+    // switch takes. Left behind, thread A's unanswered interrupt locks thread
+    // B's input with nothing on screen to explain it. A credit pause is how
+    // this stops being exotic: answering one means leaving to buy credits.
+    const planInterrupt = {
+      event: 'interrupt',
+      interrupt_id: 'plan-A',
+      action_requests: [{ name: 'SubmitPlan', description: 'Step 1. Do the thing.' }],
+    };
+    mockSend.mockImplementation(async (...args: unknown[]) => {
+      const onEvent = args[5] as (e: Record<string, unknown>) => void;
+      onEvent(planInterrupt);
+      return { disconnected: false };
+    });
+
+    let tid = 'th-A';
+    const { result, rerender } = renderHookWithProviders(() => useChatMessages('ws-x', tid));
+    await waitFor(() => expect(mockReplay).toHaveBeenCalled());
+    await settleMountEffect();
+
+    await act(async () => {
+      await result.current.handleSendMessage('make a plan', false);
+    });
+    await waitFor(() => expect(result.current.pendingInterrupt?.interruptId).toBe('plan-A'));
+
+    tid = 'th-B';
+    rerender();
+    await waitFor(() => expect(mockReplay).toHaveBeenCalledTimes(2));
+    await settleMountEffect();
+
+    expect(result.current.pendingInterrupt).toBeNull();
+  });
+
   it('thread switch clears the rendered set so the next thread renders its own cards', async () => {
     // Interrupt ids are only unique per thread. After switching threads, the
     // prior thread's rendered set must not suppress the new thread's replay.

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -49,7 +49,7 @@ import type {
   ModelStatus, FallbackSuggestion,
 } from '../session/types';
 import { SECRETARY_ACTION_TYPES, setCardStatus } from '../session/interrupts/buckets';
-import { beginResume, settleCreditPause, type CreditPauseResumeRefs } from '../session/interrupts/creditPauseResume';
+import { beginResume, restoreCreditPausePending, type CreditPauseResumeRefs } from '../session/interrupts/creditPauseResume';
 export type { ModelStatus, FallbackSuggestion } from '../session/types';
 import type { ChatSessionRuntime } from '../session/runtime';
 import { projectSubagentHistory } from '../session/subagents/projectHistory';
@@ -2389,8 +2389,10 @@ export function useChatMessages(
     if (!resumed) {
       // Another interrupt in this turn is still unanswered, so nothing was
       // sent and no stream will settle this card. Put it back rather than
-      // leave a disabled spinner the user can only clear by reloading.
-      settleCreditPause(creditPauseRefs, 'pending');
+      // leave a disabled spinner the user can only clear by reloading — and
+      // keep the reference, because the batch this answer joined dispatches
+      // later and its settler is what moves the card to `resumed`.
+      restoreCreditPausePending(creditPauseRefs);
     }
   }, [collectHitlResponseAndMaybeResume, resolveProposal, creditPauseRefs]);
 

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -48,7 +48,8 @@ import type {
   HistoryInterruptInfo,
   ModelStatus, FallbackSuggestion,
 } from '../session/types';
-import { SECRETARY_ACTION_TYPES } from '../session/interrupts/buckets';
+import { SECRETARY_ACTION_TYPES, setCardStatus } from '../session/interrupts/buckets';
+import { beginResume, settleCreditPause, type CreditPauseResumeRefs } from '../session/interrupts/creditPauseResume';
 export type { ModelStatus, FallbackSuggestion } from '../session/types';
 import type { ChatSessionRuntime } from '../session/runtime';
 import { projectSubagentHistory } from '../session/subagents/projectHistory';
@@ -678,6 +679,23 @@ export function useChatMessages(
         // Interrupt cards belong to the thread we're leaving; the next thread's
         // replay repopulates this from its persisted interrupt events.
         renderedInterruptIdsRef.current.clear();
+        // So does the answer board. Left behind, thread A's unanswered id keeps
+        // failing B's `every(id => collected[id])` batch gate, so B's own
+        // interrupt is collected but never resumed: the card holds a disabled
+        // spinner until a full reload. Its only other clears sit on paths a
+        // thread switch does not take.
+        pendingInterruptIdsRef.current.clear();
+        collectedHitlResponsesRef.current = {};
+        // And the two state slots the board arms. Their only other clears sit
+        // on answering or rejecting, which a thread switch also does not take,
+        // so thread A's leftovers act on B: a live `pendingInterrupt` disables
+        // B's composer outright, and a live `pendingRejection` turns B's next
+        // ordinary message into rejection feedback carrying A's interrupt id.
+        // A credit pause is the case that makes this ordinary rather than
+        // exotic — resolving one means leaving to buy credits, so wandering off
+        // to another thread with it unanswered is the expected way to meet it.
+        setPendingInterrupt(null);
+        setPendingRejection(null);
       }
     }
   }, [workspaceId, initialThreadId]);
@@ -918,6 +936,13 @@ export function useChatMessages(
           } else if (intInfo.type === 'delete_workspace' || intInfo.type === 'stop_workspace' || intInfo.type === 'delete_thread') {
             setPendingInterrupt({
               type: intInfo.type,
+              interruptId: intInfo.interruptId,
+              assistantMessageId: intInfo.assistantMessageId,
+              proposalId: intInfo.proposalId,
+            });
+          } else if (intInfo.type === 'credit_pause') {
+            setPendingInterrupt({
+              type: 'credit_pause',
               interruptId: intInfo.interruptId,
               assistantMessageId: intInfo.assistantMessageId,
               proposalId: intInfo.proposalId,
@@ -1917,11 +1942,28 @@ export function useChatMessages(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCompacting]);
 
+  /** The credit pause this resume is answering, so the stream can settle its
+   *  status. Held in a ref because the settle happens in stream callbacks. */
+  const resumingCreditPauseRef = useRef<string | null>(null);
+  const creditPauseRefs = useRef<CreditPauseResumeRefs>({
+    pauseId: resumingCreditPauseRef,
+    pendingInterruptIds: pendingInterruptIdsRef,
+    collectedHitlResponses: collectedHitlResponsesRef,
+    sessionEpoch: sessionEpochRef,
+    setMessages,
+  }).current;
+
   /**
-   * Resumes an interrupted workflow with an HITL response (approve or reject).
+   * Resumes an interrupted turn with an HITL response (approve or reject).
    * Follows the same pattern as handleSendMessage but sends messages: [] with hitl_response.
    */
   const resumeWithHitlResponse = useCallback(async (hitlResponse: Record<string, { decisions: Array<{ type: string; message?: string }> }>, planMode: boolean = false) => {
+    // Ahead of beginResume, so the settler's fence captures this run's own
+    // epoch rather than the previous one (which it would already fail).
+    sessionEpochRef.current += 1;
+    const settleResume = beginResume(creditPauseRefs);
+    let admitted = false;
+
     setPendingInterrupt(null);
     pendingInterruptIdsRef.current.clear();
     collectedHitlResponsesRef.current = {};
@@ -1947,7 +1989,6 @@ export function useChatMessages(
     // from the primary again) succeed; a re-fired model_fallback re-sets it.
     setFallbackSuggestion(null);
     wasStoppedRef.current = false;
-    sessionEpochRef.current += 1;
     backgroundReconnectRef.current = false;
     acquireStreamOwnership(threadId);
     // Fresh AbortController so stopWorkflow can abort this resumed stream.
@@ -1983,6 +2024,11 @@ export function useChatMessages(
         (runId) => {
           requestKeyRef.current.clear();
           currentRunIdRef.current = runId;
+          // The backend opened a run, so the resume was admitted. Settled here
+          // rather than left to the `finally` because this is the first moment
+          // "Resumed" is true, and the wait is visible on the card.
+          admitted = true;
+          settleResume(true);
         },
         abortController.signal,
         requestKey,
@@ -2004,6 +2050,8 @@ export function useChatMessages(
       if (result?.disconnected) {
         console.log('[HITL] Stream disconnected, attempting reconnect');
         wasDisconnected = true;
+        // A dropped link, not a refusal: the run is live and reconnect owns it.
+        admitted = true;
         attemptReconnectAfterDisconnect(assistantMessageId);
         return;
       }
@@ -2019,6 +2067,7 @@ export function useChatMessages(
         );
         markTranscriptPersisted();
       }
+      admitted = true;
     } catch (err: unknown) {
       if ((err as Error)?.name === 'AbortError' || wasStoppedRef.current) {
         return;
@@ -2027,19 +2076,49 @@ export function useChatMessages(
       // accepted (its response was lost) — adopt that run instead of erroring.
       if (adoptDuplicateRun(err, assistantMessageId)) {
         wasDisconnected = true;
+        // Accepted, just not by this attempt — the pause is genuinely answered.
+        admitted = true;
         return;
       }
-      console.error('[HITL] Error resuming workflow:', err);
-      setMessageError((err as Error).message || 'Failed to resume workflow');
-      setMessages((prev) =>
-        updateMessage(prev,assistantMessageId, (msg) => ({
-          ...msg,
-          content: msg.content || 'Failed to resume workflow. Please try again.',
-          isStreaming: false,
-          error: true,
-        }))
-      );
+      // 429 and 503 are both the quota service answering rather than a failure
+      // to reach it, and it authors the copy the banner renders. Stacking a
+      // generic red bubble under that reads as a second, unrelated fault, so
+      // the turn settles empty and MessageList hides it.
+      const errObj = err as Record<string, unknown>;
+      if (errObj.status === 429 || errObj.status === 503) {
+        // Only a 429 carries `rateLimitInfo`; the transport routes every other
+        // structured detail into `errorInfo`. Reading just the first left a 503
+        // with an empty object, which loses the outage copy and — because the
+        // suppression keys off `type` — offers "Manage plan" to someone who
+        // cannot reach the service to spend anything.
+        const info = (errObj.rateLimitInfo ||
+          errObj.errorInfo ||
+          {}) as Record<string, unknown>;
+        const platformUrl = (import.meta.env.VITE_PLATFORM_URL as string | undefined) || '/account';
+        setMessageError(buildRateLimitError(info, platformUrl));
+        setMessages((prev) =>
+          updateMessage(prev,assistantMessageId, (msg) => ({
+            ...msg,
+            isStreaming: false,
+          }))
+        );
+      } else {
+        console.error('[HITL] Error resuming turn:', err);
+        setMessageError((err as Error).message || 'Failed to resume this turn');
+        setMessages((prev) =>
+          updateMessage(prev,assistantMessageId, (msg) => ({
+            ...msg,
+            content: msg.content || 'Failed to resume this turn. Please try again.',
+            isStreaming: false,
+            error: true,
+          }))
+        );
+      }
     } finally {
+      // A refusal, abort or stop leaves `admitted` false: restore the interrupt
+      // board and put the card back so a top-up can retry. Already-settled
+      // paths are a no-op, so a run that did open is never reverted.
+      settleResume(admitted);
       if (mainStreamAbortRef.current === abortController) {
         mainStreamAbortRef.current = null;
       }
@@ -2125,9 +2204,15 @@ export function useChatMessages(
     collectedHitlResponsesRef.current[interruptId] = response;
     const pending = pendingInterruptIdsRef.current;
     const collected = collectedHitlResponsesRef.current;
+    // Returns whether a resume actually went out. A turn can hold several
+    // interrupts and this batches them, so one answer is often not enough;
+    // a caller that optimistically flipped its card has to know that, or the
+    // card sits in an in-flight state no stream will ever settle.
     if (pending.size > 0 && [...pending].every((id) => collected[id])) {
       resumeWithHitlResponse({ ...collected }, planMode);
+      return true;
     }
+    return false;
   }, [resumeWithHitlResponse]);
 
   const handleAnswerQuestion = useCallback((answer: string, questionId: string, interruptId: string) => {
@@ -2194,15 +2279,7 @@ export function useChatMessages(
   // Shared helper: update a proposal's status within an AssistantMessage.
   // Used by all HITL approve/reject handlers below.
   const resolveProposal = useCallback((proposalKey: string, pid: string, status: string) => {
-    setMessages((prev) =>
-      prev.map((m) => {
-        if (m.role !== 'assistant') return m;
-        const msg = m as AssistantMessage;
-        const proposals = (msg as unknown as Record<string, Record<string, Record<string, unknown>>>)[proposalKey];
-        if (!proposals?.[pid]) return m;
-        return { ...msg, [proposalKey]: { ...proposals, [pid]: { ...proposals[pid], status } } };
-      })
-    );
+    setMessages((prev) => setCardStatus(prev, proposalKey, pid, status));
   }, []);
 
   const handleApproveCreateWorkspace = useCallback(() => {
@@ -2293,6 +2370,29 @@ export function useChatMessages(
     resolveProposal('secretaryActionProposals', pendingInterrupt.proposalId!, 'rejected');
     resumeWithHitlResponse({ [pendingInterrupt.interruptId!]: { decisions: [{ type: 'reject' }] } }, false);
   }, [pendingInterrupt, resumeWithHitlResponse, resolveProposal]);
+
+  // --- Credit pause resume ---
+  // Approve is the only decision: the gate's interrupt() discards the resume
+  // value and re-checks the verdict itself, so there is nothing to answer —
+  // resuming IS the answer. Admission re-runs the quota check and can refuse
+  // with a 429 that opens no turn at all, so the click only moves the card to
+  // `resuming`; the stream settles it either way. The card supplies its own ids
+  // (single-slot pendingInterrupt would misroute after a reload).
+  const handleResumeCreditPause = useCallback((pauseId: string, interruptId: string) => {
+    if (!pauseId || !interruptId) return;
+    resumingCreditPauseRef.current = pauseId;
+    resolveProposal('creditPauses', pauseId, 'resuming');
+    const resumed = collectHitlResponseAndMaybeResume(
+      interruptId,
+      { decisions: [{ type: 'approve' }] },
+    );
+    if (!resumed) {
+      // Another interrupt in this turn is still unanswered, so nothing was
+      // sent and no stream will settle this card. Put it back rather than
+      // leave a disabled spinner the user can only clear by reloading.
+      settleCreditPause(creditPauseRefs, 'pending');
+    }
+  }, [collectHitlResponseAndMaybeResume, resolveProposal, creditPauseRefs]);
 
   const insertNotification = useCallback(
     (text: string, variant: 'info' | 'success' | 'warning' = 'info', detail?: string) => {
@@ -2715,6 +2815,7 @@ export function useChatMessages(
     handleRejectPTCAgent,
     handleApproveSecretaryAction,
     handleRejectSecretaryAction,
+    handleResumeCreditPause,
     tokenUsage,
     isShared,
     insertNotification,

--- a/web/src/pages/ChatAgent/session/history/__tests__/replayHistory.creditPause.test.ts
+++ b/web/src/pages/ChatAgent/session/history/__tests__/replayHistory.creditPause.test.ts
@@ -1,0 +1,262 @@
+/**
+ * A credit pause that was resumed must replay as resolved.
+ *
+ * Every other interrupt type has a resolution path in the replay; the credit
+ * pause is the one gate interrupt, so it has no tool call to settle it and is
+ * deliberately absent from PROPOSAL_INTERRUPT_TYPES. Its resume also carries no
+ * answer (approve with no message), so it never reaches `hitl_answers` the way
+ * a question does — `hitl_interrupt_ids` on the resume turn's query metadata is
+ * the signal. Without it the card replays `pending` forever, survives into
+ * `unresolvedHistoryInterruptRef`, and re-arms a live Resume button on a turn
+ * that already resumed and completed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AssistantMessage } from '@/types/chat';
+
+const api = vi.hoisted(() => ({ replayThreadHistory: vi.fn() }));
+
+vi.mock('../../../utils/api', () => ({
+  replayThreadHistory: api.replayThreadHistory,
+}));
+
+import { loadConversationHistory } from '../replayHistory';
+import type { HistoryRuntime } from '../../runtime';
+import type { HistoryInterruptInfo, MessageRecord } from '../../types';
+
+type Ref<T> = { current: T };
+const ref = <T,>(current: T): Ref<T> => ({ current });
+
+function buildRuntime() {
+  let messages: MessageRecord[] = [];
+  const rt = {
+    workspaceId: 'ws-1',
+    threadId: 'thread-1',
+    get messages() { return messages; },
+    t: (key: string) => key,
+    updateTodoListCard: null,
+    setMessages: ((updater: (prev: MessageRecord[]) => MessageRecord[]) => {
+      messages = updater(messages);
+    }) as HistoryRuntime['setMessages'],
+    setIsLoadingHistory: vi.fn(),
+    setIsCompacting: vi.fn(),
+    setMessageError: vi.fn(),
+    setFallbackSuggestion: vi.fn(),
+    setThreadModels: vi.fn(),
+    setLastThreadModel: vi.fn(),
+    setTokenUsage: vi.fn(),
+    setReloadTrigger: vi.fn(),
+    setThreadId: vi.fn(),
+    historyLoadingRef: ref(false),
+    replayedRunIdsRef: ref([] as string[]),
+    historyLoadedKeyRef: ref<string | null>(null),
+    historyHasUnresolvedInterruptRef: ref(false),
+    unresolvedHistoryInterruptRef: ref([] as HistoryInterruptInfo[]),
+    lastRenderedTurnIndexRef: ref<number | null>(null),
+    newMessagesStartIndexRef: ref(0),
+    historyPendingTaskToolCallIdsRef: ref([] as string[]),
+    currentMessageRef: ref<string | null>(null),
+    lastEventIdRef: ref<number | string | null>(null),
+    renderedInterruptIdsRef: ref(new Set<string>()),
+    toolCallIdToTaskIdMapRef: ref(new Map<string, string>()),
+    recentlySentTrackerRef: ref({ isRecentlySent: () => false }),
+    offloadBatchRef: ref(null),
+  } as unknown as HistoryRuntime;
+  return { rt, read: () => messages };
+}
+
+const deps = {
+  applyFallbackSuggestion: vi.fn(),
+  loadFeedback: vi.fn().mockResolvedValue(undefined),
+  projectSubagentHistory: vi.fn(),
+};
+
+/** Turn 0 asks a question and ends on a credit-pause interrupt. */
+const PAUSED_TURN = [
+  { event: 'user_message', data: { thread_id: 'thread-1', turn_index: 0, content: 'Analyse the filing' } },
+  {
+    event: 'interrupt',
+    data: {
+      thread_id: 'thread-1',
+      turn_index: 0,
+      interrupt_id: 'int-1',
+      action_requests: [{ type: 'credit_pause', message: 'Out of credits.' }],
+    },
+  },
+];
+
+/** The resume turn: no content, and the ids it answered on its query metadata. */
+const RESUME_TURN = [
+  {
+    event: 'user_message',
+    data: {
+      thread_id: 'thread-1',
+      turn_index: 1,
+      content: '',
+      metadata: { hitl_interrupt_ids: ['int-1'] },
+    },
+  },
+];
+
+function replayOf(items: Array<Record<string, unknown>>) {
+  return async (_threadId: string, onEvent: (e: Record<string, unknown>) => void) => {
+    for (const item of items) {
+      onEvent({ event: item.event, ...(item.data as Record<string, unknown>) });
+    }
+  };
+}
+
+function pauseOn(messages: MessageRecord[]) {
+  const bubble = messages.find((m) => m.id === 'history-assistant-0') as unknown as AssistantMessage;
+  return bubble?.creditPauses?.['int-1'];
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('history replay — credit pause resolution', () => {
+  it('replays a resumed pause as resolved and leaves nothing to re-arm', async () => {
+    const { rt, read } = buildRuntime();
+    api.replayThreadHistory.mockImplementation(replayOf([...PAUSED_TURN, ...RESUME_TURN]));
+
+    await loadConversationHistory(rt, deps);
+
+    expect(pauseOn(read())?.status).toBe('resumed');
+    // The re-arm path in useChatMessages reads exactly these two.
+    expect(rt.historyHasUnresolvedInterruptRef.current).toBe(false);
+    expect(rt.unresolvedHistoryInterruptRef.current).toEqual([]);
+  });
+
+  it('carries the canonical quota-denial links rather than the card building its own', async () => {
+    const { rt, read } = buildRuntime();
+    api.replayThreadHistory.mockImplementation(replayOf(PAUSED_TURN));
+
+    await loadConversationHistory(rt, deps);
+
+    expect(pauseOn(read())?.links).toEqual([
+      {
+        url: '/account/plans',
+        label: 'Manage plan',
+        labelKey: 'chat.errorLinkManagePlan',
+        external: true,
+      },
+      {
+        url: '/account/usage',
+        label: 'View usage',
+        labelKey: 'chat.errorLinkViewUsage',
+        external: true,
+      },
+    ]);
+  });
+
+  it('keeps a pause the user never resumed pending, and hands it to the re-arm path', async () => {
+    const { rt, read } = buildRuntime();
+    api.replayThreadHistory.mockImplementation(replayOf(PAUSED_TURN));
+
+    await loadConversationHistory(rt, deps);
+
+    expect(pauseOn(read())?.status).toBe('pending');
+    expect(rt.historyHasUnresolvedInterruptRef.current).toBe(true);
+    expect(rt.unresolvedHistoryInterruptRef.current).toEqual([
+      expect.objectContaining({ type: 'credit_pause', interruptId: 'int-1', proposalId: 'int-1' }),
+    ]);
+  });
+
+  it('un-resolves a pause the resume turn raised again', async () => {
+    // `hitl_interrupt_ids` is stamped when the resume is requested, not when
+    // the graph consumes the Command, so the stamp alone can be wrong. The
+    // re-raise on the resume turn is the later evidence, and without honouring
+    // it the card replays `resumed` with no Resume button on the one thread
+    // that still needs one.
+    const { rt, read } = buildRuntime();
+    api.replayThreadHistory.mockImplementation(
+      replayOf([
+        ...PAUSED_TURN,
+        ...RESUME_TURN,
+        {
+          event: 'interrupt',
+          data: {
+            thread_id: 'thread-1',
+            turn_index: 1,
+            interrupt_id: 'int-1',
+            action_requests: [{ type: 'credit_pause', message: 'Out of credits.' }],
+          },
+        },
+      ]),
+    );
+
+    await loadConversationHistory(rt, deps);
+
+    expect(pauseOn(read())?.status).toBe('pending');
+    // Still one card: the re-raise restores, it never renders a second.
+    const bubbles = read().filter((m) => m.role === 'assistant') as unknown as AssistantMessage[];
+    expect(
+      bubbles.flatMap((b) => (b.contentSegments || []).filter((sg) => sg.type === 'credit_pause')),
+    ).toHaveLength(1);
+    // ...and the re-arm path gets it back, so the click is not dropped.
+    expect(rt.historyHasUnresolvedInterruptRef.current).toBe(true);
+    expect(rt.unresolvedHistoryInterruptRef.current).toEqual([
+      expect.objectContaining({ type: 'credit_pause', interruptId: 'int-1', proposalId: 'int-1' }),
+    ]);
+  });
+
+  it('settles a pause that a later attempt finally consumed', async () => {
+    // Two refused resumes then a successful one. The re-queued entry after the
+    // first re-raise names the resume turn's bubble, not the card's, so a
+    // resolution that patched by bubble would flip an invisible copy and leave
+    // the real card pending — a Resume button on a finished thread, with the
+    // pending set never re-armed, so it would not even answer.
+    const { rt, read } = buildRuntime();
+    api.replayThreadHistory.mockImplementation(
+      replayOf([
+        ...PAUSED_TURN,
+        ...RESUME_TURN,
+        {
+          event: 'interrupt',
+          data: {
+            thread_id: 'thread-1',
+            turn_index: 1,
+            interrupt_id: 'int-1',
+            action_requests: [{ type: 'credit_pause', message: 'Out of credits.' }],
+          },
+        },
+        {
+          event: 'user_message',
+          data: {
+            thread_id: 'thread-1',
+            turn_index: 2,
+            content: '',
+            metadata: { hitl_interrupt_ids: ['int-1'] },
+          },
+        },
+      ]),
+    );
+
+    await loadConversationHistory(rt, deps);
+
+    expect(pauseOn(read())?.status).toBe('resumed');
+    expect(rt.historyHasUnresolvedInterruptRef.current).toBe(false);
+    expect(rt.unresolvedHistoryInterruptRef.current).toEqual([]);
+  });
+
+  it('resolves only the pause the resume names', async () => {
+    const { rt, read } = buildRuntime();
+    api.replayThreadHistory.mockImplementation(
+      replayOf([
+        ...PAUSED_TURN,
+        {
+          event: 'user_message',
+          data: {
+            thread_id: 'thread-1',
+            turn_index: 1,
+            content: '',
+            metadata: { hitl_interrupt_ids: ['some-other-interrupt'] },
+          },
+        },
+      ]),
+    );
+
+    await loadConversationHistory(rt, deps);
+
+    expect(pauseOn(read())?.status).toBe('pending');
+    expect(rt.historyHasUnresolvedInterruptRef.current).toBe(true);
+  });
+});

--- a/web/src/pages/ChatAgent/session/history/__tests__/replayHistory.taskStopReason.test.ts
+++ b/web/src/pages/ChatAgent/session/history/__tests__/replayHistory.taskStopReason.test.ts
@@ -1,0 +1,130 @@
+/**
+ * A task that resumed must not replay carrying the reason its previous run
+ * stopped for.
+ *
+ * The live session retracts a credit stop from both writers when the task
+ * resumes. Replay rebuilds history from the artifacts instead, and a resumed
+ * task's artifact carries no failure at all — so a merge that only overwrites
+ * when the incoming value is truthy keeps the earlier run's `credit_stop`, and
+ * the notice the resume retracted comes back on the next reload.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const api = vi.hoisted(() => ({ replayThreadHistory: vi.fn() }));
+
+vi.mock('../../../utils/api', () => ({
+  replayThreadHistory: api.replayThreadHistory,
+}));
+
+import { loadConversationHistory } from '../replayHistory';
+import type { HistoryRuntime } from '../../runtime';
+import type { HistoryInterruptInfo, MessageRecord } from '../../types';
+
+type Ref<T> = { current: T };
+const ref = <T,>(current: T): Ref<T> => ({ current });
+
+function buildRuntime() {
+  let messages: MessageRecord[] = [];
+  return {
+    workspaceId: 'ws-1',
+    threadId: 'thread-1',
+    get messages() { return messages; },
+    t: (key: string) => key,
+    updateTodoListCard: null,
+    setMessages: ((updater: (prev: MessageRecord[]) => MessageRecord[]) => {
+      messages = updater(messages);
+    }) as HistoryRuntime['setMessages'],
+    setIsLoadingHistory: vi.fn(),
+    setIsCompacting: vi.fn(),
+    setMessageError: vi.fn(),
+    setFallbackSuggestion: vi.fn(),
+    setThreadModels: vi.fn(),
+    setLastThreadModel: vi.fn(),
+    setTokenUsage: vi.fn(),
+    setReloadTrigger: vi.fn(),
+    setThreadId: vi.fn(),
+    historyLoadingRef: ref(false),
+    replayedRunIdsRef: ref([] as string[]),
+    historyLoadedKeyRef: ref<string | null>(null),
+    historyHasUnresolvedInterruptRef: ref(false),
+    unresolvedHistoryInterruptRef: ref([] as HistoryInterruptInfo[]),
+    lastRenderedTurnIndexRef: ref<number | null>(null),
+    newMessagesStartIndexRef: ref(0),
+    historyPendingTaskToolCallIdsRef: ref([] as string[]),
+    currentMessageRef: ref<string | null>(null),
+    lastEventIdRef: ref<number | string | null>(null),
+    renderedInterruptIdsRef: ref(new Set<string>()),
+    toolCallIdToTaskIdMapRef: ref(new Map<string, string>()),
+    recentlySentTrackerRef: ref({ isRecentlySent: () => false }),
+    offloadBatchRef: ref(null),
+  } as unknown as HistoryRuntime;
+}
+
+function replayOf(items: Array<Record<string, unknown>>) {
+  return async (_threadId: string, onEvent: (e: Record<string, unknown>) => void) => {
+    for (const item of items) onEvent(item);
+  };
+}
+
+const USER_TURN = {
+  event: 'user_message',
+  thread_id: 'thread-1',
+  turn_index: 0,
+  content: 'Analyse the filing',
+};
+
+function taskArtifact(
+  tool_call_id: string,
+  payload: Record<string, unknown>,
+) {
+  return {
+    event: 'artifact',
+    artifact_type: 'task',
+    artifact_id: `art-${tool_call_id}`,
+    tool_call_id,
+    payload: { task_id: 'T1', type: 'equity-analyst', description: 'Read the 10-K', ...payload },
+  };
+}
+
+const STOPPED = taskArtifact('tc-1', {
+  action: 'spawned',
+  status: 'cancelled',
+  error: 'Out of credits.',
+  error_type: 'credit_stop',
+});
+
+const RESUMED = taskArtifact('tc-2', { action: 'resumed', status: 'running' });
+
+async function historyFor(items: Array<Record<string, unknown>>) {
+  const projectSubagentHistory = vi.fn();
+  api.replayThreadHistory.mockImplementation(replayOf(items));
+  await loadConversationHistory(buildRuntime(), {
+    applyFallbackSuggestion: vi.fn(),
+    loadFeedback: vi.fn().mockResolvedValue(undefined),
+    projectSubagentHistory,
+  });
+  return projectSubagentHistory.mock.calls[0][0].get('task:T1');
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('history replay — a task stop reason', () => {
+  it('is dropped once a later artifact shows the task running again', async () => {
+    const entry = await historyFor([USER_TURN, STOPPED, RESUMED]);
+
+    expect(entry.status).toBe('running');
+    expect(entry.error).toBeUndefined();
+    expect(entry.errorType).toBeUndefined();
+  });
+
+  it('survives when nothing later contradicts it', async () => {
+    // The complement, and the reason the fix is not "never carry a reason
+    // forward": a task that really did stop keeps its reason and its type, or
+    // the notice the whole surface exists for never renders after a reload.
+    const entry = await historyFor([USER_TURN, STOPPED]);
+
+    expect(entry.status).toBe('cancelled');
+    expect(entry.error).toBe('Out of credits.');
+    expect(entry.errorType).toBe('credit_stop');
+  });
+});

--- a/web/src/pages/ChatAgent/session/history/replayHistory.ts
+++ b/web/src/pages/ChatAgent/session/history/replayHistory.ts
@@ -627,9 +627,18 @@ export async function loadConversationHistory(
               if (description && !existing.description) existing.description = description;
               if (prompt && !existing.prompt) existing.prompt = prompt || description || '';
               if (type && !existing.type) existing.type = type;
-              if (stampedStatus) existing.status = stampedStatus;
-              if (stampedError) existing.error = stampedError;
-              if (stampedErrorType) existing.errorType = stampedErrorType;
+              // The failure travels with the status it arrived with, and is
+              // replaced by it rather than merged under it. Every replayed
+              // task artifact carries a status; a resumed task's carries no
+              // failure at all, so preserving the previous run's reason is
+              // exactly how a retracted credit stop comes back on the next
+              // reload — the live session clears both writers when the task
+              // resumes, and replay would put one of them straight back.
+              if (stampedStatus) {
+                existing.status = stampedStatus;
+                existing.error = stampedError;
+                existing.errorType = stampedErrorType;
+              }
               // Monotonic max: artifacts stamp claims-through-their-turn, and
               // page/artifact processing order must not regress the watermark.
               if (stampedRunStartedMs != null) {

--- a/web/src/pages/ChatAgent/session/history/replayHistory.ts
+++ b/web/src/pages/ChatAgent/session/history/replayHistory.ts
@@ -33,7 +33,7 @@ import {
 import type {
   TokenUsage, SSEEvent, HistoryInterruptInfo, SubagentHistoryData, PairState,
 } from '../types';
-import { PROPOSAL_INTERRUPT_TYPES, PROPOSAL_DATA_KEY_MAP } from '../interrupts/buckets';
+import { PROPOSAL_INTERRUPT_TYPES, PROPOSAL_DATA_KEY_MAP, resolvePendingHistoryInterrupt, setCardStatus } from '../interrupts/buckets';
 import { projectHistoryInterrupt } from '../interrupts/fromHistoryEvent';
 import type { HistoryRuntime } from '../runtime';
 
@@ -311,33 +311,18 @@ export async function loadConversationHistory(
           rt.setLastThreadModel(llmModel);
         }
         // Resolve pending plan_approval interrupt from content (empty = approved, non-empty = rejected).
-        {
-          const idx = pendingHistoryInterrupts.findIndex((p) => p.type === 'plan_approval');
-          if (idx !== -1) {
-            const matched = pendingHistoryInterrupts[idx];
-            const hasContent = typeof event.content === 'string' && event.content.trim();
-            const resolvedStatus = hasContent ? 'rejected' : 'approved';
-            rt.setMessages((prev) =>
-              updateMessage(prev,matched.assistantMessageId, (msg) => {
-                if (msg.role !== 'assistant') return msg;
-                const aMsg = msg as AssistantMessage;
-                const approvals = aMsg.planApprovals || {};
-                const key = matched.planApprovalId!;
-                return {
-                  ...aMsg,
-                  planApprovals: {
-                    ...approvals,
-                    [key]: {
-                      ...(approvals[key] || {}),
-                      status: resolvedStatus,
-                    },
-                  },
-                };
-              })
-            );
-            pendingHistoryInterrupts.splice(idx, 1);
-          }
-        }
+        resolvePendingHistoryInterrupt(
+          pendingHistoryInterrupts,
+          (p) => p.type === 'plan_approval',
+          (m) => ({
+            bucket: 'planApprovals',
+            key: m.planApprovalId!,
+            fields: {
+              status: typeof event.content === 'string' && event.content.trim() ? 'rejected' : 'approved',
+            },
+          }),
+          rt.setMessages,
+        );
 
         // Resolve ask_user_question interrupts from resume query metadata (hitl_answers).
         // Persisted immediately by persist_query_start(), keyed by interrupt_id.
@@ -345,33 +330,46 @@ export async function loadConversationHistory(
           const hitlAnswers = event.metadata?.hitl_answers as Record<string, unknown> | undefined;
           if (hitlAnswers && pendingHistoryInterrupts.length > 0) {
             for (const [interruptId, answerValue] of Object.entries(hitlAnswers)) {
-              const idx = pendingHistoryInterrupts.findIndex(
-                (p) => p.type === 'ask_user_question' && p.interruptId === interruptId
+              resolvePendingHistoryInterrupt(
+                pendingHistoryInterrupts,
+                (p) => p.type === 'ask_user_question' && p.interruptId === interruptId,
+                (m) => ({
+                  bucket: 'userQuestions',
+                  key: m.questionId!,
+                  fields: {
+                    status: answerValue !== null ? 'answered' : 'skipped',
+                    answer: answerValue as string | null,
+                  },
+                }),
+                rt.setMessages,
               );
-              if (idx !== -1) {
-                const matched = pendingHistoryInterrupts[idx];
-                const resolvedStatus = answerValue !== null ? 'answered' : 'skipped';
-                const qKey = matched.questionId!;
-                rt.setMessages((prev) =>
-                  updateMessage(prev,matched.assistantMessageId, (msg) => {
-                    if (msg.role !== 'assistant') return msg;
-                    const aMsg = msg as AssistantMessage;
-                    const questions = aMsg.userQuestions || {};
-                    return {
-                      ...aMsg,
-                      userQuestions: {
-                        ...questions,
-                        [qKey]: {
-                          ...(questions[qKey] || {}),
-                          status: resolvedStatus,
-                          answer: answerValue as string | null,
-                        },
-                      },
-                    };
-                  })
-                );
-                pendingHistoryInterrupts.splice(idx, 1);
-              }
+            }
+          }
+        }
+
+        // Resolve credit_pause interrupts from the resume query's metadata.
+        // A credit resume carries no answer (approve with no message), so it
+        // never lands in `hitl_answers` the way a question does — but every
+        // HITL resume stamps `hitl_interrupt_ids` with the ids it answered,
+        // and that is the signal here. Without it the card replays pending
+        // forever and re-arms a live Resume button on a turn that already
+        // resumed and completed.
+        {
+          const resumedIds = event.metadata?.hitl_interrupt_ids as string[] | undefined;
+          if (Array.isArray(resumedIds) && pendingHistoryInterrupts.length > 0) {
+            for (const interruptId of resumedIds) {
+              const idx = pendingHistoryInterrupts.findIndex(
+                (p) => p.type === 'credit_pause' && p.interruptId === interruptId,
+              );
+              if (idx === -1) continue;
+              pendingHistoryInterrupts.splice(idx, 1);
+              // By card id, not by bubble: a pause re-raised on a refused
+              // resume is re-queued against that resume's bubble, so a later
+              // attempt resolving through updateMessage would flip an invisible
+              // copy and leave the visible card pending — a Resume button on a
+              // finished thread, and the pending set is gone, so it would not
+              // even answer. The live path settles by id for the same reason.
+              rt.setMessages((prev) => setCardStatus(prev, 'creditPauses', interruptId, 'resumed'));
             }
           }
         }
@@ -600,8 +598,11 @@ export async function loadConversationHistory(
           // (payload.status). The top-level `status` is a hardcoded "completed"
           // and MUST be ignored.
           const stampedStatus = payload.status as string | undefined;
-          // Ledger failure reason, stamped only on an errored task artifact.
+          // Ledger failure reason, stamped on any task that settled with one.
           const stampedError = payload.error as string | undefined;
+          // Its machine spelling, which is what tells a stop the user can act
+          // on (a credit stop) from one that is only worth reporting.
+          const stampedErrorType = payload.error_type as string | undefined;
           const stampedRunStartedMs =
             typeof payload.projected_run_started_ms === 'number'
               ? payload.projected_run_started_ms
@@ -618,6 +619,7 @@ export async function loadConversationHistory(
                 type: type || 'general-purpose',
                 status: stampedStatus,
                 error: stampedError,
+                errorType: stampedErrorType,
                 projectedRunStartedMs: stampedRunStartedMs,
               });
             } else {
@@ -627,6 +629,7 @@ export async function loadConversationHistory(
               if (type && !existing.type) existing.type = type;
               if (stampedStatus) existing.status = stampedStatus;
               if (stampedError) existing.error = stampedError;
+              if (stampedErrorType) existing.errorType = stampedErrorType;
               // Monotonic max: artifacts stamp claims-through-their-turn, and
               // page/artifact processing order must not regress the watermark.
               if (stampedRunStartedMs != null) {
@@ -756,84 +759,56 @@ export async function loadConversationHistory(
 
         // Resolve pending ask_user_question interrupt from tool_call_result
         // (fallback for conversations where hitl_answers wasn't persisted)
-        {
-          const idx = pendingHistoryInterrupts.findIndex((p) => p.type === 'ask_user_question');
-          if (idx !== -1 && typeof event.content === 'string' &&
-              (event.content.startsWith('User answered:') || event.content.startsWith('User skipped'))) {
-            const matched = pendingHistoryInterrupts[idx];
-            const content = event.content;
-            const isAnswered = content.startsWith('User answered:');
-            const answerText = isAnswered ? content.replace('User answered: ', '') : null;
-            const qKey = matched.questionId!;
-            rt.setMessages((prev) =>
-              updateMessage(prev, matched.assistantMessageId, (msg) => {
-                if (msg.role !== 'assistant') return msg;
-                const aMsg = msg as AssistantMessage;
-                const questions = aMsg.userQuestions || {};
-                return {
-                  ...aMsg,
-                  userQuestions: {
-                    ...questions,
-                    [qKey]: {
-                      ...(questions[qKey] || {}),
-                      status: isAnswered ? 'answered' : 'skipped',
-                      answer: answerText,
-                    },
-                  },
-                };
-              })
-            );
-            pendingHistoryInterrupts.splice(idx, 1);
-          }
+        if (typeof event.content === 'string' &&
+            (event.content.startsWith('User answered:') || event.content.startsWith('User skipped'))) {
+          const isAnswered = event.content.startsWith('User answered:');
+          const answerText = isAnswered ? event.content.replace('User answered: ', '') : null;
+          resolvePendingHistoryInterrupt(
+            pendingHistoryInterrupts,
+            (p) => p.type === 'ask_user_question',
+            (m) => ({
+              bucket: 'userQuestions',
+              key: m.questionId!,
+              fields: { status: isAnswered ? 'answered' : 'skipped', answer: answerText },
+            }),
+            rt.setMessages,
+          );
         }
 
         // Resolve pending create_workspace, start_question, ptc_agent, or secretary action interrupt from tool_call_result
-        {
-          const idx = pendingHistoryInterrupts.findIndex((p) => PROPOSAL_INTERRUPT_TYPES.has(p.type));
-          if (idx !== -1 && typeof event.content === 'string') {
-            const matched = pendingHistoryInterrupts[idx];
-            const content = event.content;
-            const dataKey = PROPOSAL_DATA_KEY_MAP[matched.type] || 'questionProposals';
-
-            let resolvedStatus = 'approved';
-            let resultPayload: Record<string, unknown> | null = null;
-            if (content.startsWith('User declined')) {
-              resolvedStatus = 'rejected';
-            } else {
-              try {
-                const parsed = JSON.parse(content);
-                if (parsed?.success === false) resolvedStatus = 'rejected';
-                resultPayload = parsed;
-              } catch { /* non-JSON → treat as approved */ }
-            }
-
-            const pKey = matched.proposalId!;
-            // Extract thread_id/workspace_id from ptc_agent result for navigation
-            const extraFields: Record<string, unknown> = {};
-            if (matched.type === 'ptc_agent' && resultPayload) {
-              if (resultPayload.thread_id) extraFields.thread_id = resultPayload.thread_id;
-              if (resultPayload.workspace_id) extraFields.workspace_id = resultPayload.workspace_id;
-            }
-            rt.setMessages((prev) =>
-              updateMessage(prev,matched.assistantMessageId, (msg) => {
-                if (msg.role !== 'assistant') return msg;
-                const aMsg = msg as AssistantMessage;
-                const existing = ((aMsg as unknown as Record<string, unknown>)[dataKey] || {}) as Record<string, Record<string, unknown>>;
-                return {
-                  ...aMsg,
-                  [dataKey]: {
-                    ...existing,
-                    [pKey]: {
-                      ...(existing[pKey] || {}),
-                      status: resolvedStatus,
-                      ...extraFields,
-                    },
-                  },
-                };
-              })
-            );
-            pendingHistoryInterrupts.splice(idx, 1);
-          }
+        if (typeof event.content === 'string') {
+          const content = event.content;
+          // Parsed inside the patch builder so replay only pays for it on the
+          // tool result that actually settles a pending proposal.
+          resolvePendingHistoryInterrupt(
+            pendingHistoryInterrupts,
+            (p) => PROPOSAL_INTERRUPT_TYPES.has(p.type),
+            (m) => {
+              let resolvedStatus = 'approved';
+              let resultPayload: Record<string, unknown> | null = null;
+              if (content.startsWith('User declined')) {
+                resolvedStatus = 'rejected';
+              } else {
+                try {
+                  const parsed = JSON.parse(content);
+                  if (parsed?.success === false) resolvedStatus = 'rejected';
+                  resultPayload = parsed;
+                } catch { /* non-JSON → treat as approved */ }
+              }
+              // Extract thread_id/workspace_id from ptc_agent result for navigation
+              const extraFields: Record<string, unknown> = {};
+              if (m.type === 'ptc_agent' && resultPayload) {
+                if (resultPayload.thread_id) extraFields.thread_id = resultPayload.thread_id;
+                if (resultPayload.workspace_id) extraFields.workspace_id = resultPayload.workspace_id;
+              }
+              return {
+                bucket: PROPOSAL_DATA_KEY_MAP[m.type] || 'questionProposals',
+                key: m.proposalId!,
+                fields: { status: resolvedStatus, ...extraFields },
+              };
+            },
+            rt.setMessages,
+          );
         }
 
         return;

--- a/web/src/pages/ChatAgent/session/interrupts/__tests__/creditPauseResume.test.ts
+++ b/web/src/pages/ChatAgent/session/interrupts/__tests__/creditPauseResume.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The resume settler's fence. Restoring a refused resume's interrupt board is
+ * correct only on the thread that armed it: the settler runs from the aborted
+ * stream's `finally`, which is strictly after a thread switch has already
+ * cleared the board, so an unfenced restore lands thread A's ids on thread B.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { beginResume, type CreditPauseResumeRefs } from '../creditPauseResume';
+
+function makeRefs(): CreditPauseResumeRefs {
+  return {
+    pauseId: { current: 'pause-1' },
+    pendingInterruptIds: { current: new Set(['int-a']) },
+    collectedHitlResponses: { current: {} },
+    sessionEpoch: { current: 1 },
+    setMessages: vi.fn(),
+  } as unknown as CreditPauseResumeRefs;
+}
+
+describe('beginResume', () => {
+  it('puts the board back when the resume is refused on the same thread', () => {
+    const refs = makeRefs();
+    const settle = beginResume(refs);
+    // What resumeWithHitlResponse does next, assuming admission.
+    refs.pendingInterruptIds.current = new Set();
+    refs.collectedHitlResponses.current = {};
+
+    settle(false);
+
+    expect([...refs.pendingInterruptIds.current]).toEqual(['int-a']);
+    expect(refs.pauseId.current).toBeNull();
+    expect(refs.setMessages).toHaveBeenCalled();
+  });
+
+  it('leaves a departed thread’s board alone', () => {
+    const refs = makeRefs();
+    const settle = beginResume(refs);
+    refs.pendingInterruptIds.current = new Set();
+    // The thread switch: clears the board, bumps the epoch.
+    refs.sessionEpoch.current += 1;
+
+    // ...and only then does the aborted stream's `finally` fire.
+    settle(false);
+
+    // B's board stays B's. Restoring A's unanswered id here would fail B's
+    // `every(id => collected[id])` batch gate for the rest of the session.
+    expect([...refs.pendingInterruptIds.current]).toEqual([]);
+    // And no card is settled on whatever thread is now on screen.
+    expect(refs.setMessages).not.toHaveBeenCalled();
+    expect(refs.pauseId.current).toBe('pause-1');
+  });
+});

--- a/web/src/pages/ChatAgent/session/interrupts/__tests__/fromLiveEvent.creditPause.test.ts
+++ b/web/src/pages/ChatAgent/session/interrupts/__tests__/fromLiveEvent.creditPause.test.ts
@@ -1,0 +1,83 @@
+/**
+ * A re-raised credit pause has to land back on the card that renders it.
+ *
+ * The resume settles the card the moment the backend opens a run, because
+ * admission is the only signal the client gets — a run opens whether or not the
+ * graph goes on to consume the pause. When it does not, the same interrupt id
+ * streams again into a fresh `assistant-hitl-*` bubble, and the duplicate-card
+ * suppression means that bubble has no segment of its own. Writing the pause
+ * there leaves the visible card on `resumed` with nothing left to answer it,
+ * and `status` is what history replays, so the dead end survives a reload.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { AssistantMessage } from '@/types/chat';
+
+import { projectLiveInterrupt } from '../fromLiveEvent';
+import type { StreamRuntime } from '../../runtime';
+import type { MessageRecord, SSEEvent, StreamProcessorRefs } from '../../types';
+
+type Ref<T> = { current: T };
+const ref = <T,>(current: T): Ref<T> => ({ current });
+
+const PAUSE_ID = 'int-credit-1';
+
+function pauseEvent(): SSEEvent {
+  return {
+    type: 'interrupt',
+    interrupt_id: PAUSE_ID,
+    action_requests: [{ type: 'credit_pause', message: 'Out of credits' }],
+  } as unknown as SSEEvent;
+}
+
+function build(messages: MessageRecord[]) {
+  let current = messages;
+  const rt = {
+    setMessages: ((updater: (prev: MessageRecord[]) => MessageRecord[]) => {
+      current = updater(current);
+    }) as StreamRuntime['setMessages'],
+    setPendingInterrupt: vi.fn(),
+    pendingInterruptIdsRef: ref(new Set<string>()),
+    renderedInterruptIdsRef: ref(new Set<string>()),
+  } as unknown as StreamRuntime;
+  const refs = {
+    contentOrderCounterRef: ref(0),
+  } as unknown as StreamProcessorRefs;
+  return { rt, refs, read: () => current };
+}
+
+const bubble = (id: string): MessageRecord =>
+  ({ id, role: 'assistant', content: '', contentSegments: [] }) as unknown as MessageRecord;
+
+const cardOn = (m: MessageRecord) =>
+  (m as AssistantMessage).creditPauses?.[PAUSE_ID];
+
+describe('a credit pause that is raised twice', () => {
+  it('renders one card, and re-raising puts that card back to pending', () => {
+    const { rt, refs, read } = build([bubble('a-1')]);
+
+    projectLiveInterrupt(rt, pauseEvent(), 'a-1', refs);
+    expect(cardOn(read()[0])?.status).toBe('pending');
+    expect((read()[0] as AssistantMessage).contentSegments).toHaveLength(1);
+
+    // The resume: admission opened a run, so the card reads resumed.
+    let msgs = read();
+    msgs = msgs.map((m) => ({
+      ...(m as AssistantMessage),
+      creditPauses: { [PAUSE_ID]: { ...cardOn(m)!, status: 'resumed' } },
+    })) as unknown as MessageRecord[];
+    const second = build([...msgs, bubble('a-2')]);
+    second.rt.renderedInterruptIdsRef.current.add(PAUSE_ID);
+
+    projectLiveInterrupt(second.rt, pauseEvent(), 'a-2', second.refs);
+
+    const [first, fresh] = second.read();
+    expect(cardOn(first)?.status).toBe('pending');
+    // No second card: one segment on the original bubble, none on the new one.
+    expect((first as AssistantMessage).contentSegments).toHaveLength(1);
+    expect((fresh as AssistantMessage).contentSegments || []).toHaveLength(0);
+    // ...and nothing unrenderable left behind on the fresh bubble.
+    expect(cardOn(fresh)).toBeUndefined();
+    // The pause is tracked again, so a later click is not dropped.
+    expect(second.rt.pendingInterruptIdsRef.current.has(PAUSE_ID)).toBe(true);
+  });
+});

--- a/web/src/pages/ChatAgent/session/interrupts/buckets.ts
+++ b/web/src/pages/ChatAgent/session/interrupts/buckets.ts
@@ -6,6 +6,8 @@
  */
 
 import type { AssistantMessage } from '@/types/chat';
+import { updateMessage } from '../../hooks/utils/messageHelpers';
+import type { HistoryInterruptInfo, MessageRecord, SetMessages } from '../types';
 
 /** Interrupt types that map to proposal-based HITL cards (workspace, question, ptc, secretary). */
 const PROPOSAL_INTERRUPT_TYPES = new Set([
@@ -34,9 +36,63 @@ const SECRETARY_ACTION_TYPES = new Set(['delete_workspace', 'stop_workspace', 'd
 const INTERRUPT_CARD_BUCKETS = [
   'planApprovals', 'userQuestions', 'workspaceProposals',
   'questionProposals', 'ptcAgentProposals', 'secretaryActionProposals',
+  'creditPauses',
 ] as const satisfies readonly (keyof AssistantMessage)[];
+
+/**
+ * Flip one card's status wherever it lives. A deduped re-raise can put the card
+ * on a bubble other than the one the answer came from, so every assistant
+ * message is searched rather than the one that was clicked.
+ */
+function setCardStatus(
+  messages: MessageRecord[],
+  bucket: string,
+  cardId: string,
+  status: string,
+): MessageRecord[] {
+  return messages.map((m) => {
+    if (m.role !== 'assistant') return m;
+    const cards = (m as unknown as Record<string, Record<string, Record<string, unknown>>>)[bucket];
+    if (!cards?.[cardId]) return m;
+    return { ...(m as AssistantMessage), [bucket]: { ...cards, [cardId]: { ...cards[cardId], status } } };
+  });
+}
+
+/** Which card a resolved history interrupt writes to, and what it writes. */
+interface HistoryCardPatch {
+  bucket: string;
+  key: string;
+  fields: Record<string, unknown>;
+}
+
+/**
+ * Settle the first pending history interrupt `match` accepts: merge its patch
+ * into the card and drop it from the pending list, so what remains at the end
+ * of replay is exactly what the user still owes an answer.
+ */
+function resolvePendingHistoryInterrupt(
+  pending: HistoryInterruptInfo[],
+  match: (p: HistoryInterruptInfo) => boolean,
+  toPatch: (matched: HistoryInterruptInfo) => HistoryCardPatch,
+  setMessages: SetMessages,
+): boolean {
+  const idx = pending.findIndex(match);
+  if (idx === -1) return false;
+  const matched = pending[idx];
+  const { bucket, key, fields } = toPatch(matched);
+  setMessages((prev) =>
+    updateMessage(prev, matched.assistantMessageId, (m) => {
+      if (m.role !== 'assistant') return m;
+      const msg = m as AssistantMessage;
+      const cards = ((msg as unknown as Record<string, unknown>)[bucket] || {}) as Record<string, Record<string, unknown>>;
+      return { ...msg, [bucket]: { ...cards, [key]: { ...(cards[key] || {}), ...fields } } };
+    })
+  );
+  pending.splice(idx, 1);
+  return true;
+}
 
 export {
   PROPOSAL_INTERRUPT_TYPES, PROPOSAL_DATA_KEY_MAP, SECRETARY_ACTION_TYPES,
-  INTERRUPT_CARD_BUCKETS,
+  INTERRUPT_CARD_BUCKETS, setCardStatus, resolvePendingHistoryInterrupt,
 };

--- a/web/src/pages/ChatAgent/session/interrupts/creditPauseCard.ts
+++ b/web/src/pages/ChatAgent/session/interrupts/creditPauseCard.ts
@@ -1,0 +1,27 @@
+/**
+ * The card state a `credit_pause` interrupt projects to. Shared by the live and
+ * history paths so one wire payload cannot render two different cards.
+ */
+
+import type { CreditPauseState } from '@/types/chat';
+import type { ActionRequest } from '@/types/sse';
+import { buildRateLimitError } from '@/utils/rateLimitError';
+
+export function buildCreditPauseState(
+  request: ActionRequest,
+  interruptId: string,
+): CreditPauseState {
+  // The denial copy is the platform's and lands here straight off the wire, so
+  // `message?: string` is a compile-time claim rather than a check: a non-string
+  // would reach JSX and take the transcript down for a user already stuck at a
+  // pause, so an unusable one degrades to the card's no-message layout.
+  const message = typeof request.message === 'string' ? request.message : undefined;
+  // A pause is a quota denial the user resolves on the same two pages a 429
+  // sends them to, so the links come from that builder rather than a second
+  // copy — including its exclusion for denials no account page can fix.
+  const { links } = buildRateLimitError(
+    { type: request.type, message },
+    (import.meta.env.VITE_PLATFORM_URL as string | undefined) || '/account',
+  );
+  return { status: 'pending', message, links, interruptId };
+}

--- a/web/src/pages/ChatAgent/session/interrupts/creditPauseResume.ts
+++ b/web/src/pages/ChatAgent/session/interrupts/creditPauseResume.ts
@@ -1,0 +1,64 @@
+/**
+ * The credit-pause half of an HITL resume: which pause a resume is answering,
+ * and what to put back when it is refused. Extracted from useChatMessages
+ * (carve B).
+ */
+
+import type { MutableRefObject } from 'react';
+import type { CreditPauseStatus } from '@/types/chat';
+import type { SetMessages } from '../types';
+import { setCardStatus } from './buckets';
+
+type HitlDecisions = { decisions: Array<{ type: string; message?: string }> };
+
+export interface CreditPauseResumeRefs {
+  /** The pause the in-flight resume answers, null when it answers none. */
+  pauseId: MutableRefObject<string | null>;
+  pendingInterruptIds: MutableRefObject<Set<string>>;
+  collectedHitlResponses: MutableRefObject<Record<string, HitlDecisions>>;
+  /** Bumped on every new run and every thread switch, so a settler can tell
+   *  whether the board it snapshotted is still the board on screen. */
+  sessionEpoch: MutableRefObject<number>;
+  setMessages: SetMessages;
+}
+
+/**
+ * Move the in-flight pause card, once. The one unacceptable outcome is a card
+ * left on `resuming` with no way left to answer the pause, so every exit from a
+ * resume comes through here.
+ */
+export function settleCreditPause(refs: CreditPauseResumeRefs, status: CreditPauseStatus): void {
+  const pauseId = refs.pauseId.current;
+  if (!pauseId) return;
+  refs.pauseId.current = null;
+  refs.setMessages((prev) => setCardStatus(prev, 'creditPauses', pauseId, status));
+}
+
+/**
+ * Snapshot the interrupt board for one resume attempt and return its settler.
+ *
+ * Clearing the board assumes the resume is admitted. It can be refused, and an
+ * empty board then fails the `pending.size > 0` gate in
+ * collectHitlResponseAndMaybeResume, so every later click is dropped and the
+ * interrupt becomes unanswerable. The settler puts the snapshot back.
+ */
+export function beginResume(refs: CreditPauseResumeRefs): (admitted: boolean) => void {
+  const priorPendingIds = new Set(refs.pendingInterruptIds.current);
+  const priorCollected = { ...refs.collectedHitlResponses.current };
+  // The board belongs to the thread that armed it. A thread switch clears the
+  // board and bumps the epoch, but this settler runs later still, from the
+  // aborted stream's `finally` — so unfenced, a refused resume on thread A
+  // restores A's pending ids on top of thread B. Nothing on B will ever
+  // collect them, and B's own interrupt then fails the `every(id => collected)`
+  // batch gate for good. Refusal plus navigation is the ordinary path here,
+  // not an exotic one: answering a credit pause means leaving to buy credits.
+  const epoch = refs.sessionEpoch.current;
+  return (admitted: boolean) => {
+    if (refs.sessionEpoch.current !== epoch) return;
+    if (!admitted) {
+      refs.pendingInterruptIds.current = priorPendingIds;
+      refs.collectedHitlResponses.current = priorCollected;
+    }
+    settleCreditPause(refs, admitted ? 'resumed' : 'pending');
+  };
+}

--- a/web/src/pages/ChatAgent/session/interrupts/creditPauseResume.ts
+++ b/web/src/pages/ChatAgent/session/interrupts/creditPauseResume.ts
@@ -35,6 +35,23 @@ export function settleCreditPause(refs: CreditPauseResumeRefs, status: CreditPau
 }
 
 /**
+ * Put the card back on `pending`, KEEPING the pause reference.
+ *
+ * The batched case, and the reason it is not a settle: another interrupt in
+ * this turn is still unanswered, so nothing was dispatched and no stream will
+ * move this card. The click still stands though — the answer is held for the
+ * batch — so the pause this resume is answering has not changed. Clearing the
+ * reference here is what strands the card: the batch dispatches later, and the
+ * real settler then finds no pause to move and leaves a Resume button offered
+ * on a turn that is already running again.
+ */
+export function restoreCreditPausePending(refs: CreditPauseResumeRefs): void {
+  const pauseId = refs.pauseId.current;
+  if (!pauseId) return;
+  refs.setMessages((prev) => setCardStatus(prev, 'creditPauses', pauseId, 'pending'));
+}
+
+/**
  * Snapshot the interrupt board for one resume attempt and return its settler.
  *
  * Clearing the board assumes the resume is admitted. It can be refused, and an

--- a/web/src/pages/ChatAgent/session/interrupts/fromHistoryEvent.ts
+++ b/web/src/pages/ChatAgent/session/interrupts/fromHistoryEvent.ts
@@ -8,6 +8,8 @@
 
 import type { AssistantMessage } from '@/types/chat';
 import { updateMessage } from '../../hooks/utils/messageHelpers';
+import { setCardStatus } from './buckets';
+import { buildCreditPauseState } from './creditPauseCard';
 import type { SSEEvent, PairState, HistoryInterruptInfo } from '../types';
 import type { HistoryRuntime } from '../runtime';
 
@@ -23,23 +25,44 @@ export function projectHistoryInterrupt(
   event: SSEEvent,
   ctx: HistoryInterruptContext,
 ): void {
+  const actionRequests = event.action_requests || [];
+  const actionType = actionRequests[0]?.type as string | undefined;
+  const pairIndex = event.turn_index ?? ctx.currentActivePairIndex;
+  const interruptAssistantId = pairIndex != null ? ctx.assistantMessagesByPair.get(pairIndex) : null;
+  const pairState = pairIndex != null ? ctx.pairStateByPair.get(pairIndex) : null;
+
   // Skip a re-raised interrupt: LangGraph re-emits an unanswered
   // interrupt with the same interrupt_id on every resume, landing on a
   // later turn's bubble. The first occurrence owns the card (and its
   // ctx.pendingHistoryInterrupts entry, which answer-replay resolves by id);
   // re-emissions would append a duplicate card and a phantom pending
   // entry, so drop them wholesale.
-  if (event.interrupt_id && rt.renderedInterruptIdsRef.current.has(event.interrupt_id)) return;
-  const pairIndex = event.turn_index ?? ctx.currentActivePairIndex;
-  const interruptAssistantId = pairIndex != null ? ctx.assistantMessagesByPair.get(pairIndex) : null;
-  const pairState = pairIndex != null ? ctx.pairStateByPair.get(pairIndex) : null;
+  if (event.interrupt_id && rt.renderedInterruptIdsRef.current.has(event.interrupt_id)) {
+    // A credit pause is the exception, because it is the one interrupt resolved
+    // from the resume turn's `hitl_interrupt_ids` — stamped when the resume is
+    // requested, not when the graph consumes it. A re-raise is proof it never
+    // was, and it replays after that stamp, so it is the later truth: put the
+    // card back and re-queue the entry that arms the Resume button. Otherwise
+    // the pause replays answered with nothing left to answer it.
+    if (actionType === 'credit_pause' && interruptAssistantId) {
+      const proposalId = event.interrupt_id;
+      rt.setMessages((prev) => setCardStatus(prev, 'creditPauses', proposalId, 'pending'));
+      if (!ctx.pendingHistoryInterrupts.some((p) => p.interruptId === proposalId)) {
+        ctx.pendingHistoryInterrupts.push({
+          type: 'credit_pause',
+          assistantMessageId: interruptAssistantId,
+          proposalId,
+          interruptId: proposalId,
+        });
+      }
+    }
+    return;
+  }
 
   if (interruptAssistantId && pairState) {
     // Mark rendered only once a card will actually attach — a pair-less
     // event must not poison the set and drop a later valid re-raise.
     if (event.interrupt_id) rt.renderedInterruptIdsRef.current.add(event.interrupt_id);
-    const actionRequests = event.action_requests || [];
-    const actionType = actionRequests[0]?.type as string | undefined;
 
     if (actionType === 'ask_user_question') {
       // --- User question interrupt (history) ---
@@ -204,6 +227,30 @@ export function projectHistoryInterrupt(
 
       ctx.pendingHistoryInterrupts.push({
         type: actionType,
+        assistantMessageId: interruptAssistantId,
+        proposalId,
+        interruptId: event.interrupt_id,
+      });
+    } else if (actionType === 'credit_pause') {
+      // --- Credit pause interrupt (history) ---
+      const proposalId = event.interrupt_id!;
+      const pauseState = buildCreditPauseState(actionRequests[0], event.interrupt_id!);
+      const order = event._eventId != null ? Number(event._eventId) : ++pairState.contentOrderCounter;
+
+      rt.setMessages((prev) =>
+        updateMessage(prev,interruptAssistantId, (m) => {
+          if (m.role !== 'assistant') return m;
+          const msg = m as AssistantMessage;
+          return {
+            ...msg,
+            contentSegments: [...(msg.contentSegments || []), { type: 'credit_pause' as const, proposalId, order }],
+            creditPauses: { ...(msg.creditPauses || {}), [proposalId]: pauseState },
+          };
+        })
+      );
+
+      ctx.pendingHistoryInterrupts.push({
+        type: 'credit_pause',
         assistantMessageId: interruptAssistantId,
         proposalId,
         interruptId: event.interrupt_id,

--- a/web/src/pages/ChatAgent/session/interrupts/fromLiveEvent.ts
+++ b/web/src/pages/ChatAgent/session/interrupts/fromLiveEvent.ts
@@ -7,6 +7,8 @@
 
 import type { AssistantMessage } from '@/types/chat';
 import { updateMessage } from '../../hooks/utils/messageHelpers';
+import { setCardStatus } from './buckets';
+import { buildCreditPauseState } from './creditPauseCard';
 import type { SSEEvent, StreamProcessorRefs } from '../types';
 import type { StreamRuntime } from '../runtime';
 
@@ -192,6 +194,36 @@ export function projectLiveInterrupt(
     rt.pendingInterruptIdsRef.current.add(event.interrupt_id!);
     rt.setPendingInterrupt({
       type: actionType,
+      interruptId: event.interrupt_id,
+      assistantMessageId,
+      proposalId,
+    });
+  } else if (actionType === 'credit_pause') {
+    // --- Credit pause interrupt ---
+    const proposalId = event.interrupt_id!;
+    const pauseState = buildCreditPauseState(actionRequests[0], event.interrupt_id!);
+    const order = event._eventId != null ? Number(event._eventId) : ++refs.contentOrderCounterRef.current;
+
+    // A re-raise is the pause saying it was never consumed, whatever the resume
+    // looked like from the client: admission opens a run either way, so the card
+    // was already flipped to `resumed`. Put that card back rather than writing a
+    // pending entry onto this bubble, which the suppression above leaves with no
+    // segment to render it — the pause would otherwise sit unanswerable, and the
+    // status is what history replays.
+    rt.setMessages((prev) =>
+      interruptAlreadyRendered
+        ? setCardStatus(prev, 'creditPauses', proposalId, 'pending')
+        : updateMessage(prev,assistantMessageId, (m) => { if (m.role !== 'assistant') return m; const msg = m as AssistantMessage; return {
+            ...msg,
+            contentSegments: appendCardSegment(msg.contentSegments, { type: 'credit_pause', proposalId, order }),
+            creditPauses: { ...(msg.creditPauses || {}), [proposalId]: pauseState },
+            isStreaming: false,
+          }; })
+    );
+
+    rt.pendingInterruptIdsRef.current.add(event.interrupt_id!);
+    rt.setPendingInterrupt({
+      type: 'credit_pause',
       interruptId: event.interrupt_id,
       assistantMessageId,
       proposalId,

--- a/web/src/pages/ChatAgent/session/stream/lifecycle.ts
+++ b/web/src/pages/ChatAgent/session/stream/lifecycle.ts
@@ -191,6 +191,12 @@ export const reconnectToStream = async (
             return !stripProposalIds.has(seg.proposalId);
           }
           if (seg.type === 'plan_approval') return !stripPlanApprovalIds.has(seg.planApprovalId);
+          // A credit pause is stripped like the rest. Falling through to
+          // `true` kept the history copy while the id above was released from
+          // the rendered set, so the reconnect's re-delivery rendered a second
+          // card — and resolving one left the other `pending`, which pins
+          // every task card in the finishing state for the rest of the turn.
+          if (seg.type === 'credit_pause') return !stripProposalIds.has(seg.proposalId);
           return true;
         });
         const next: AssistantMessage = { ...msg, contentSegments: newSegments };
@@ -200,7 +206,7 @@ export const reconnectToStream = async (
           next.userQuestions = map;
         }
         if (stripProposalIds.size > 0) {
-          for (const key of ['workspaceProposals', 'questionProposals', 'ptcAgentProposals', 'secretaryActionProposals'] as const) {
+          for (const key of ['workspaceProposals', 'questionProposals', 'ptcAgentProposals', 'secretaryActionProposals', 'creditPauses'] as const) {
             const bucket = msg[key];
             if (!bucket) continue;
             const map = { ...bucket };

--- a/web/src/pages/ChatAgent/session/stream/processStreamEvent.ts
+++ b/web/src/pages/ChatAgent/session/stream/processStreamEvent.ts
@@ -7,6 +7,7 @@
 import { isUpstreamHint, type StructuredError } from '@/utils/rateLimitError';
 import { applyAnnotationArtifact } from '@/pages/MarketView/stores/chartAnnotationStore';
 import type { AssistantMessage } from '@/types/chat';
+import { CREDIT_STOP_ERROR_TYPE } from '@/types/sse';
 import { setStoredThreadId } from '../../hooks/utils/threadStorage';
 import { createAssistantMessage, appendMessage, updateMessage } from '../../hooks/utils/messageHelpers';
 import type { HtmlWidgetData } from '../../hooks/utils/types';
@@ -101,7 +102,17 @@ export const createStreamEventProcessor = (rt: StreamRuntime, deps: StreamRouter
   // pending-instruction bubble that taskRefs.messages doesn't (useCardState
   // keeps the longer array), and a failed task may have no assistant
   // message at all — a pushed message survives both.
-  const appendTaskNoticeMessage = (taskId: string, text: string, detail?: string): void => {
+  //
+  // `card` rides the same write rather than taking one of its own: by the time
+  // a terminal notice arrives the card is usually already inactive, and a write
+  // carrying no messages is dropped there as a stale pure-status update. The
+  // messages make this one a content update, which always lands.
+  const appendTaskNoticeMessage = (
+    taskId: string,
+    text: string,
+    detail?: string,
+    card?: Record<string, unknown>,
+  ): void => {
     if (!rt.updateSubagentCard) return;
     const taskRefs = getOrCreateTaskRefs(refs, taskId);
     const order = ++taskRefs.contentOrderCounterRef.current;
@@ -115,7 +126,7 @@ export const createStreamEventProcessor = (rt: StreamRuntime, deps: StreamRouter
       toolCallProcesses: {},
     });
     taskRefs.messages = updatedMessages;
-    rt.updateSubagentCard(taskId, { messages: updatedMessages });
+    rt.updateSubagentCard(taskId, { ...card, messages: updatedMessages });
   };
 
   const processEvent = (event: SSEEvent): void => {
@@ -579,8 +590,24 @@ export const createStreamEventProcessor = (rt: StreamRuntime, deps: StreamRouter
         } else if (eventType === 'error' || event.error) {
           // chan_close carries only the terminal status; the failure reason
           // exists only on this frame — surface it in the task transcript.
+          // This frame is also the only place the task path carries
+          // `error_type`, which is what separates a credit stop (the run was
+          // cut short by the turn's budget) from an actual failure.
           const errMsg = (event.error || event.message || '') as string;
-          appendTaskNoticeMessage(taskId, rt.t('chat.taskErrorNotification'), errMsg || undefined);
+          const stopped = event.error_type === CREDIT_STOP_ERROR_TYPE;
+          // The reason lands on the card as well, because the card is what
+          // the MAIN transcript reads. Without it a background task stopped
+          // for money reads there as a bare "Stopped" — indistinguishable
+          // from one the user ended — while its only explanation sits in a
+          // transcript they have to open the task to see.
+          appendTaskNoticeMessage(
+            taskId,
+            rt.t(stopped ? 'chat.taskStoppedNotification' : 'chat.taskErrorNotification'),
+            errMsg || undefined,
+            errMsg
+              ? { error: errMsg, ...(event.error_type ? { errorType: event.error_type } : {}) }
+              : undefined,
+          );
         }
       }
       return; // Don't process subagent events in main chat view
@@ -806,6 +833,18 @@ export const createStreamEventProcessor = (rt: StreamRuntime, deps: StreamRouter
           // retract the observed terminal outcome so the settled-task guards
           // stop skipping it (it is live again under a new run).
           rt.terminalTaskOutcomesRef.current.delete(task_id as string);
+          // The same retraction for WHY it stopped, and it has to reach both
+          // writers rather than just the card below: the telemetry resolver
+          // takes whichever of the two holds a reason, and refreshSubagentCard
+          // copies history's back onto the card on the next open, so clearing
+          // one alone is undone by the other. The ledger agrees on the next
+          // reload, where the task's latest run is the resumed one and carries
+          // no failure at all.
+          const resumedEntry = rt.subagentHistoryRef.current?.[agentId];
+          if (resumedEntry) {
+            resumedEntry.error = undefined;
+            resumedEntry.errorType = undefined;
+          }
           if (rt.updateSubagentCard) {
             // Prefer preserving the original spawn description (already on the card).
             // But after reconnect the card may have been wiped + recreated without a
@@ -819,6 +858,12 @@ export const createStreamEventProcessor = (rt: StreamRuntime, deps: StreamRouter
               type: (type || 'general-purpose') as string,
               status: 'active',
               isActive: true,
+              // The card half of the retraction above. Card state is keyed by
+              // task, and the resume's card shares that key with the one that
+              // stopped, so leaving it set would show the stop notice on a task
+              // actively working.
+              error: undefined,
+              errorType: undefined,
               ...(historyDesc ? { description: historyDesc } : {}),
               ...(historyPrompt ? { prompt: historyPrompt } : {}),
             });

--- a/web/src/pages/ChatAgent/session/subagents/__tests__/resolveSubagentTelemetry.test.ts
+++ b/web/src/pages/ChatAgent/session/subagents/__tests__/resolveSubagentTelemetry.test.ts
@@ -107,3 +107,48 @@ describe('resolveSubagentTelemetry', () => {
     expect(JSON.stringify(history)).toBe(historySnap);
   });
 });
+
+/**
+ * The stop reason has its own precedence, deliberately unlike the numbers.
+ * Only one of the two writers ever holds a reason for a given task — the live
+ * error frame stamps the card, replay stamps history from the ledger — so
+ * reading it from whichever source won the count would blank it on exactly
+ * the permutation the other one covers.
+ */
+describe('resolveSubagentTelemetry — stop reason', () => {
+  const REASON = 'Monthly credit limit reached (50/50 credits)';
+
+  it('takes the reason from history while the numbers come from the card', () => {
+    const card: SubagentDataLike = { messages: [msgWith(2)], tokenUsage: ZERO_USAGE };
+    const history: SubagentHistoryLike = { error: REASON, errorType: 'credit_stop' };
+    expect(resolveSubagentTelemetry(card, history)).toEqual({
+      toolCalls: 2,
+      tokenUsage: ZERO_USAGE,
+      stopReason: REASON,
+      stopReasonType: 'credit_stop',
+    });
+  });
+
+  it('takes the reason from the card when history is the source of the numbers', () => {
+    const card: SubagentDataLike = { error: REASON, errorType: 'credit_stop' };
+    const history: SubagentHistoryLike = { toolCalls: 13, tokenUsage: ZERO_USAGE };
+    expect(resolveSubagentTelemetry(card, history)).toEqual({
+      toolCalls: 13,
+      tokenUsage: ZERO_USAGE,
+      stopReason: REASON,
+      stopReasonType: 'credit_stop',
+    });
+  });
+
+  it('omits both keys entirely when neither source has a reason', () => {
+    const result = resolveSubagentTelemetry({ messages: [msgWith(1)] }, undefined);
+    expect(result).not.toHaveProperty('stopReason');
+    expect(result).not.toHaveProperty('stopReasonType');
+  });
+
+  it('keeps a reason that arrived without a type — it is still worth stating', () => {
+    const result = resolveSubagentTelemetry(undefined, { error: 'run ended: cancelled' });
+    expect(result?.stopReason).toBe('run ended: cancelled');
+    expect(result).not.toHaveProperty('stopReasonType');
+  });
+});

--- a/web/src/pages/ChatAgent/session/subagents/projectHistory.ts
+++ b/web/src/pages/ChatAgent/session/subagents/projectHistory.ts
@@ -253,6 +253,7 @@ export function projectSubagentHistory(
       // to 'running' and let /status reconciliation settle it.
       status: taskMetadata?.status || 'running',
       error: taskMetadata?.error,
+      errorType: taskMetadata?.errorType,
       toolCalls: countToolCalls(finalMessages),
       tokenUsage: tempTokenUsage,
       currentTool: '',

--- a/web/src/pages/ChatAgent/session/subagents/resolveSubagentTelemetry.ts
+++ b/web/src/pages/ChatAgent/session/subagents/resolveSubagentTelemetry.ts
@@ -59,9 +59,15 @@ export function resolveSubagentTelemetry(
   // replay stamps history from the ledger — so the reason takes whichever has
   // one rather than whichever won the count.
   const reason = ((): Pick<SubagentTelemetry, 'stopReason' | 'stopReasonType'> => {
-    const error = subagentData?.error || history?.error;
+    // One source for both fields, picked once. Read independently they can
+    // pair a reason from the card with a type from history, and the type is
+    // what decides whether a stop is offered back to the user with plan
+    // links — so a mismatch does not garble the copy, it changes what the
+    // surface claims happened.
+    const source = subagentData?.error ? subagentData : history;
+    const error = source?.error;
     if (!error) return {};
-    const errorType = subagentData?.errorType || history?.errorType;
+    const errorType = source?.errorType;
     return { stopReason: error, ...(errorType ? { stopReasonType: errorType } : {}) };
   })();
 

--- a/web/src/pages/ChatAgent/session/subagents/resolveSubagentTelemetry.ts
+++ b/web/src/pages/ChatAgent/session/subagents/resolveSubagentTelemetry.ts
@@ -1,5 +1,6 @@
 /**
- * Pure resolver for inline-card subagent telemetry.
+ * Pure resolver for what an inline subagent card shows about a task it does
+ * not own: its telemetry, and why it stopped.
  *
  * Two writers feed the inline subagent card: the live `cards[...]` state
  * (driven by SSE events) and the post-refresh `subagentHistoryRef`
@@ -18,6 +19,11 @@ import { ZERO_USAGE, type SubagentTokenUsage } from '../../utils/tokenUsage';
 export interface SubagentTelemetry {
   toolCalls: number;
   tokenUsage: SubagentTokenUsage;
+  /** Why a settled task ended, when it ended with a reason. */
+  stopReason?: string;
+  /** That reason's machine spelling, so a surface can offer the remedy for the
+   *  one kind of stop that has one. */
+  stopReasonType?: string;
 }
 
 interface MessageLike {
@@ -28,12 +34,16 @@ interface MessageLike {
 export interface SubagentDataLike {
   messages?: MessageLike[];
   tokenUsage?: SubagentTokenUsage;
+  error?: string;
+  errorType?: string;
 }
 
 export interface SubagentHistoryLike {
   messages?: MessageLike[];
   tokenUsage?: SubagentTokenUsage;
   toolCalls?: number;
+  error?: string;
+  errorType?: string;
 }
 
 export function resolveSubagentTelemetry(
@@ -43,6 +53,18 @@ export function resolveSubagentTelemetry(
   const sdMessages = subagentData?.messages;
   const sdTokenUsage = subagentData?.tokenUsage;
 
+  // The reason has its own precedence, deliberately unlike the numbers: those
+  // pick a source and read it whole, but only one of the two writers ever
+  // holds a reason for a given task — the live error frame stamps the card,
+  // replay stamps history from the ledger — so the reason takes whichever has
+  // one rather than whichever won the count.
+  const reason = ((): Pick<SubagentTelemetry, 'stopReason' | 'stopReasonType'> => {
+    const error = subagentData?.error || history?.error;
+    if (!error) return {};
+    const errorType = subagentData?.errorType || history?.errorType;
+    return { stopReason: error, ...(errorType ? { stopReasonType: errorType } : {}) };
+  })();
+
   // Card path: prefer live state, but only when the card has actually been
   // populated. A click-created card with empty messages and zero tokens
   // should still pull from history below — the bug we hit when post-refresh
@@ -51,6 +73,7 @@ export function resolveSubagentTelemetry(
     return {
       toolCalls: countToolCalls(sdMessages),
       tokenUsage: sdTokenUsage ?? ZERO_USAGE,
+      ...reason,
     };
   }
 
@@ -60,6 +83,7 @@ export function resolveSubagentTelemetry(
     return {
       toolCalls: history.toolCalls ?? countToolCalls(history.messages),
       tokenUsage: history.tokenUsage ?? ZERO_USAGE,
+      ...reason,
     };
   }
 
@@ -68,5 +92,6 @@ export function resolveSubagentTelemetry(
   return {
     toolCalls: countToolCalls(sdMessages),
     tokenUsage: sdTokenUsage ?? ZERO_USAGE,
+    ...reason,
   };
 }

--- a/web/src/pages/ChatAgent/session/types.ts
+++ b/web/src/pages/ChatAgent/session/types.ts
@@ -158,9 +158,12 @@ interface SubagentHistoryEntry {
   type: string;
   messages: Record<string, unknown>[];
   status: string;
-  /** Ledger failure reason, present only for an errored task. Surfaced in the
-   *  detail view header so a "Failed" card explains why. */
+  /** Ledger failure reason, present for any task that settled with one — a
+   *  stop as well as a failure. Surfaced in the detail view header and on the
+   *  inline card, so neither a "Failed" nor a "Stopped" card is unexplained. */
   error?: string;
+  /** That reason's machine spelling (``credit_stop``, ``transport_lost``, …). */
+  errorType?: string;
   toolCalls: number;
   tokenUsage: SubagentTokenUsage;
   currentTool: string;
@@ -208,8 +211,11 @@ interface SubagentHistoryData {
   type?: string;
   /** Backend-stamped real task status from replayed task artifacts (running|completed|cancelled). */
   status?: string;
-  /** Backend-stamped ledger failure reason, present only for an errored task. */
+  /** Backend-stamped ledger failure reason, present for any task that
+   *  settled with one — a stop as well as a failure. */
   error?: string;
+  /** The reason's machine spelling (``credit_stop``, ``transport_lost``, …). */
+  errorType?: string;
   /** Build-time stamp: start (epoch ms) of the newest run whose transcript
    *  the projection actually claimed — NOT the ledger's latest run, which
    *  can still be executing and deliberately excluded from the payload. */

--- a/web/src/pages/MarketView/components/MarketChatPanel.tsx
+++ b/web/src/pages/MarketView/components/MarketChatPanel.tsx
@@ -406,6 +406,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
     handleRejectPTCAgent,
     handleApproveSecretaryAction,
     handleRejectSecretaryAction,
+    handleResumeCreditPause,
     // Turn/context state — drives the stop button, input gating, and the
     // interrupted / plan-feedback / compaction status banners.
     pendingInterrupt,
@@ -649,6 +650,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
   const stableRejectPTCAgent = useStableHandler(handleRejectPTCAgent);
   const stableApproveSecretaryAction = useStableHandler(handleApproveSecretaryAction);
   const stableRejectSecretaryAction = useStableHandler(handleRejectSecretaryAction);
+  const stableResumeCreditPause = useStableHandler(handleResumeCreditPause);
   const stableEditMessage = useStableHandler((id: string, content: string) =>
     handleEditMessage(id, content, chatInputRef.current?.getModelOptions?.()));
   const stableRegenerate = useStableHandler((id: string) =>
@@ -678,6 +680,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
     onRejectPTCAgent: stableRejectPTCAgent,
     onApproveSecretaryAction: stableApproveSecretaryAction,
     onRejectSecretaryAction: stableRejectSecretaryAction,
+    onResumeCreditPause: stableResumeCreditPause,
     onEditMessage: stableEditMessage,
     onRegenerate: stableRegenerate,
     onRetry: stableRetry,
@@ -690,7 +693,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
     stableAnswerQuestion, stableSkipQuestion, stableApproveCreateWorkspace,
     stableRejectCreateWorkspace, stableApproveStartQuestion, stableRejectStartQuestion,
     stableApprovePTCAgent, stableRejectPTCAgent, stableApproveSecretaryAction,
-    stableRejectSecretaryAction, stableEditMessage, stableRegenerate, stableRetry,
+    stableRejectSecretaryAction, stableResumeCreditPause, stableEditMessage, stableRegenerate, stableRetry,
     stableThumbUp, stableThumbDown, stableReportWithAgent, stableWidgetSendPrompt,
   ]);
 

--- a/web/src/pages/MarketView/components/__tests__/MarketChatPanel.test.tsx
+++ b/web/src/pages/MarketView/components/__tests__/MarketChatPanel.test.tsx
@@ -23,6 +23,7 @@ const h = vi.hoisted(() => ({
   handleRejectPTCAgent: vi.fn(),
   handleApproveSecretaryAction: vi.fn(),
   handleRejectSecretaryAction: vi.fn(),
+  handleResumeCreditPause: vi.fn(),
   handleEditMessage: vi.fn(),
   handleRegenerate: vi.fn(),
   handleRetry: vi.fn(),
@@ -75,6 +76,7 @@ vi.mock('@/pages/ChatAgent/hooks/useChatMessages', () => ({
     handleRejectPTCAgent: h.handleRejectPTCAgent,
     handleApproveSecretaryAction: h.handleApproveSecretaryAction,
     handleRejectSecretaryAction: h.handleRejectSecretaryAction,
+    handleResumeCreditPause: h.handleResumeCreditPause,
     pendingInterrupt: h.pendingInterrupt,
     pendingRejection: null,
     hasActiveSubagents: false,
@@ -190,6 +192,7 @@ describe('MarketChatPanel', () => {
       ['onRejectPTCAgent', h.handleRejectPTCAgent],
       ['onApproveSecretaryAction', h.handleApproveSecretaryAction],
       ['onRejectSecretaryAction', h.handleRejectSecretaryAction],
+      ['onResumeCreditPause', h.handleResumeCreditPause],
     ];
     for (const [key, spy] of wiring) {
       expect(typeof a[key]).toBe('function');

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -7,6 +7,7 @@ import type {
   TodoItem,
   ProvenanceSourceType,
 } from './sse';
+import type { ErrorLinkSpec } from '@/utils/rateLimitError';
 
 // --- Content Segments (discriminated union) ---
 
@@ -128,6 +129,12 @@ export interface PlanApprovalSegment {
   order: number;
 }
 
+export interface CreditPauseSegment {
+  type: 'credit_pause';
+  proposalId: string;
+  order: number;
+}
+
 export type ContentSegment =
   | ReasoningSegment
   | TextSegment
@@ -142,7 +149,8 @@ export type ContentSegment =
   | DeleteWorkspaceSegment
   | StopWorkspaceSegment
   | DeleteThreadSegment
-  | PlanApprovalSegment;
+  | PlanApprovalSegment
+  | CreditPauseSegment;
 
 // --- Process Records ---
 
@@ -336,6 +344,24 @@ export interface SecretaryActionProposalState {
   interruptId?: string;
 }
 
+/**
+ * ``resuming`` is the in-flight leg and exists because a resume can be refused:
+ * admission re-runs the quota check and answers 429 without opening a turn, so
+ * a click cannot be treated as success. Only an accepted run reaches
+ * ``resumed``; a refusal returns the card to ``pending`` so a top-up can retry.
+ */
+export type CreditPauseStatus = 'pending' | 'resuming' | 'resumed';
+
+export interface CreditPauseState {
+  status: CreditPauseStatus;
+  /** The quota service's denial copy, relayed verbatim — never authored here. */
+  message?: string;
+  /** Where the user resolves the denial, built by ``buildRateLimitError`` so a
+   *  pause and a 429 banner offer the same destinations. */
+  links?: ErrorLinkSpec[];
+  interruptId: string;
+}
+
 // --- Chat Messages ---
 
 export interface UserMessage {
@@ -394,6 +420,7 @@ export interface AssistantMessage {
   questionProposals?: Record<string, QuestionProposalState>;
   ptcAgentProposals?: Record<string, PTCAgentProposalState>;
   secretaryActionProposals?: Record<string, SecretaryActionProposalState>;
+  creditPauses?: Record<string, CreditPauseState>;
   // Runtime flags
   steering?: boolean;
   steeringDelivered?: boolean;

--- a/web/src/types/sse.ts
+++ b/web/src/types/sse.ts
@@ -1,5 +1,12 @@
 /** SSE event type union and per-event interfaces */
 
+/**
+ * `error_type` on a task's terminal frame when the credit gate stopped it,
+ * rather than something failing. Mirrors CREDIT_STOP_ERROR_TYPE in
+ * src/server/contracts/status.py by hand — change there first, then here.
+ */
+export const CREDIT_STOP_ERROR_TYPE = 'credit_stop';
+
 export type SSEEventType =
   | 'metadata'
   | 'reasoning_signal'
@@ -268,6 +275,8 @@ export interface ActionRequest {
   thread_id?: string;
   report_back?: boolean;
   tool_call_id?: string;
+  /** credit_pause: the quota service's denial copy, relayed verbatim. */
+  message?: string;
 }
 
 export interface InterruptEvent extends BaseSSEEvent {

--- a/web/src/utils/__tests__/rateLimitError.test.ts
+++ b/web/src/utils/__tests__/rateLimitError.test.ts
@@ -6,8 +6,18 @@ import { buildRateLimitError } from '../rateLimitError';
 // naming our own deployment would still pass if the value were hardcoded.
 const PORTAL = 'https://account.example.com';
 const PORTAL_LINKS = [
-  { url: `${PORTAL}/plans`, label: 'Manage plan', external: true },
-  { url: `${PORTAL}/usage`, label: 'View usage', external: true },
+  {
+    url: `${PORTAL}/plans`,
+    label: 'Manage plan',
+    labelKey: 'chat.errorLinkManagePlan',
+    external: true,
+  },
+  {
+    url: `${PORTAL}/usage`,
+    label: 'View usage',
+    labelKey: 'chat.errorLinkViewUsage',
+    external: true,
+  },
 ];
 
 describe('buildRateLimitError', () => {
@@ -53,8 +63,18 @@ describe('buildRateLimitError', () => {
     // and the CTA does nothing.
     const result = buildRateLimitError({ type: 'monthly_credit_limit' }, '/account');
     expect(result.links).toEqual([
-      { url: '/account/plans', label: 'Manage plan', external: true },
-      { url: '/account/usage', label: 'View usage', external: true },
+      {
+        url: '/account/plans',
+        label: 'Manage plan',
+        labelKey: 'chat.errorLinkManagePlan',
+        external: true,
+      },
+      {
+        url: '/account/usage',
+        label: 'View usage',
+        labelKey: 'chat.errorLinkViewUsage',
+        external: true,
+      },
     ]);
   });
 

--- a/web/src/utils/rateLimitError.ts
+++ b/web/src/utils/rateLimitError.ts
@@ -50,7 +50,14 @@ export function isUpstreamHint(value: unknown): value is UpstreamErrorHint {
 
 export interface ErrorLinkSpec {
   url: string;
+  /** Literal text, for a label the producer authored (or the service did, on a
+   *  link that arrives off the wire already worded). ``labelKey`` wins when
+   *  both are set. */
   label: string;
+  /** i18n key, for a label this client writes and therefore has to translate.
+   *  Resolved by ``ErrorLink`` — this module stays translation-free, the same
+   *  split as ``UPSTREAM_HINT_I18N_KEY``. */
+  labelKey?: string;
   /** Marks a destination outside this SPA. The URL cannot say so on its own:
    *  with a path-shaped ``VITE_PLATFORM_URL`` the account portal is same-origin
    *  and indistinguishable from one of our routes. See ``ErrorLink`` for what
@@ -118,8 +125,18 @@ export function buildRateLimitError(
   const links: ErrorLinkSpec[] | undefined =
     platformUrl && !NOT_ABOUT_THE_ACCOUNT.has(info.type as string)
       ? [
-          { url: `${platformUrl}/plans`, label: 'Manage plan', external: true },
-          { url: `${platformUrl}/usage`, label: 'View usage', external: true },
+          {
+            url: `${platformUrl}/plans`,
+            label: 'Manage plan',
+            labelKey: 'chat.errorLinkManagePlan',
+            external: true,
+          },
+          {
+            url: `${platformUrl}/usage`,
+            label: 'View usage',
+            labelKey: 'chat.errorLinkViewUsage',
+            external: true,
+          },
         ]
       : undefined;
 


### PR DESCRIPTION
## Overview

A turn that runs out of credits mid-flight is now stopped and offered back, instead of running to completion and landing on the user as debt they never agreed to. The turn checkpoints at a model boundary, the transcript shows the quota service's own denial copy with a link to the plan page, and Resume continues the same turn from the step it stopped at. Background subagents in the same turn family share one reservation, stop the same way, and are offered back on the resume.

| | Files | + | - |
|---|---|---|---|
| New | 23 | 4,536 | 0 |
| Modified | 76 | 2,322 | 743 |
| **Total** | **99** | **6,858** | **743** |
| Net of tests | 69 | 3,879 | 704 |

**Agent middleware** &nbsp; `middleware/credit_gate.py` (new, 651) is the whole gate: a `CreditLease` per turn family and a `CreditGateState` per lane, plus the two background loops that heartbeat spend and renew the reservation. `background_subagent/outcomes.py` (new, 96) owns a run's terminal outcome so the ledger row, the wire frame and the in-memory result cannot disagree about it; `run_executor.py` (+61/-30) opens each child's lane through a context manager that sets the ContextVar on every path, including to None.

**Server** &nbsp; `services/credit_gate_port.py` (new, 520) is the wire to the quota service and the only place a response is turned into a verdict. `database/runs/credit_ledger.py` (new, 248) carries the in-flight heartbeat and the query that finds what a resume should offer back. `utils/credit_resume_context.py` (new, 60) writes the resume's context into graph state. `contracts/status.py` (+69/-12) declares the `credit_pause` interrupt reason and the `credit_stop` error type both halves match on. `dependencies/usage_limits.py` (+47/-20) promotes the three names the port needs to a declared surface instead of a borrowed underscore. `services/history/task_status.py` (+31/-10) and `database/runs/subagent_runs.py` (+50/-9) carry a stopped task's reason and its machine type from the ledger into the replayed artifact, under the existing `status_only` gate that keeps failure text out of an unauthenticated replay.

**Pricing** &nbsp; `llms/pricing_utils.py` (+105/-2) adds `blended_rate` and `chunk_multiplier`, which say what one model boundary costs relative to a baseline model. `utils/tracking/per_call_token_tracker.py` (+62/-12) exposes the running platform spend the gate meters on, and stops holding its lock across the pricing pass.

**Migration** &nbsp; `033_in_flight_credits.py` (new, 214) adds the in-flight credit columns and the settled-at stamp on the run ledger. Numbered behind `032_free_moomoo_name.py`, which merged first: merge order is the rule, and `down_revision` is the line that actually matters.

**Web** &nbsp; `CreditPauseCard.tsx` (new, 110) is the card. `session/interrupts/creditPauseCard.ts` (new, 27) builds its state once for both the live and history paths; `creditPauseResume.ts` (new, 64) owns every exit from a resume. `CreditPausePendingContext.tsx` (new, 31) lets the task cards read the turn's pause without a prop threaded through the tree. `SubagentTaskMessageContent.tsx` (+114/-2) puts a stopped task's reason on the inline card and exports the credit-stop notice the main transcript renders at the foot of the message. `MessageContentSegments.tsx` (+255/-369) and `replayHistory.ts` (+104/-129) both shrink even so: four near-identical history-resolution blocks collapse onto one helper.

**Tests** &nbsp; 30 files, +2,979. Nine new suites pin the gate's arithmetic, the port's parsing, the ledger's resume query, the contract mirrors between the two halves, the card's replay, where the stop notice renders, and the retraction a resume performs.

## Why this way

**One reservation per turn family, not per lane.** A subagent asking for its own ceiling gets denied against its parent's grant, which is the same budget. So the lease is refcounted: lanes join and leave it, the last one out releases. Membership moves under a lock because a lane can arrive after the last one left (a subagent's first step is scheduled independently of its spawn), and interleaving that arrival with the departure is what leaves a lease closed with members in it, or open with none.

**Enforcement is at a model boundary, deliberately.** Stopping anywhere else means killing a turn mid-tool-call with no checkpoint to resume from. The cost is that a denial landing after a turn's last boundary cannot stop it; see Known limits.

**The gate fails open, always.** An unreachable quota service, a 5xx, an unreadable body: all of them mean "no verdict", and the gate keeps enforcing the last verdict it trusted. A run that cannot ask is a run that keeps working. The one place that fails closed is admission, which is the right polarity there: refusing to start a turn is recoverable, killing one that is already running is not.

**Nothing on the model-call path waits on the network.** The gate's whole cost at a boundary is one float comparison against numbers already in memory: family spend against the current ceiling. Acquiring, renewing and heartbeating all happen on background tasks polling every 2s, and a renewal fires two minutes ahead of expiry, so a slow or hanging quota service adds no latency to a turn. Running past the granted chunk does not block either: exhausting it is what triggers the next background ask, not a gate the boundary waits at, so the only thing a boundary ever asks is whether the service has already said no. That is what makes failing open cheap rather than a special case, and it is paid for in exposure rather than latency: see Known limits for the overshoot that buys.

**A stop is not a failure.** A subagent stopped for credits settles `cancelled`, not `error`, so the chip, the nav row and the summary line all read "Stopped". It keeps its failure payload, because the denial copy is the explanation and the `credit_stop` type is what offers the task back for resume.

**A background stop is the turn's news, not a footnote on one card.** A task can outlive the turn that spawned it, and when the gate stops one the turn has already settled: there is no model boundary left to interrupt, so no pause card is ever raised in the thread. Left alone the denial reaches only that task's own transcript, behind a click, while the thread shows a Stopped chip indistinguishable from a task the user ended. The reason now travels from the ledger through the artifact stamp, and the main transcript renders it at the foot of the message rather than beside the card that stopped: the closing prose was written before the gate fired and still promises a result, so a notice above it is read first and contradicted second. A resume retracts it, from the history entry as well as the card, because the resolver takes whichever of the two holds a reason and clearing one alone is undone by the other.

**The reservation is sized by what a boundary costs.** A flat chunk is burned by one call on a premium model, which puts the run back on the quota service for every boundary it crosses, and is far more than a cheap run can spend. `chunk_multiplier` weights a model's four card rates by the measured production token mix (traffic runs about 80% cache reads, so the input rate alone is the wrong proxy) and snaps the result to a coarse ladder, so a cent of manifest drift cannot restate every reservation.

**The denial copy is never authored here.** The quota service knows the plan, the counts, the user's language and their local day. The card relays its message verbatim and takes its links from the same builder a 429 banner uses, including that builder's exclusion for denials no account page can resolve.

## How it works

`build_run_credit_gate` opens a lane at the top of a turn, keyed to the run and carrying its model's rate. Each lane heartbeats its spend to the run ledger; the lease refreshes against the quota service on a floor of one answered acquire every few seconds per family. A grant raises the ceiling monotonically. A denial does not raise it, and from that point `should_stop(spent)` is true once the family's spend passes the ceiling it was already granted, checked in `abefore_model`.

A stopped main run raises through `interrupt()` with the `credit_pause` reason; a stopped subagent raises `CreditStopError`, settles `cancelled`, and its lane leaves the lease. Release is fenced on the generation the grant carried, so a departing release cannot delete a reservation a later lane has already reopened.

On resume, `build_credit_resume_update` reads the ledger for the runs the gate stopped and puts them into graph state, so the agent re-enters them rather than starting over.

The gate is only built when `HOST_MODE != "oss"` and a quota service is configured. Without one, none of this exists at runtime: no lease, no heartbeat, no card.

## Verification

Exercised end to end against a live backend, real sandboxes and a real model, with a bench that dials the account's headroom between runs.

The scenario table below was gathered before the quota service's review pass. Its wire contract has since been re-verified against the current build: the capability payload and its published multiplier bounds, both acquire shapes including a real denial, release, and this side's parsing of each. The full scenario suite is scheduled to re-run against the current build before merge.

| Scenario | Result |
|---|---|
| Funded turn | Untouched. Ceiling granted at the expected multiple of the baseline, released at the end. |
| Main run out of credits | `interrupt` frame carrying the platform's copy verbatim, `run_end outcome: interrupted`, ledger stamped `credit_pause`. |
| Resume | Same turn continued from the step it stopped at and completed. |
| Subagent outliving its parent | Lease still held after the main run ended, released 14 ms before the child finalized. |
| Subagent out of credits | Settled `cancelled` with `error_type: credit_stop`; the wire frame carries the same string the frontend matches on. |
| Pause plus stopped task, then resume | Agent re-entered the task on its own; the ledger shows `init/cancelled/credit_stop` then `resume/completed` against one task id. |
| Quota service returning 500 for a whole turn | Turn completed all steps. Release gave up after its bounded attempts and left the reservation to expire. |
| Quota service unreachable at admission | 503 with a retry hint, turn never started. Pre-existing behavior, opposite polarity on purpose. |

Suites: 9,388 backend unit tests pass, 3,284 web tests pass, typecheck clean, lint clean.

## Known limits

**The gate is one model boundary behind.** It learns of a denial from a lease refresh and stops at the next model call, so a turn whose denial lands after its last boundary runs to completion. The same lag applies to refills: a run that crosses its granted ceiling keeps going on unreserved credit until the next background ask answers, which the acquire spacing floors at a few seconds. Measured overshoot on a deliberately tiny ceiling: 1.96 credits spent against a 1.21 ceiling. Closing it means either enforcing inside a tool call, which has no checkpoint to resume from, or making the refresh synchronous on every boundary, which puts a network round trip on the hot path of every model call.

**Admission and the gate fail in opposite directions**, which is intentional but worth knowing when reading an incident: if the quota service is down, new turns are refused and running turns keep running.

**A background task stopped under a completed parent is not offered back.** `list_credit_stopped_for_resume` anchors on the run before the resuming one, and yields nothing unless that run is itself the credit pause, which is what stops it re-announcing the same stops on every later approval the thread asks for. A task whose parent turn had already finished normally is stopped with no pause to anchor to, so the next turn's model gets no record of it and will not re-enter it unprompted. The user sees the stop and its remedy; the agent will not offer the resume. Widening the anchor needs a different idempotency guard and is not in this change.

**Nor is one that stops after a resume has already begun.** The same anchor reads the ledger once, at the moment the resume starts. A background task still inside a tool call then has not stopped yet: it stops at its next model boundary, after the snapshot has been taken, and by then the thread's newest run is the resume rather than the pause, so there is nothing left for it to anchor to. The task still stops, and still carries its reason where the user can see it; what is lost is the instruction telling the next turn's model to re-enter it. Waiting for live children to settle first would put a multi-minute tool call in front of a resume click, so this closes with the same widened anchor as the case above, not before it.

## Paired change

The reservation authority lives in the quota service and ships alongside this. This half is inert without it: with no lease route answering, every acquire is "no verdict" and every turn runs exactly as it does today.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790640639&installation_model_id=432753&pr_number=380&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F380&signature=a8cf2c027552fda775ce4a508b39858f5783323bc3458504d9e86e7b91530148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime credit controls for turns and shared subagent activity, including BYOK support.
  * Added pause-and-resume support when credits are unavailable.
  * Added chat cards and status indicators for paused turns and stopped subagents.
  * Improved model pricing and credit estimation across cache and usage tiers.
  * Added links to manage plans and view usage from credit-related messages.

* **Bug Fixes**
  * Improved billing settlement and recovery of abandoned runs.
  * Preserved cancellation reasons and clarified turn-related messages.
  * Improved reconnect and history handling for paused or stopped tasks.
  * Reduced repeated warnings for unavailable pricing information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

