### PR TITLE
fix(web): ring a text field for the keyboard, not for the mouse

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -64,6 +64,18 @@ washes, glows and fills. A picture of a branded thing reads as brand, not as
 state. The alternative is a picture whose color has to be kept in step with the
 brand by hand, which is how that panel spent a rebrand still showing the old one.
 
+**The sign-in page is the one product surface that is exempt**, and the reason
+is that the rule has nothing to bite on there. It carries no chrome, no
+navigation and no data, so there is nothing for the accent to annotate, and the
+neutral focus ring would paint in a color the page uses nowhere else. Amber is
+its whole interaction vocabulary instead: the submit button has always taken the
+fill on hover, and keyboard focus takes the same fill rather than inventing a
+second language for the same "about to act" state. Focus is not left to hue
+alone, since hue is what a color deficiency flattens: an underline by default, a
+doubled edge on the boxed controls, an outline under forced colors. The exemption
+is the `.login-page` surface itself, not the route it mounts on: the same build
+serves the app from that route once someone is signed in.
+
 Semantic color (profit/loss/warning/danger) is separate from the accent and
 never substitutes for it.
 

--- a/web/e2e/auth-surface.focus.spec.js
+++ b/web/e2e/auth-surface.focus.spec.js
@@ -1,0 +1,244 @@
+/**
+ * The auth surface answers focus in its own language: no ring anywhere, an
+ * ember halo on a field a keyboard reached, and each button or link lighting in
+ * the colour this page reserves for a control about to act.
+ *
+ * Two things break silently here and neither is visible from a component. A
+ * field matches `:focus-visible` for a mouse click as well as a Tab, which is
+ * spec behaviour rather than a quirk, so the ember lit on every click for as
+ * long as that rule existed. And once the app-wide ring is suppressed on this
+ * surface, a control added without a focus treatment has nothing at all, which
+ * no unit test can see because jsdom paints no cascade.
+ *
+ * That second failure is per view, not per page: the surface is four screens
+ * behind one class, and a screen the audit never opens is a screen where every
+ * control can be dark. So the tab walk runs on each of them, reached the way a
+ * user reaches them.
+ *
+ * Runs against the `auth-surface` project, which boots its own dev server in
+ * platform mode. Only the send that opens the inbox screen is answered, by a
+ * route handler rather than a server, so nothing here reaches a network.
+ */
+import { test, expect } from '@playwright/test';
+
+import { outlineOn, tabTo, unpainted } from './helpers/focusPaint.js';
+
+const EMAIL = 'input[type=email]';
+const SUBMIT = '.login-page__submit';
+const TOGGLE = '.login-page__password-toggle';
+/**
+ * Everything a Tab can land on, in the view under test. Disabled controls are
+ * out: they are unreachable by definition and have no focus state to check, so
+ * counting them would report a permanent dark control -- the resend button
+ * spends its first minute that way.
+ */
+const FOCUSABLE = '.login-page button:not(:disabled), .login-page a, .login-page input:not(:disabled)';
+
+/** The paint that carries focus on this surface, once transitions settle. */
+async function paintOn(page, sel) {
+  return page.evaluate(async (s) => {
+    const el = document.querySelector(s);
+    if (!el) throw new Error(`${s} is not on the page`);
+    await new Promise((r) => setTimeout(r, 300));
+    const cs = getComputedStyle(el);
+    return {
+      focused: document.activeElement === el,
+      outline: cs.outlineStyle,
+      outlineColor: cs.outlineColor,
+      border: cs.borderColor,
+      background: cs.backgroundColor,
+      color: cs.color,
+      shadow: cs.boxShadow,
+      underline: cs.textDecorationLine,
+    };
+  }, sel);
+}
+
+/** The screen the surface opens on: a list of sign-in methods. */
+async function methodView(page) {
+  await page.goto('/app');
+  await expect(page.locator('.login-page__method-btn--primary')).toBeVisible();
+}
+
+/** Email and password, one click in from the method list. */
+async function emailView(page) {
+  await methodView(page);
+  await page.locator('.login-page__method-btn--primary').click();
+  await expect(page.locator(EMAIL)).toBeVisible();
+}
+
+/**
+ * The screen after a link is sent, which owns the one control no other view
+ * has. Reaching it needs a send to succeed, so the send is answered here
+ * instead of by a server: this spec measures paint, and an auth backend is not
+ * part of what it is measuring.
+ */
+async function inboxView(page) {
+  await page.route('**/auth/v1/otp**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }));
+  await methodView(page);
+  await page.locator('.login-page__method-btn').last().click();
+  await expect(page.locator(EMAIL)).toBeVisible();
+  await page.locator(EMAIL).fill('someone@example.com');
+  await page.locator(SUBMIT).click();
+  await expect(page.locator('.login-page__resend-btn')).toBeVisible();
+}
+
+/**
+ * Walk the whole tab order of whatever is on screen and return the controls
+ * that never changed paint.
+ *
+ * Walked with real Tab presses. A programmatic focus does not match
+ * :focus-visible on a button in a page no key has touched, so a loop calling
+ * .focus() reports every button dark and proves nothing.
+ */
+async function darkAfterTabWalk(page) {
+  const resting = await page.evaluate((sel) => {
+    const paint = (el) => {
+      const c = getComputedStyle(el);
+      return [c.outlineStyle, c.borderColor, c.backgroundColor, c.color,
+        c.boxShadow, c.textDecorationLine, c.textDecorationThickness].join('|');
+    };
+    return [...document.querySelectorAll(sel)].map((el, i) => {
+      el.dataset.focusProbe = String(i);
+      return { i, name: [...el.classList].find((c) => c.startsWith('login-page')) || el.tagName, paint: paint(el) };
+    });
+  }, FOCUSABLE);
+
+  const lit = new Set();
+  for (let press = 0; press < resting.length * 3; press += 1) {
+    await page.keyboard.press('Tab');
+    const hit = await page.evaluate(async () => {
+      const el = document.activeElement;
+      if (!(el instanceof HTMLElement) || el.dataset.focusProbe === undefined) return null;
+      await new Promise((r) => setTimeout(r, 300));
+      const c = getComputedStyle(el);
+      return {
+        i: Number(el.dataset.focusProbe),
+        paint: [c.outlineStyle, c.borderColor, c.backgroundColor, c.color,
+          c.boxShadow, c.textDecorationLine, c.textDecorationThickness].join('|'),
+      };
+    });
+    if (hit && hit.paint !== resting[hit.i].paint) lit.add(hit.i);
+  }
+
+  return {
+    walked: resting.length,
+    dark: resting.filter((r) => !lit.has(r.i)).map((r) => r.name),
+  };
+}
+
+test.describe('a field on the auth surface', () => {
+  test('keeps the ember for a keyboard and the muted halo for a mouse', async ({ page }) => {
+    await emailView(page);
+    await page.locator(EMAIL).click();
+    const clicked = await paintOn(page, EMAIL);
+    expect(clicked.focused).toBe(true);
+    // Unpainted rather than absent: the app-wide suppression outranks this
+    // page's own `outline: none` and leaves a transparent outline behind, so
+    // forced colors has something to repaint. Nothing shows either way.
+    expect(unpainted(clicked.outline, clicked.outlineColor)).toBe(true);
+
+    await emailView(page);
+    await tabTo(page, EMAIL);
+    const tabbed = await paintOn(page, EMAIL);
+    expect(tabbed.focused).toBe(true);
+    expect(unpainted(tabbed.outline, tabbed.outlineColor)).toBe(true);
+
+    // The ember is the whole point of the keyboard case, and the click has to
+    // land somewhere other than the ember rather than nowhere at all.
+    expect(tabbed.border).not.toBe(clicked.border);
+    expect(tabbed.shadow).not.toBe(clicked.shadow);
+    expect(clicked.shadow).not.toBe('none');
+  });
+});
+
+test.describe('a button or link on the auth surface', () => {
+  test('wears no ring, whichever device brought focus', async ({ page }) => {
+    await emailView(page);
+    await tabTo(page, SUBMIT);
+    expect((await outlineOn(page, SUBMIT)).style).toBe('none');
+
+    // A control the mouse pressed should not light at all. The password toggle
+    // is the one button here that can be clicked without leaving the view.
+    await page.locator(TOGGLE).click();
+    const clicked = await paintOn(page, TOGGLE);
+    expect(clicked.focused).toBe(true);
+    expect(unpainted(clicked.outline, clicked.outlineColor)).toBe(true);
+    expect(clicked.background).toMatch(/^rgba\(0, 0, 0, 0\)$|^transparent$/);
+  });
+});
+
+/**
+ * The rule that makes these pass is a default rather than a list of the
+ * controls that opted in, so a control added later is wrong-looking at worst.
+ * Without it the failure is silent: no ring, no replacement, and nothing on
+ * screen to say where the keyboard is.
+ */
+test.describe('every view of the auth surface', () => {
+  const VIEWS = [
+    { name: 'the method list', open: methodView, least: 6 },
+    { name: 'the email form', open: emailView, least: 5 },
+    { name: 'the check-inbox screen', open: inboxView, least: 3 },
+  ];
+
+  for (const { name, open, least } of VIEWS) {
+    test(`lights every focusable on ${name}`, async ({ page }) => {
+      await open(page);
+      const { walked, dark } = await darkAfterTabWalk(page);
+      // A view that stopped rendering its controls would otherwise pass with
+      // an empty walk.
+      expect(walked).toBeGreaterThanOrEqual(least);
+      expect(dark).toEqual([]);
+    });
+  }
+
+  test('lights the resend button, once its cooldown lets it be focused', async ({ page }) => {
+    // Resend opens disabled for the minute the send rate limit lasts, so the
+    // walk above skips it and it is the one control of this surface no view
+    // covers. Run the minute out rather than leave the gap: it is a boxed
+    // control, and boxed controls are exactly the ones whose focus treatment
+    // turns the default underline off and replaces it.
+    await page.clock.install();
+    await inboxView(page);
+
+    // One second at a time, not one jump: the countdown re-arms its timer from
+    // an effect, so the next tick does not exist yet when the current one
+    // fires. A single fastForward finds one timer and lands on 59.
+    const resend = page.locator('.login-page__resend-btn');
+    for (let tick = 0; tick < 90 && await resend.isDisabled(); tick += 1) {
+      await page.clock.runFor(1000);
+    }
+    await expect(resend).toBeEnabled();
+
+    const { dark } = await darkAfterTabWalk(page);
+    expect(dark).toEqual([]);
+  });
+});
+
+/**
+ * With forced colors on, everything this surface focuses with is gone: the OS
+ * re-paints backgrounds and borders from its own palette, and box-shadow is
+ * dropped outright. The underline survives, but the boxed controls are the
+ * ones that switch it off. So the outline the page suppresses everywhere else
+ * has to come back here, and only here.
+ */
+test.describe('the auth surface under forced colors', () => {
+  // Emulated per page rather than declared with `test.use`: the context-level
+  // option leaves `(forced-colors: active)` unmatched in this browser, so the
+  // block under test would never be evaluated and the assertion would fail for
+  // a reason that has nothing to do with the CSS.
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ forcedColors: 'active' });
+  });
+
+  test('gives the boxed controls an outline back', async ({ page }) => {
+    await methodView(page);
+    await tabTo(page, '.login-page__method-btn--primary');
+    expect((await outlineOn(page, '.login-page__method-btn--primary')).style).toBe('solid');
+
+    await emailView(page);
+    await tabTo(page, SUBMIT);
+    expect((await outlineOn(page, SUBMIT)).style).toBe('solid');
+  });
+});

--- a/web/e2e/auth-surface.focus.spec.js
+++ b/web/e2e/auth-surface.focus.spec.js
@@ -205,6 +205,12 @@ test.describe('every view of the auth surface', () => {
     // One second at a time, not one jump: the countdown re-arms its timer from
     // an effect, so the next tick does not exist yet when the current one
     // fires. A single fastForward finds one timer and lands on 59.
+    //
+    // `install()` makes the clock steerable, it does not stop it -- `pauseAt`
+    // is what freezes time. Measured: a 300ms setTimeout inside the page still
+    // resolves in 300ms after installing. So the waits further down this file
+    // are unaffected, and real time alone is still far too slow to walk out a
+    // 60s cooldown inside a 30s test, which is what runFor is for.
     const resend = page.locator('.login-page__resend-btn');
     for (let tick = 0; tick < 90 && await resend.isDisabled(); tick += 1) {
       await page.clock.runFor(1000);

--- a/web/e2e/focus-ring.spec.js
+++ b/web/e2e/focus-ring.spec.js
@@ -17,6 +17,7 @@
  * balance: they are the thing most at risk.
  */
 import { test, expect, mockAPI } from './fixtures.js';
+import { keyboardFocus, outlineOn, tabTo, unpainted } from './helpers/focusPaint.js';
 
 // The account button in the sidebar footer, chosen because it is a plain
 // DropdownMenu over the shared ui/ wrapper -- whatever is true here is true of
@@ -156,20 +157,6 @@ async function mountChartFixture(page, chart, bar) {
 }
 
 /** What is focused right now, and the outline actually computed on it. */
-async function focused(page) {
-  return page.evaluate(() => {
-    const el = document.activeElement;
-    const cs = getComputedStyle(el);
-    return {
-      tag: el.tagName,
-      tabindex: el.getAttribute('tabindex'),
-      style: cs.outlineStyle,
-      width: cs.outlineWidth,
-      color: cs.outlineColor,
-    };
-  });
-}
-
 test.describe('a chart clicked with the mouse', () => {
   test.beforeEach(async ({ page }) => {
     await mountChartFixture(page, CHART, BAR_BOX);
@@ -177,7 +164,7 @@ test.describe('a chart clicked with the mouse', () => {
 
   test('leaves no ring on the layer a click on a bar lands in', async ({ page }) => {
     await page.locator(BAR).click();
-    const el = await focused(page);
+    const el = await outlineOn(page);
     // If this is the surface, the fixture stopped reproducing the real bug.
     expect({ tag: el.tag, tabindex: el.tabindex }).toEqual({ tag: 'g', tabindex: '-1' });
     // `auto` is the UA ring, in a blue this product uses nowhere.
@@ -186,7 +173,7 @@ test.describe('a chart clicked with the mouse', () => {
 
   test('leaves no ring on the surface a click on empty plot space lands in', async ({ page }) => {
     await page.mouse.click(EMPTY_PLOT.x, EMPTY_PLOT.y);
-    const el = await focused(page);
+    const el = await outlineOn(page);
     expect(el.tag).toBe('svg');
     expect(el.style).toBe('none');
   });
@@ -201,15 +188,191 @@ test.describe('a chart reached by keyboard', () => {
     await page.locator(BEFORE).focus();
     await page.keyboard.press('Tab');
 
-    const surface = await focused(page);
+    const surface = await outlineOn(page);
     expect(surface.tag).toBe('svg');
     expect(surface.style).toBe('solid');
 
     await page.locator(PLAIN).focus();
-    const plain = await focused(page);
+    const plain = await outlineOn(page);
     expect(plain.style).toBe('solid');
     // One baseline rule serves both; drift here means a chart grew its own.
     expect(surface.color).toBe(plain.color);
     expect(surface.width).toBe(plain.width);
+  });
+});
+
+/**
+ * The text-field half. A text field is the one control the browser always
+ * matches :focus-visible on, a mouse click included: the heuristic exists so a
+ * field about to receive typing looks focused, and it is spec behaviour, not a
+ * quirk. So the baseline ring reached all 33 raw inputs the moment their
+ * `outline-none` came off, and a click drew a ring the same click on a button
+ * would not. No selector can separate those two cases, which is why the fix
+ * stamps how focus arrived and why this file is the only place it is visible.
+ *
+ * The keyboard cases below are again the ones most at risk: suppressing the
+ * ring on every text field would satisfy every mouse assertion here and leave
+ * a keyboard user with a caret for an indicator.
+ */
+const SEARCH = '.dashboard-search-input';
+const COMPOSER = '.chat-input-container textarea';
+const WORKSPACE_SEARCH = 'input[placeholder="Search workspaces..."]';
+// The pill around the Workspaces field: the field fills it, so the ring goes on
+// the container. See the `rings-within` block at the bottom of this file.
+const WORKSPACE_PILL = `.rings-within:has(> ${WORKSPACE_SEARCH})`;
+// The name field of the Create Workspace modal: a call site of the shared
+// ui/ Input, which drew a ring of its own rather than the baseline.
+const SHARED_INPUT = '.cwm-modal .cwm-field input';
+
+/**
+ * One row per kind of text field in the app; `open` is how to get to it, and
+ * `rings` names the element the indicator lands on when it is not the field.
+ */
+const CLICKED = [
+  { field: 'the dashboard search box', sel: SEARCH },
+  { field: 'the chat composer', sel: COMPOSER },
+  {
+    field: 'the Workspaces search box',
+    sel: WORKSPACE_SEARCH,
+    rings: WORKSPACE_PILL,
+    open: (page) => page.goto('/chat'),
+  },
+  {
+    // The shared primitive is the other half of the app's text fields: it drew
+    // its own `focus-visible:ring-2` rather than the baseline, on the same
+    // always-on pseudo-class, so it rang on a click for its own reasons.
+    field: 'a shared ui/ Input',
+    sel: SHARED_INPUT,
+    open: async (page) => {
+      await page.goto('/chat');
+      await page.getByRole('button', { name: /new workspace/i }).first().click();
+    },
+  },
+];
+
+test.describe('a text field clicked with the mouse', () => {
+  for (const { field, sel, open } of CLICKED) {
+    test(`leaves no ring on ${field}`, async ({ page }) => {
+      if (open) await open(page);
+      const target = page.locator(sel);
+      await expect(target).toBeVisible();
+
+      // The resting paint is the reference, because "no ring" is not the same
+      // question as "no outline": half the app draws its ring as a Tailwind
+      // box-shadow, and `outline: none` cannot suppress one. Reading the shadow
+      // against its own resting value is what makes restoring a `ring-2` on
+      // this field fail here instead of passing quietly.
+      const resting = await outlineOn(page, sel);
+
+      await target.click();
+      const clicked = await outlineOn(page, sel);
+      expect(clicked.focused).toBe(true);
+      expect(unpainted(clicked.style, clicked.color)).toBe(true);
+      expect(clicked.shadow).toBe(resting.shadow);
+    });
+  }
+});
+
+test.describe('a text field reached by keyboard', () => {
+  // The mouse cases above are the ones a regression re-opens; these are the
+  // ones an over-eager fix closes. Suppressing the ring on every text field
+  // satisfies every assertion in the block above and leaves a keyboard user
+  // with a caret for an indicator, so each field family has to answer both.
+  for (const { field, sel, rings, open } of CLICKED) {
+    test(`rings ${field}`, async ({ page }) => {
+      if (open) await open(page);
+      await expect(page.locator(sel)).toBeVisible();
+      await keyboardFocus(page, sel);
+      expect(await outlineOn(page, sel)).toMatchObject({ focused: true });
+      expect(await outlineOn(page, rings ?? sel)).toMatchObject({ style: 'solid' });
+    });
+  }
+
+  test('wears the same ring as every other control', async ({ page }) => {
+    // The tab order is only complete once the route has mounted; walking it
+    // early wraps through a shorter ring and never arrives.
+    await expect(page.locator(SEARCH)).toBeVisible();
+    await tabTo(page, SEARCH);
+    const field = await outlineOn(page, SEARCH);
+    expect(field.style).toBe('solid');
+
+    // One baseline rule serves both; drift here means a field grew its own.
+    // The reference is a plain button rather than a control off the page:
+    // several draw their ring as an inset shadow instead (the account row
+    // does), and an outline of `none` would make this pass vacuously.
+    await page.evaluate(() => {
+      const plain = document.createElement('button');
+      plain.id = 'plain-text-reference';
+      plain.type = 'button';
+      plain.setAttribute('style', 'position:fixed;z-index:9999;top:8px;left:8px');
+      document.body.append(plain);
+    });
+    await page.locator('#plain-text-reference').evaluate((el) => el.focus());
+    const reference = await outlineOn(page);
+    expect(reference.style).toBe('solid');
+    expect(field.color).toBe(reference.color);
+    expect(field.width).toBe(reference.width);
+  });
+
+  test('still rings after the click that focused it is followed by typing', async ({ page }) => {
+    // The trap in gating on "last input device": typing is a keydown, so a
+    // global flag would light the ring under the user mid-sentence.
+    await page.click(SEARCH);
+    await page.keyboard.type('AAPL');
+    const typed = await outlineOn(page, SEARCH);
+    expect(typed.focused).toBe(true);
+    expect(unpainted(typed.style, typed.color)).toBe(true);
+  });
+
+  test('leaves an outline box for forced colors to repaint', async ({ page }) => {
+    // Forced colors repaints outlines out of the system palette, but it cannot
+    // paint one that was never drawn -- and it drops the box-shadow and
+    // normalizes the border that would otherwise mark a clicked field, so the
+    // outline is the last thing standing. Suppressing with `none` leaves a
+    // high-contrast user a caret and nothing else, which is why the rule writes
+    // a transparent 2px outline instead. Read from the computed style rather
+    // than under emulation: emulating the media query does not perform the
+    // colour substitution that makes the outline visible, so the substitution
+    // is the browser's half of the contract and this is ours.
+    await page.click(SEARCH);
+    const clicked = await outlineOn(page, SEARCH);
+    expect(clicked.style).toBe('solid');
+    expect(clicked.color).toMatch(/,\s*0\)$/);
+  });
+});
+
+/**
+ * A field that fills a bordered container has nowhere to put a ring of its own:
+ * an outline on the field alone cuts across the container's border and leaves
+ * the icon beside it outside the indicator. `rings-within` moves the ring onto
+ * the container, and has to carry the same device gate the field does -- which
+ * is the half a container rule is most likely to miss, since :focus-within has
+ * no :focus-visible counterpart to inherit it from.
+ */
+test.describe('a field whose container is the indicator', () => {
+  const PILL = WORKSPACE_PILL;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/chat');
+    await expect(page.getByPlaceholder('Search workspaces...')).toBeVisible();
+  });
+
+  test('rings the Workspaces pill when the field inside it is tabbed to', async ({ page }) => {
+    await keyboardFocus(page, `${PILL} > input`);
+    expect(await outlineOn(page, PILL)).toMatchObject({ style: 'solid' });
+  });
+
+  test('leaves the pill unringed on a click', async ({ page }) => {
+    const resting = await outlineOn(page, PILL);
+    await page.getByPlaceholder('Search workspaces...').click();
+    const clicked = await outlineOn(page, PILL);
+    expect(unpainted(clicked.style, clicked.color)).toBe(true);
+    expect(clicked.shadow).toBe(resting.shadow);
+  });
+
+  test('leaves the field itself unringed either way, so the two never stack', async ({ page }) => {
+    const field = `${PILL} > input`;
+    await keyboardFocus(page, field);
+    expect(await outlineOn(page, field)).toMatchObject({ focused: true, style: 'none' });
   });
 });

--- a/web/e2e/helpers/focusPaint.js
+++ b/web/e2e/helpers/focusPaint.js
@@ -1,0 +1,84 @@
+/**
+ * Reading the ring a control actually wears.
+ *
+ * jsdom paints no outlines, so a unit test cannot see any of this: whether a
+ * ring is there, what colour it is, and which device earned it only exist in a
+ * real browser under a real click. Shared by the specs that measure it.
+ */
+
+/**
+ * The outline painted on one control, plus enough identity to say which control
+ * answered. Defaults to whatever holds focus, since most questions here are
+ * about the focused element rather than a named one.
+ *
+ * `shadow` is here because an outline is only half of how this app draws a
+ * ring: a Tailwind `ring-*` utility is a box-shadow, which no outline property
+ * reports. Asserting `outline: none` alone would call a field clean while a
+ * ring was plainly painted on it, so the mouse assertions compare this too.
+ */
+export async function outlineOn(page, sel = ':focus') {
+  return page.evaluate((s) => {
+    const el = document.querySelector(s);
+    if (!el) throw new Error(`${s} is not on the page`);
+    const cs = getComputedStyle(el);
+    return {
+      tag: el.tagName,
+      tabindex: el.getAttribute('tabindex'),
+      focused: document.activeElement === el,
+      style: cs.outlineStyle,
+      width: cs.outlineWidth,
+      color: cs.outlineColor,
+      shadow: cs.boxShadow,
+    };
+  }, sel);
+}
+
+/**
+ * Is this outline invisible on screen? Two shapes mean the same thing to a
+ * viewer: no outline at all, and one painted in nothing. The second is what a
+ * rule writes when it has to leave forced colors something to repaint, so a
+ * check that only accepted `none` would read that as a ring coming back.
+ */
+export function unpainted(style, color) {
+  return style === 'none' || /,\s*0\)\s*$/.test(color);
+}
+
+/**
+ * Put focus on a control down the keyboard path, for the fields a Tab walk
+ * cannot reach cheaply -- one inside a modal, one at the end of a long route.
+ *
+ * A keystroke first, then a programmatic move. What decides the ring is the
+ * device recorded when focus last moved, and `focusin` fires for either kind of
+ * move, so this reaches the same state a Tab does. It does not prove the
+ * control is a tab stop; `tabTo` is what proves that, and one field exercises
+ * it so the tab order itself stays covered. ArrowDown rather than Escape or
+ * Tab: it clears the pointer flag without closing a modal or moving focus off
+ * the element under test.
+ */
+export async function keyboardFocus(page, sel) {
+  await page.keyboard.press('ArrowDown');
+  await page.locator(sel).evaluate((el) => {
+    // Blur first, or this is a no-op on a field something already autofocused
+    // -- the Create Workspace modal does -- and no focusin fires to re-read the
+    // device. A keyboard user arrives by a real focus move; so does this.
+    document.activeElement?.blur();
+    el.focus();
+  });
+}
+
+/**
+ * Walk the tab order until it lands on a control. A real Tab rather than a
+ * programmatic focus, because the two arrive by different paths and only one of
+ * them is what a keyboard user does.
+ */
+export async function tabTo(page, sel, max = 40) {
+  for (let i = 0; i < max; i += 1) {
+    await page.keyboard.press('Tab');
+    const there = await page.evaluate(
+      (s) => document.activeElement === document.querySelector(s),
+      sel,
+    );
+    if (there) return;
+  }
+  throw new Error(`the tab order never reached ${sel} in ${max} presses`);
+}

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -3,6 +3,10 @@ import { defineConfig } from '@playwright/test';
 // Use a dedicated port so E2E tests never collide with the user's dev server
 // on :5173 (which might have real Supabase env vars) or other local services.
 const E2E_PORT = 5176;
+// The auth surface only exists in platform mode, and the mode is fixed when the
+// dev server boots, not per test. So it gets a server of its own rather than a
+// flag some spec could flip.
+const E2E_AUTH_PORT = 5177;
 
 export default defineConfig({
   testDir: './e2e',
@@ -34,12 +38,35 @@ export default defineConfig({
       },
     },
     {
+      command: `npm run dev -- --port ${E2E_AUTH_PORT}`,
+      port: E2E_AUTH_PORT,
+      reuseExistingServer: false,
+      env: {
+        VITE_HOST_MODE: 'platform',
+        // Non-empty so lib/supabase.ts constructs its client and the login page
+        // renders. It resolves to nothing: the one spec that submits answers
+        // the send with a route handler, so no request leaves the browser.
+        VITE_SUPABASE_URL: 'https://example.supabase.co',
+        VITE_SUPABASE_PUBLISHABLE_KEY: 'e2e-placeholder-key',
+        VITE_API_BASE_URL: 'http://127.0.0.1:4100',
+      },
+    },
+    {
       command: 'node e2e/mock-sse-server.js',
       port: 4100,
       reuseExistingServer: !process.env.CI,
     },
   ],
   projects: [
-    { name: 'chromium', use: { browserName: 'chromium' } },
+    {
+      name: 'chromium',
+      testIgnore: /auth-surface\..*\.spec\.js/,
+      use: { browserName: 'chromium' },
+    },
+    {
+      name: 'auth-surface',
+      testMatch: /auth-surface\..*\.spec\.js/,
+      use: { browserName: 'chromium', baseURL: `http://127.0.0.1:${E2E_AUTH_PORT}` },
+    },
   ],
 });

--- a/web/src/components/model/ApiKeyInput.tsx
+++ b/web/src/components/model/ApiKeyInput.tsx
@@ -3,7 +3,6 @@ import { Eye, EyeOff, Check, X } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Loader } from "@/components/ui/loader"
-import { cn } from "@/lib/utils"
 
 export interface TestResult {
   success: boolean
@@ -104,7 +103,7 @@ export function ApiKeyInput({
             onChange={(e) => onChange(e.target.value)}
             onBlur={handleBlur}
             placeholder={maskedKey || "Paste your API key here"}
-            className={cn("pr-12 focus-visible:ring-offset-0", hasError && "focus-visible:ring-0")}
+            className="pr-12"
             style={
               hasError
                 ? { borderColor: "var(--color-loss)" }

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -6,7 +6,7 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
     <input
       type={type}
       className={cn(
-        "flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-base sm:text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-base sm:text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -26,7 +26,7 @@ export function ToggleSwitch({ checked, onChange, disabled, className, ariaLabel
       onClick={onChange}
       disabled={disabled}
       className={cn(
-        'relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none',
+        'relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out',
         className,
       )}
       style={{

--- a/web/src/components/ui/textarea.tsx
+++ b/web/src/components/ui/textarea.tsx
@@ -5,7 +5,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttribu
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}

--- a/web/src/components/ui/toast.tsx
+++ b/web/src/components/ui/toast.tsx
@@ -59,7 +59,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus-visible:ring-destructive",
       className
     )}
     {...props}
@@ -74,7 +74,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus-visible:ring-red-400",
       className
     )}
     toast-close=""

--- a/web/src/lib/inputModality.ts
+++ b/web/src/lib/inputModality.ts
@@ -12,6 +12,16 @@
 /** Held alone, a modifier is someone reaching for Cmd-Tab, not navigating. */
 const MODIFIERS = new Set(['Meta', 'Control', 'Alt', 'Shift']);
 
+/**
+ * Set on the document element while the focus the page currently holds arrived
+ * by pointer. `tokens.css` reads it to keep the ring off a text field the mouse
+ * focused -- the one control `:focus-visible` matches for either device, so a
+ * selector alone cannot tell a click from a Tab. One element holds focus at a
+ * time, so a single record says everything a mark on each element would, and
+ * leaves nothing behind on every field the mouse has ever touched.
+ */
+const POINTER_FOCUS = 'data-pointer-focus';
+
 let pointer = false;
 
 if (typeof window !== 'undefined') {
@@ -23,6 +33,15 @@ if (typeof window !== 'undefined') {
     (event) => {
       if (!MODIFIERS.has(event.key)) pointer = false;
     },
+    true,
+  );
+  // Written when focus moves rather than read at paint: typing into a field is
+  // a keydown, so a rule consulting the live flag would light a ring under the
+  // user mid-sentence. Freezing it here answers what the ring actually asks,
+  // which is how the control holding focus was reached.
+  window.addEventListener(
+    'focusin',
+    () => { document.documentElement.toggleAttribute(POINTER_FOCUS, pointer); },
     true,
   );
 }

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -921,8 +921,11 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
         <div className="flex-shrink-0 flex flex-col gap-4 pb-4 md:pb-6 px-1 enter-fade-up enter-fade-up-d1">
           {/* Search Bar */}
           <div className="w-full">
+            {/* The pill rings for the field inside it: a ring drawn on the
+                field alone would cut this border and leave the icon outside
+                the indicator. `rings-within` in tokens.css owns the rule. */}
             <div
-              className="flex items-center gap-2 h-11 px-3 rounded-xl border transition-colors"
+              className="rings-within flex items-center gap-2 h-11 px-3 rounded-xl border transition-colors"
               style={{
                 backgroundColor: 'var(--color-bg-input)',
                 borderColor: 'var(--color-border-muted)',

--- a/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
+++ b/web/src/pages/ChatAgent/components/charts/InlineChartAnnotationCard.tsx
@@ -55,6 +55,10 @@ const MarketChartSurface = lazy(() =>
 const TEXT_COLOR = 'var(--color-text-tertiary)';
 const ACCENT = 'var(--color-accent-primary)';
 const ACCENT_SOFT = 'var(--color-accent-soft)';
+const FOCUS_RING = 'var(--color-focus-ring)';
+
+const RESTING_SHADOW = '0 1px 2px rgba(0,0,0,0.05), 0 16px 36px -18px rgba(0,0,0,0.5)';
+const RAISED_SHADOW = '0 2px 6px rgba(0,0,0,0.06), 0 26px 50px -20px rgba(0,0,0,0.6)';
 
 // Centered overlay for the chart's loading / empty states.
 const CENTERED: React.CSSProperties = {
@@ -108,8 +112,11 @@ export function InlineChartAnnotationCard({
 
   // Stage-2 modal open state (standalone ChatAgent page only).
   const [open, setOpen] = useState(false);
-  // Card hover drives the CTA fill (glass → accent).
+  // The card lifts for either device; only a keyboard also gets a ring, since
+  // the rounded corners mean the outline is suppressed and drawn as a shadow.
   const [hover, setHover] = useState(false);
+  const [keyboardFocus, setKeyboardFocus] = useState(false);
+  const raised = hover || keyboardFocus;
 
   // Resting-card price preview: cached bars for this symbol/timeframe. Skipped
   // inside MarketView (chartPresent) where the card collapses to a chip.
@@ -252,47 +259,30 @@ export function InlineChartAnnotationCard({
             setOpen(true);
           }
         }}
-        onMouseEnter={(e) => {
-          setHover(true);
-          e.currentTarget.style.borderColor = ACCENT;
-          e.currentTarget.style.transform = 'translateY(-2px)';
-          e.currentTarget.style.boxShadow =
-            '0 2px 6px rgba(0,0,0,0.06), 0 26px 50px -20px rgba(0,0,0,0.6)';
-        }}
-        onMouseLeave={(e) => {
-          setHover(false);
-          e.currentTarget.style.borderColor = CARD_BORDER;
-          e.currentTarget.style.transform = 'none';
-          e.currentTarget.style.boxShadow =
-            '0 1px 2px rgba(0,0,0,0.05), 0 16px 36px -18px rgba(0,0,0,0.5)';
-        }}
-        // Keyboard focus needs a visible ring (outline is suppressed for the
-        // rounded card). Gate on :focus-visible so a mouse click stays clean.
-        onFocus={(e) => {
-          if (!e.currentTarget.matches(':focus-visible')) return;
-          setHover(true);
-          e.currentTarget.style.borderColor = ACCENT;
-          e.currentTarget.style.transform = 'translateY(-2px)';
-          e.currentTarget.style.boxShadow =
-            `0 0 0 2px ${ACCENT}, 0 2px 6px rgba(0,0,0,0.06), 0 26px 50px -20px rgba(0,0,0,0.6)`;
-        }}
-        onBlur={(e) => {
-          setHover(false);
-          e.currentTarget.style.borderColor = CARD_BORDER;
-          e.currentTarget.style.transform = 'none';
-          e.currentTarget.style.boxShadow =
-            '0 1px 2px rgba(0,0,0,0.05), 0 16px 36px -18px rgba(0,0,0,0.5)';
-        }}
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+        // :focus-visible is the only thing that answers whether a keyboard
+        // brought focus here; the ring stays off a click. The colour is the
+        // shared focus token rather than the accent, which reads as selected.
+        onFocus={(e) => setKeyboardFocus(e.currentTarget.matches(':focus-visible'))}
+        onBlur={() => setKeyboardFocus(false)}
         style={{
           position: 'relative',
           background: CARD_BG,
-          border: `1px solid ${CARD_BORDER}`,
+          border: `1px solid ${keyboardFocus ? FOCUS_RING : raised ? ACCENT : CARD_BORDER}`,
           borderRadius: 20,
           overflow: 'hidden',
           cursor: 'pointer',
-          outline: 'none',
+          // The ring is a shadow, because the card's 20px corners want one that
+          // follows them. Forced colors drops shadows, so the keyboard state
+          // also carries a transparent outline: invisible here, painted in the
+          // system's focus color there, and the only indicator left in it.
+          outline: keyboardFocus ? '2px solid transparent' : 'none',
           userSelect: 'none',
-          boxShadow: '0 1px 2px rgba(0,0,0,0.05), 0 16px 36px -18px rgba(0,0,0,0.5)',
+          transform: raised ? 'translateY(-2px)' : 'none',
+          boxShadow: keyboardFocus
+            ? `0 0 0 2px ${FOCUS_RING}, ${RAISED_SHADOW}`
+            : raised ? RAISED_SHADOW : RESTING_SHADOW,
           transition: 'border-color 0.16s, box-shadow 0.16s, transform 0.16s',
         }}
       >
@@ -493,7 +483,7 @@ export function InlineChartAnnotationCard({
             </div>
           )}
 
-          {/* Bottom-right — CTA (glass → accent on hover). */}
+          {/* Bottom-right — CTA (glass → accent whenever the card is raised). */}
           <span
             style={{
               position: 'absolute',
@@ -507,16 +497,16 @@ export function InlineChartAnnotationCard({
               padding: '9px 15px',
               borderRadius: 11,
               backdropFilter: 'blur(8px)',
-              background: hover ? ACCENT : GLASS_BG,
-              border: `1px solid ${hover ? 'transparent' : GLASS_BORDER}`,
-              color: hover ? '#fff' : 'var(--color-text-primary)',
+              background: raised ? ACCENT : GLASS_BG,
+              border: `1px solid ${raised ? 'transparent' : GLASS_BORDER}`,
+              color: raised ? '#fff' : 'var(--color-text-primary)',
               transition: 'background 0.16s, color 0.16s, border-color 0.16s',
             }}
           >
             {t('chat.chartAnnotationCard.openAnnotatedChart')}
             <ArrowRight
               size={14}
-              style={{ transform: hover ? 'translateX(3px)' : 'none', transition: 'transform 0.16s' }}
+              style={{ transform: raised ? 'translateX(3px)' : 'none', transition: 'transform 0.16s' }}
             />
           </span>
         </div>

--- a/web/src/pages/Dashboard/widgets/definitions/NewsFeedWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/NewsFeedWidget.tsx
@@ -358,7 +358,7 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
 
       <div className="flex items-center gap-2 mb-3 flex-wrap">
         <div
-          className="flex items-center gap-1.5 h-7 px-2 rounded-md border"
+          className="rings-within flex items-center gap-1.5 h-7 px-2 rounded-md border"
           style={{
             backgroundColor: 'var(--color-bg-subtle)',
             borderColor: 'var(--color-border-muted)',
@@ -372,7 +372,7 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
             placeholder={t('dashboard.widgets.newsFeed.tickerPlaceholder')}
             value={tickerFilter}
             onChange={(e) => setTickerFilter(e.target.value)}
-            className="flex-1 text-[0.6875rem] bg-transparent border-none outline-none focus-visible:ring-1 focus-visible:ring-ring min-w-0"
+            className="flex-1 text-[0.6875rem] bg-transparent border-none min-w-0"
             style={{ color: 'var(--color-text-primary)' }}
           />
           {tickerFilter ? (
@@ -417,7 +417,7 @@ function NewsFeedWidget({ instance, updateConfig }: WidgetRenderProps<NewsFeedCo
             value={sourceFilter}
             onChange={(e) => setSourceFilter(e.target.value)}
             aria-label={t('dashboard.widgets.newsFeed.sourceLabel')}
-            className="h-7 px-2 rounded-md border text-[0.6875rem] outline-none focus-visible:ring-1 focus-visible:ring-ring cursor-pointer max-w-[140px]"
+            className="h-7 px-2 rounded-md border text-[0.6875rem] cursor-pointer max-w-[140px]"
             style={{
               backgroundColor: 'var(--color-bg-subtle)',
               borderColor: 'var(--color-border-muted)',

--- a/web/src/pages/Dashboard/widgets/framework/settings/SymbolListField.tsx
+++ b/web/src/pages/Dashboard/widgets/framework/settings/SymbolListField.tsx
@@ -97,7 +97,7 @@ export function SymbolListField({
         {label}
       </span>
       <div
-        className="flex flex-wrap gap-1.5 p-1.5 rounded border"
+        className="rings-within flex flex-wrap gap-1.5 p-1.5 rounded border"
         style={{
           backgroundColor: 'var(--color-bg-card)',
           borderColor: 'var(--color-border-default)',
@@ -137,7 +137,7 @@ export function SymbolListField({
                 ? placeholder ?? t('dashboard.widgets.settings.symbolListPlaceholder')
                 : ''
           }
-          className="flex-1 min-w-[100px] border-0 !p-0 !h-6 text-xs bg-transparent shadow-none focus-visible:ring-0 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex-1 min-w-[100px] border-0 !p-0 !h-6 text-xs bg-transparent shadow-none disabled:opacity-50 disabled:cursor-not-allowed"
           style={{
             color: 'var(--color-text-primary)',
             textTransform: 'uppercase',

--- a/web/src/pages/Login/LoginPage.css
+++ b/web/src/pages/Login/LoginPage.css
@@ -146,10 +146,13 @@
   box-shadow: 0 0 0 3px var(--color-border-muted);
 }
 
-/* Keyboard/assistive focus only (:focus-visible never matches mouse clicks):
-   trade the muted halo for the ember so tab position is unmissable. The extra
-   .login-page ancestor outranks the shared Input's Tailwind focus-visible ring. */
-.login-page .login-page__input:focus-visible {
+/* Keyboard/assistive focus only: trade the muted halo above for the ember, so
+   tab position is unmissable. :focus-visible alone does not mean keyboard on a
+   text field -- the browser matches it for a mouse click too, so that a field
+   about to receive typing looks focused -- and the ember fired on every click
+   here for as long as this rule has existed. The origin lib/inputModality.ts
+   stamps is what actually separates the two: a click keeps the muted halo. */
+:root:not([data-pointer-focus]) .login-page__input:focus-visible {
   border-color: var(--login-ember);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--login-ember) 35%, transparent);
 }
@@ -202,12 +205,77 @@
   transform: none;
 }
 
-/* Keyboard focus takes the ember, not the browser default. Mouse focus on
-   inputs keeps the soft halo; their keyboard ring lives with the input rules. */
+/* No ring on this surface's buttons and links. Keyboard focus prints ember
+   instead -- the color this page already reserves for a control that is about
+   to act. Clearing the outline is not optional here: without it the app-wide
+   baseline ring paints in a color this page uses nowhere. Nor is replacing it,
+   since suppressing both would leave the sign-in page with nothing for a
+   keyboard to follow.
+
+   Ember separates from the resting greys by hue more than by luminance, so it
+   carries under 3:1 and a red-green deficiency can flatten it. Every control
+   therefore gets a second signal that still reads with the hue taken out: a
+   heavy underline by default, a fill where there was none on the primary
+   buttons, a doubled edge on the secondary ones, a tinted pad behind the icon
+   toggle.
+
+   The quiet treatment is the default rather than a list of the controls that
+   want it, so a control added later is wrong-looking at worst instead of
+   silently unfocusable. Hover stays ink, so the two states still read apart.
+   Field focus is separate; its halo lives with the input rules above. */
 .login-page button:focus-visible,
 .login-page a:focus-visible {
-  outline: 2px solid var(--login-ember);
-  outline-offset: 2px;
+  outline: none;
+  color: var(--login-ember);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+
+/* A boxed control has somewhere better to put it than its own label. The inset
+   shadow doubles the border it already wears rather than adding a second ring
+   outside it: a 1px edge going to 2px is the geometry change the underline
+   provides elsewhere, and it lands inside the button's own box, so the row of
+   method buttons does not shift as focus walks it. */
+.login-page__method-btn:focus-visible:not(:disabled),
+.login-page__resend-btn:focus-visible:not(:disabled) {
+  border-color: var(--login-ember);
+  box-shadow: inset 0 0 0 1px var(--login-ember);
+  color: var(--color-text-primary);
+  text-decoration: none;
+}
+
+.login-page__submit:focus-visible:not(:disabled),
+.login-page__method-btn--primary:focus-visible:not(:disabled) {
+  background: var(--login-ember);
+  border-color: var(--login-ember);
+  color: var(--color-bg-page);
+  text-decoration: none;
+}
+
+/* An icon has no text to underline, so its second signal is a tint behind it. */
+.login-page__password-toggle:focus-visible {
+  background: color-mix(in srgb, var(--login-ember) 16%, transparent);
+  border-radius: 0.5rem;
+}
+
+/* Forced colors takes all of the above apart. Backgrounds and borders are
+   re-painted from the OS palette, so the ember fill and the ember edge stop
+   distinguishing a focused button from a resting one, and box-shadow is
+   dropped outright, which is the doubled edge and the field halo. The
+   underline survives -- but the boxed controls are exactly the ones that turn
+   it off. What else survives is the outline this page went out of its way to
+   clear, so put that back for this mode, with no color of its own so the
+   system supplies its focus color, and ungated by device: someone who asked
+   the OS for maximum contrast is the last person to leave without an
+   indicator on a click. */
+@media (forced-colors: active) {
+  .login-page button:focus-visible,
+  .login-page a:focus-visible,
+  .login-page__input:focus-visible {
+    outline: 2px solid;
+    outline-offset: 2px;
+  }
 }
 
 .login-page__legal {

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -433,6 +433,78 @@ html {
     outline-offset: 2px;
   }
 
+  /* A text field is the one control the browser matches :focus-visible on for
+     either device. The heuristic is deliberate -- a field about to receive
+     typing has to look focused -- but it means the rule above rings a field
+     the mouse just clicked, where the same click on a button rings nothing.
+     No selector separates the two, so lib/inputModality.ts records how focus
+     arrived and this reads it back. A field the mouse focused keeps the caret
+     and its own border change; a Tab still brings the ring.
+
+     Spelled out type by type because the exemption has to be the narrow set
+     where every key is typing. A checkbox, a range, a number spinner and a
+     date field all take keys that are *commands*, and Chromium starts matching
+     :focus-visible the moment one arrives -- while this record still says
+     pointer, because focus never moved and no focusin fired. Written as
+     `input` those controls go dark under the user's own first keystroke.
+     Anything left off this list keeps a ring on a click, which is the mild
+     half of the trade.
+
+     Transparent rather than `none`, which is not a stylistic choice: forced
+     colors repaints every outline in the system palette but cannot paint one
+     that was never drawn, and it drops the box-shadow and normalizes the
+     border a field would otherwise be distinguished by. `none` here leaves a
+     high-contrast user with a clicked field marked by nothing but the caret.
+     A transparent outline is invisible everywhere else and becomes the
+     system's own focus color there -- the same reason Tailwind's
+     `outline-none` compiles to this and not to `outline: none`. */
+  :root[data-pointer-focus] :is(
+    textarea,
+    [contenteditable],
+    input:not([type]),
+    input[type="text"],
+    input[type="email"],
+    input[type="password"],
+    input[type="search"],
+    input[type="tel"],
+    input[type="url"]
+  ):focus-visible {
+    outline: 2px solid transparent;
+  }
+
+  /* A field that fills a bordered container has nowhere to put a ring of its
+     own. An outline on the field alone cuts across the container's border and
+     leaves whatever else lives in there outside the indicator: the icon on a
+     search pill, the chips already entered on a token field. Mark the container
+     and it rings on the field's behalf.
+
+     Scoped to a direct-child input so a button sharing the container -- a clear
+     affordance, a chip's remove -- still rings itself instead of lighting the
+     whole box. Gated like the rule above and for the same reason: the field
+     inside matches :focus-visible for either device, so ungated this would
+     light the container on a click.
+
+     All three sit behind @supports because only the first of them survives a
+     parser without :has(): taking the ring off the field is a plain selector,
+     while the two rules that put it on the container are dropped as invalid.
+     Split, the fallback is not a ring in the wrong place, it is no ring at
+     all. Together they degrade to the baseline, which rings the field. */
+  @supports selector(:has(*)) {
+    .rings-within > input:focus-visible {
+      outline: none;
+    }
+
+    .rings-within:has(> input:focus-visible) {
+      outline: 2px solid var(--color-focus-ring);
+      outline-offset: 2px;
+    }
+
+    /* Transparent for the reason the field rule above is. */
+    :root[data-pointer-focus] .rings-within:has(> input:focus-visible) {
+      outline: 2px solid transparent;
+    }
+  }
+
   /* Inside an SVG, Chromium paints its own ring on plain :focus -- it does not
      gate that on :focus-visible the way it does for HTML, so a mouse click on
      a chart draws a ring where the same click on a button would not. Take the


### PR DESCRIPTION
## Overview

|  | Files | + | − |
|---|---:|---:|---:|
| Total | 17 | 761 | 80 |
| Net (excl. tests) | 13 | 224 | 61 |

**By module**

| Path | Δ | What |
|---|---:|---|
| `src/styles/tokens.css` | +72 | The device gate on the baseline ring, and `rings-within` for a field that fills a container |
| `src/lib/inputModality.ts` | +19 | Stamps `data-pointer-focus` on the document element when focus moves |
| `src/pages/Login/LoginPage.css` | +84/−8 | The sign-in page's own treatment, plus a forced-colors fallback |
| `src/components/ui/{input,textarea,switch,toast}.tsx` | +5/−5 | Retire four bespoke rings in favour of the baseline; `focus:` → `focus-visible:` on the toast controls |
| `WorkspaceGallery`, `NewsFeedWidget`, `SymbolListField`, `ApiKeyInput` | +9/−9 | Three pills ring as containers; one field gets its indicator back |
| `InlineChartAnnotationCard.tsx` | +32/−38 | One `raised` state in place of four inline style writers |
| `DESIGN.md` | +12 | Records the sign-in page as the one surface exempt from accent discipline |
| `e2e/` + `playwright.config.js` | +537/−19 | Two specs, a shared helper, and a second dev server in platform mode |

**What this introduces:** one document-level record of how the focus the page currently holds arrived, written on `focusin` and read by CSS. That is the only thing that separates a click from a Tab on a text field, and nothing in a component can see it.

## The bug

A text field is the one control the browser matches `:focus-visible` on for either device. The heuristic is deliberate and specified: a field about to receive typing has to look focused. So when the app grew a baseline ring, it reached all 33 raw inputs the moment their `outline-none` came off, and a click drew a ring the same click on a button would not.

No selector separates the two cases. `lib/inputModality.ts` already tracked the last input device for Radix; it now also stamps `data-pointer-focus` on `<html>` whenever focus moves, and `tokens.css` gates the suppression on it.

The record is written **when focus moves**, not read at paint time. Typing is a `keydown`, so a rule consulting the live flag would light a ring under the user mid-sentence. There is a test for exactly that.

## The exemption is spelled out type by type

```css
:root[data-pointer-focus] :is(
  textarea, [contenteditable],
  input:not([type]), input[type="text"], input[type="email"],
  input[type="password"], input[type="search"], input[type="tel"], input[type="url"]
):focus-visible { outline: none; }
```

Written as a bare `input` this is a defect. A checkbox, radio, range or number spinner takes keys that are *commands*, and Chromium starts matching `:focus-visible` the moment one arrives, while the record still says pointer because focus never moved and no `focusin` fired. Measured before the narrowing:

| Control | Interaction | Outline |
|---|---|---|
| checkbox | click, then Space | `none` |
| radio | click, then Space | `none` |
| range | click, then Arrow | `none` |
| checkbox / radio / range / number (after) | same | `solid 2px` |
| text field (after) | click, then type | `none` |

Anything left off the list keeps a ring on a click, which is the mild half of the trade.

## A field that fills a container

An outline on the field alone cuts across the container's border and leaves the icon beside it outside the indicator. `rings-within` puts the ring on the container, scoped to a direct-child input so a sibling button still rings itself, and gated the same way the field rule is. It replaces the amber `focus-within` on the Workspaces pill and the `focus-visible:ring-1` the news filter drew for itself, and gives the symbol-list field an indicator it never had.

## The sign-in page

The auth surface has no ring at all: keyboard focus prints in the ember the page already reserves for a control about to act. Ember separates from the resting greys by hue more than luminance, so every control also carries a signal that survives with the hue removed: a heavy underline by default, a fill on the primary buttons, a doubled edge on the secondary ones, a tinted pad behind the icon toggle. It is a default rather than a list of controls that opted in, so a control added later is wrong-looking at worst instead of silently unfocusable.

Forced colors takes all of that apart: backgrounds and borders come from the OS palette and `box-shadow` is dropped outright, and the boxed controls are exactly the ones that switch the underline off. That mode gets the outline back.

Amber as a button fill is something `DESIGN.md` forbids by name, and `--login-ember` is the accent hex itself. The page has carried the ember hover fill on its submit button for as long as it has existed, so the rule was already untrue there; rather than give this one surface a focus colour it uses nowhere else, `DESIGN.md` now records the exemption and what it costs, scoped to `.login-page`.

## Forced colors, everywhere else

Suppressing a ring with `outline: none` is not the same as suppressing it with a transparent one. Forced colors repaints outlines out of the system palette but cannot paint one that was never drawn, and it drops `box-shadow` and normalizes the border a field would otherwise be marked by, so `none` leaves a high-contrast user with the caret alone. Tailwind's `outline-none` compiles to `outline: 2px solid transparent` for exactly this reason, which means replacing it with `outline: none` would have made that mode worse than before this change rather than merely no better.

Every pointer suppression here writes the transparent outline instead, and the chart annotation card carries one on its keyboard-focus state, since its ring is a shadow that follows the card's corners.

## Verification

- `pnpm test` — 3251 passed (297 files)
- `pnpm test:e2e` focus specs — 28 passed, across both projects
- `pnpm typecheck`, `pnpm build` — clean; critical path 446.5 kB gz against a 450 kB ceiling
- `pnpm lint` — 0 errors, and the touched files carry no warnings

Three defects were found by the browser rather than by reading: a keyboard assertion that hard-coded the field as the indicator after the ring moved to its container; a resend button reported permanently dark because it opens disabled for its 60s rate-limit window; and `test.use({ forcedColors: 'active' })` never matching `(forced-colors: active)` in this browser, which failed the forced-colors test for a reason unrelated to the CSS.

## Risk

- **Every text field in the app changes what a mouse click paints.** The click keeps the caret and the field's own border or halo; the ring is now keyboard-only. That is the fix, but it is a visible change on every form.
- **`:has()` in `rings-within`.** Already used in `printExport.css`. All three rules sit behind `@supports selector(:has(*))`, because only the first survives a parser without it: taking the ring off the field is a plain selector, while the two that put it on the container are dropped as invalid. Split, the fallback is no ring at all; together they degrade to the baseline, which rings the field.
- **Three dashboard call sites are covered by the shared rule, not by a test of their own.** The Workspaces pill exercises `rings-within` in both directions; the news-filter and symbol-list pills have the same DOM shape and the same rule, verified by reading rather than by measurement.
- **The check-inbox spec intercepts the send.** It is the only spec here that submits anything; the route handler answers it, so no request leaves the browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved focus indicators across authentication, dashboard, chat, workspace, chart, and shared form controls.
  * Keyboard focus now receives clear visual treatment, while mouse-focused fields avoid unnecessary rings.
  * Focus styling is preserved in high-contrast and forced-color modes.
  * Improved focus behavior for grouped search fields, toggles, links, buttons, and toast actions.

* **Tests**
  * Added end-to-end coverage for keyboard navigation, focus visibility, pointer interactions, authentication flows, and forced-color support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->