### PR TITLE
refactor(models): refresh the model catalog and take ratings from Artificial Analysis

### DIFF
--- a/scripts/ops/calibrate_model_ratings.py
+++ b/scripts/ops/calibrate_model_ratings.py
@@ -251,7 +251,7 @@ def main() -> None:
 
     matched, unmatched, changes = [], [], 0
     print(f"basis={args.basis}  fields={','.join(sorted(write_fields))}\n")
-    print(f"{'model':30s} {'cur s/i':>7}  {'AA II':>6} {'AA tps':>7}  {'new s/i':>7}  AA row (effort matched)")
+    print(f"{'model':30s} {'cur s/i':>7}  {'AA II':>6} {'AA tps':>7}  {'new s/i':>7}  AA row ({args.basis})")
     print("-" * 100)
     for k in sorted(visible):
         cur = manifest[k]

--- a/scripts/ops/calibrate_model_ratings.py
+++ b/scripts/ops/calibrate_model_ratings.py
@@ -66,12 +66,7 @@ STOP_TOKENS = {"preview", "experimental", "exp"}
 # Models AA's language endpoint doesn't track (or tracks without throughput).
 # Hand-grounded from the cited sources; applied to every visible variant of the
 # base, and only for the fields present (so AA-derived fields survive otherwise).
-MANUAL = {
-    # GLM turbo throughput <- OpenRouter/Fireworks (~48-70 tok/s). 'turbo' is
-    # cheap/agentic, not high-throughput. Intelligence stays AA-derived.
-    "glm-5-turbo":  {"speed": 2, "ref": "OpenRouter ~48 / Fireworks 70 tok/s -> band 2"},
-    "glm-5v-turbo": {"speed": 2, "ref": "GLM-turbo family throughput ~48-70 tok/s"},
-}
+MANUAL: dict[str, dict] = {}
 
 
 def band(value: float, bands: list[tuple[float, int]]) -> int:

--- a/scripts/ops/calibrate_model_ratings.py
+++ b/scripts/ops/calibrate_model_ratings.py
@@ -52,8 +52,12 @@ MANIFEST = REPO / "src/llms/manifest/models.json"
 DEFAULT_ENV = REPO / ".env"
 
 # Frontier-calibrated bands. (lower_bound_inclusive, tier) high->low.
-INTEL_BANDS = [(56, 5), (49, 4), (42, 3), (35, 2), (0, 1)]   # <- AA intelligence index
-SPEED_BANDS = [(150, 5), (110, 4), (75, 3), (50, 2), (0, 1)]  # <- AA output tokens/sec
+# Placed in the GAPS of the observed distribution, not at round numbers: a
+# threshold sitting on top of a model flips that badge on the next AA refresh.
+# Intelligence has no clean cut above 50 (17 of 23 models fall in 51.5..63.1),
+# so band 5 stays crowded on purpose and 54 is only the widest gap available.
+INTEL_BANDS = [(54, 5), (49, 4), (42, 3), (35, 2), (0, 1)]   # <- AA intelligence index
+SPEED_BANDS = [(150, 5), (100, 4), (65, 3), (45, 2), (0, 1)]  # <- AA output tokens/sec
 
 # Our access/region/serving variants that map onto a base model's AA rating.
 VARIANT_SUFFIXES = (
@@ -68,6 +72,27 @@ STOP_TOKENS = {"preview", "experimental", "exp"}
 # base, and only for the fields present (so AA-derived fields survive otherwise).
 MANUAL: dict[str, dict] = {}
 
+# Our model key -> AA slug, where AA files a model under its research release
+# name and the vendor sells it under another. The opposite of a MANUAL entry:
+# it removes hand-set numbers by letting AA's own row reach the model.
+AA_SLUG_ALIASES = {
+    # DashScope's `qwen3.8-flash` is the productionised Qwen3.8-Flash-Next
+    # (same weights, 262k native context served extended to 1M).
+    "qwen3.8-flash": "qwen3-8-flash-next",
+}
+
+
+def _keep_inline_arrays(text: str, original: str) -> str:
+    """Re-collapse the short arrays the manifest hand-keeps on one line.
+
+    ``json.dumps`` expands every array, which would bury a values-only rewrite
+    under whitespace noise in the diff.
+    """
+    for m in re.finditer(r'^([ \t]*)"([^"]+)": (\[[^\[\]]*\])(,?)$', original, re.M):
+        indent, key, inline, comma = m.groups()
+        expanded = json.dumps(json.loads(inline), indent=2).replace("\n", "\n" + indent)
+        text = text.replace(f'{indent}"{key}": {expanded}{comma}', m.group(0))
+    return text
 
 def band(value: float, bands: list[tuple[float, int]]) -> int:
     for lo, tier in bands:
@@ -204,7 +229,9 @@ def main() -> None:
 
     aa = fetch_aa(get_key(args.env_file), use_cache=not args.no_cache)
     by_tokens: dict[frozenset[str], list[dict]] = {}
+    by_slug: dict[str, dict] = {}
     for m in aa:
+        by_slug[m["slug"]] = m
         for label in (m["slug"], m["name"]):
             by_tokens.setdefault(tokens(label), []).append(m)
 
@@ -223,7 +250,9 @@ def main() -> None:
     for k in sorted(visible):
         cur = manifest[k]
         cur_s, cur_i = cur.get("speed"), cur.get("intelligence")
-        rows = by_tokens.get(tokens(k)) or by_tokens.get(tokens(base_name(k)))
+        alias = by_slug.get(AA_SLUG_ALIASES.get(collapse_base(k), ""))
+        rows = [alias] if alias else (
+            by_tokens.get(tokens(k)) or by_tokens.get(tokens(base_name(k))))
         row = pick_row(rows, target_effort_rank(cur), args.basis) if rows else {}
         if not row:
             ov = overrides.get(k, {})
@@ -268,7 +297,8 @@ def main() -> None:
                 if f in ov and f in write_fields:
                     manifest[k][f] = ov[f]
         # Match the manifest's canonical format exactly so the diff is values-only.
-        MANIFEST.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+        rendered = json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
+        MANIFEST.write_text(_keep_inline_arrays(rendered, MANIFEST.read_text()))
         print(f"\nWROTE {MANIFEST} — fields={','.join(sorted(write_fields))}; "
               f"{len(matched)} AA models + {len(overrides)} manual-override variants")
     else:

--- a/scripts/ops/calibrate_model_ratings.py
+++ b/scripts/ops/calibrate_model_ratings.py
@@ -10,11 +10,17 @@ model-detail flyout:
 AA lists one row PER reasoning-effort per model (xhigh/high/medium/low/
 non-reasoning). Two ways to read an "intelligence" number off that:
 
-  --basis served  (default) pick the AA row whose effort matches how WE run the
-                  model (from manifest ``parameters``), nearest-effort fallback.
-                  Honest: gpt-5.4@medium rates below gpt-5.5, not tied to it.
-  --basis ceiling pick the highest-intelligence row. Simpler, but mid-tier
-                  "full" models look near-flagship.
+  --basis ceiling (default) pick the highest-intelligence row. Simpler, but
+                  mid-tier "full" models look near-flagship.
+  --basis served  pick the AA row whose effort matches how WE run the model
+                  (from manifest ``parameters``), nearest-effort fallback. The
+                  honest reading in principle, and not the default because the
+                  two rank functions below still disagree with the manifest:
+                  ``target_effort_rank`` never reads ``extra_body.reasoning_effort``
+                  and maps neither ``max`` nor ``none``, and ``aa_effort_rank``
+                  does not recognise a bare "(max)" suffix. Until those are
+                  fixed it silently falls back to the ceiling row, or worse,
+                  to a lower-effort one.
 
 The AA index spans the whole AA universe (~5..62 in v4); our manifest is all
 frontier models, so a global quantile collapses to 5. We bucket with
@@ -22,8 +28,8 @@ FRONTIER-CALIBRATED absolute thresholds (INTEL_BANDS / SPEED_BANDS) so a "5"
 always means the same thing and the lineup still spreads across 1-5.
 
 Usage:
-  python scripts/ops/calibrate_model_ratings.py                  # dry-run, served basis
-  python scripts/ops/calibrate_model_ratings.py --basis ceiling  # dry-run, ceiling
+  python scripts/ops/calibrate_model_ratings.py                  # dry-run, ceiling basis
+  python scripts/ops/calibrate_model_ratings.py --basis served   # dry-run, served
   python scripts/ops/calibrate_model_ratings.py --apply --fields intelligence
   python scripts/ops/calibrate_model_ratings.py --apply --fields intelligence,speed
   python scripts/ops/calibrate_model_ratings.py --no-cache       # force refetch
@@ -219,7 +225,7 @@ def pick_row(rows: list[dict], target: int | None, basis: str) -> dict:
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--apply", action="store_true", help="write models.json (default: dry-run)")
-    ap.add_argument("--basis", choices=("served", "ceiling"), default="served")
+    ap.add_argument("--basis", choices=("served", "ceiling"), default="ceiling")
     ap.add_argument("--fields", default="intelligence,speed",
                     help="comma list of fields to write on --apply")
     ap.add_argument("--no-cache", action="store_true")

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -589,6 +589,34 @@
     ],
     "reasoning_effort_default": "high"
   },
+  "deepseek-v4-flash-vision-exp": {
+    "model_id": "deepseek-v4-flash-vision-exp",
+    "provider": "deepseek",
+    "visible": true,
+    "speed": 3,
+    "intelligence": 3,
+    "context": 1000000,
+    "input_modalities": [
+      "text",
+      "image"
+    ],
+    "parameters": {
+      "max_tokens": 384000,
+      "thinking": {
+        "type": "enabled"
+      },
+      "output_config": {
+        "effort": "high"
+      }
+    },
+    "reasoning_efforts": [
+      "none",
+      "low",
+      "high",
+      "max"
+    ],
+    "reasoning_effort_default": "high"
+  },
   "glm-5.2": {
     "prompt_guidance": "lean",
     "model_id": "glm-5.2",

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -814,6 +814,35 @@
     ],
     "reasoning_effort_default": "xhigh"
   },
+  "qwen3.8-flash": {
+    "model_id": "qwen3.8-flash",
+    "provider": "dashscope",
+    "visible": true,
+    "speed": 5,
+    "intelligence": 4,
+    "context": 1000000,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf",
+      "video"
+    ],
+    "extra_body": {
+      "reasoning": {
+        "effort": "medium"
+      }
+    },
+    "reasoning_efforts": [
+      "none",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max"
+    ],
+    "reasoning_effort_default": "medium"
+  },
   "qwen3.7-plus": {
     "model_id": "qwen3.7-plus",
     "provider": "dashscope",
@@ -842,31 +871,6 @@
       "max"
     ],
     "reasoning_effort_default": "xhigh"
-  },
-  "qwen3.7-flash": {
-    "model_id": "qwen3.7-flash",
-    "provider": "dashscope",
-    "visible": true,
-    "speed": 5,
-    "intelligence": 3,
-    "context": 1000000,
-    "input_modalities": [
-      "text",
-      "image",
-      "pdf",
-      "video"
-    ],
-    "extra_body": {
-      "reasoning": {
-        "effort": "medium"
-      }
-    },
-    "reasoning_efforts": [
-      "none",
-      "minimal",
-      "medium"
-    ],
-    "reasoning_effort_default": "medium"
   },
   "qwen3.8-max-intl": {
     "prompt_guidance": "lean",
@@ -898,6 +902,35 @@
     ],
     "reasoning_effort_default": "xhigh"
   },
+  "qwen3.8-flash-intl": {
+    "model_id": "qwen3.8-flash",
+    "provider": "dashscope-intl",
+    "visible": true,
+    "speed": 5,
+    "intelligence": 4,
+    "context": 1000000,
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf",
+      "video"
+    ],
+    "extra_body": {
+      "reasoning": {
+        "effort": "medium"
+      }
+    },
+    "reasoning_efforts": [
+      "none",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max"
+    ],
+    "reasoning_effort_default": "medium"
+  },
   "qwen3.7-plus-intl": {
     "model_id": "qwen3.7-plus",
     "provider": "dashscope-intl",
@@ -926,31 +959,6 @@
       "max"
     ],
     "reasoning_effort_default": "xhigh"
-  },
-  "qwen3.7-flash-intl": {
-    "model_id": "qwen3.7-flash",
-    "provider": "dashscope-intl",
-    "visible": true,
-    "speed": 5,
-    "intelligence": 3,
-    "context": 1000000,
-    "input_modalities": [
-      "text",
-      "image",
-      "pdf",
-      "video"
-    ],
-    "extra_body": {
-      "reasoning": {
-        "effort": "medium"
-      }
-    },
-    "reasoning_efforts": [
-      "none",
-      "minimal",
-      "medium"
-    ],
-    "reasoning_effort_default": "medium"
   },
   "kimi-k3": {
     "prompt_guidance": "lean",

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -382,27 +382,6 @@
     ],
     "reasoning_effort_default": "medium"
   },
-  "gemini-3.1-flash-image": {
-    "model_id": "gemini-3.1-flash-image-preview",
-    "provider": "gemini",
-    "visible": true,
-    "speed": 5,
-    "intelligence": 3,
-    "context": 32000,
-    "input_modalities": [
-      "text",
-      "image"
-    ],
-    "parameters": {
-      "include_thoughts": true,
-      "thinking_level": "minimal"
-    },
-    "reasoning_efforts": [
-      "minimal",
-      "high"
-    ],
-    "reasoning_effort_default": "minimal"
-  },
   "gpt-oss-120b": {
     "model_id": "gpt-oss-120b",
     "provider": "vllm",

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -637,11 +637,7 @@
     ],
     "reasoning_efforts": [
       "none",
-      "minimal",
-      "low",
-      "medium",
       "high",
-      "xhigh",
       "max"
     ],
     "reasoning_effort_default": "max"
@@ -829,11 +825,7 @@
     ],
     "reasoning_efforts": [
       "none",
-      "minimal",
-      "low",
-      "medium",
       "high",
-      "xhigh",
       "max"
     ],
     "reasoning_effort_default": "max"

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -589,31 +589,6 @@
     ],
     "reasoning_effort_default": "high"
   },
-  "glm-5.1": {
-    "model_id": "glm-5.1",
-    "provider": "z-ai",
-    "visible": true,
-    "speed": 3,
-    "intelligence": 4,
-    "context": 200000,
-    "parameters": {
-      "max_tokens": 128000
-    },
-    "extra_body": {
-      "thinking": {
-        "type": "enabled",
-        "clear_thinking": false
-      }
-    },
-    "input_modalities": [
-      "text"
-    ],
-    "reasoning_efforts": [
-      "none",
-      "high"
-    ],
-    "reasoning_effort_default": "high"
-  },
   "glm-5.2": {
     "prompt_guidance": "lean",
     "model_id": "glm-5.2",
@@ -700,108 +675,6 @@
     ],
     "reasoning_effort_default": "max"
   },
-  "glm-5v-turbo": {
-    "model_id": "glm-5v-turbo",
-    "provider": "z-ai",
-    "visible": true,
-    "speed": 2,
-    "intelligence": 3,
-    "context": 200000,
-    "parameters": {
-      "max_tokens": 128000
-    },
-    "extra_body": {
-      "thinking": {
-        "type": "enabled",
-        "clear_thinking": false
-      }
-    },
-    "input_modalities": [
-      "text",
-      "image",
-      "pdf"
-    ],
-    "reasoning_efforts": [
-      "none",
-      "high"
-    ],
-    "reasoning_effort_default": "high"
-  },
-  "glm-5-turbo": {
-    "model_id": "glm-5-turbo",
-    "provider": "z-ai",
-    "visible": true,
-    "speed": 2,
-    "intelligence": 3,
-    "context": 200000,
-    "parameters": {
-      "max_tokens": 128000
-    },
-    "extra_body": {
-      "thinking": {
-        "type": "enabled",
-        "clear_thinking": false
-      }
-    },
-    "input_modalities": [
-      "text"
-    ],
-    "reasoning_efforts": [
-      "none",
-      "high"
-    ],
-    "reasoning_effort_default": "high"
-  },
-  "glm-5-turbo-cn": {
-    "model_id": "glm-5-turbo",
-    "provider": "z-ai-cn",
-    "visible": true,
-    "speed": 2,
-    "intelligence": 3,
-    "context": 200000,
-    "parameters": {
-      "max_tokens": 128000
-    },
-    "extra_body": {
-      "thinking": {
-        "type": "enabled",
-        "clear_thinking": false
-      }
-    },
-    "input_modalities": [
-      "text"
-    ],
-    "reasoning_efforts": [
-      "none",
-      "high"
-    ],
-    "reasoning_effort_default": "high"
-  },
-  "glm-5.1-cn": {
-    "model_id": "glm-5.1",
-    "provider": "z-ai-cn",
-    "visible": true,
-    "speed": 3,
-    "intelligence": 4,
-    "context": 200000,
-    "parameters": {
-      "max_tokens": 128000
-    },
-    "extra_body": {
-      "thinking": {
-        "type": "enabled",
-        "clear_thinking": false
-      }
-    },
-    "input_modalities": [
-      "text"
-    ],
-    "reasoning_efforts": [
-      "none",
-      "high"
-    ],
-    "reasoning_effort_default": "high"
-  },
   "glm-5.2-cn": {
     "prompt_guidance": "lean",
     "model_id": "glm-5.2",
@@ -887,33 +760,6 @@
       "max"
     ],
     "reasoning_effort_default": "max"
-  },
-  "glm-5v-turbo-cn": {
-    "model_id": "glm-5v-turbo",
-    "provider": "z-ai-cn",
-    "visible": true,
-    "speed": 2,
-    "intelligence": 3,
-    "context": 200000,
-    "parameters": {
-      "max_tokens": 128000
-    },
-    "extra_body": {
-      "thinking": {
-        "type": "enabled",
-        "clear_thinking": false
-      }
-    },
-    "input_modalities": [
-      "text",
-      "image",
-      "pdf"
-    ],
-    "reasoning_efforts": [
-      "none",
-      "high"
-    ],
-    "reasoning_effort_default": "high"
   },
   "minimax-m3": {
     "model_id": "MiniMax-M3",

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -646,6 +646,64 @@
     ],
     "reasoning_effort_default": "max"
   },
+  "glm-5.3": {
+    "prompt_guidance": "lean",
+    "model_id": "glm-5.3",
+    "provider": "z-ai",
+    "visible": true,
+    "speed": 3,
+    "intelligence": 5,
+    "context": 1000000,
+    "parameters": {
+      "max_tokens": 128000
+    },
+    "extra_body": {
+      "thinking": {
+        "type": "enabled",
+        "clear_thinking": false
+      },
+      "reasoning_effort": "max"
+    },
+    "input_modalities": [
+      "text"
+    ],
+    "reasoning_efforts": [
+      "low",
+      "high",
+      "max"
+    ],
+    "reasoning_effort_default": "max"
+  },
+  "glm-5.3-flash": {
+    "prompt_guidance": "lean",
+    "model_id": "glm-5.3-flash",
+    "provider": "z-ai",
+    "visible": true,
+    "speed": 4,
+    "intelligence": 4,
+    "context": 1000000,
+    "parameters": {
+      "max_tokens": 128000
+    },
+    "extra_body": {
+      "thinking": {
+        "type": "enabled",
+        "clear_thinking": false
+      },
+      "reasoning_effort": "max"
+    },
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "reasoning_efforts": [
+      "low",
+      "high",
+      "max"
+    ],
+    "reasoning_effort_default": "max"
+  },
   "glm-5v-turbo": {
     "model_id": "glm-5v-turbo",
     "provider": "z-ai",
@@ -776,6 +834,64 @@
       "medium",
       "high",
       "xhigh",
+      "max"
+    ],
+    "reasoning_effort_default": "max"
+  },
+  "glm-5.3-cn": {
+    "prompt_guidance": "lean",
+    "model_id": "glm-5.3",
+    "provider": "z-ai-cn",
+    "visible": true,
+    "speed": 3,
+    "intelligence": 5,
+    "context": 1000000,
+    "parameters": {
+      "max_tokens": 128000
+    },
+    "extra_body": {
+      "thinking": {
+        "type": "enabled",
+        "clear_thinking": false
+      },
+      "reasoning_effort": "max"
+    },
+    "input_modalities": [
+      "text"
+    ],
+    "reasoning_efforts": [
+      "low",
+      "high",
+      "max"
+    ],
+    "reasoning_effort_default": "max"
+  },
+  "glm-5.3-flash-cn": {
+    "prompt_guidance": "lean",
+    "model_id": "glm-5.3-flash",
+    "provider": "z-ai-cn",
+    "visible": true,
+    "speed": 4,
+    "intelligence": 4,
+    "context": 1000000,
+    "parameters": {
+      "max_tokens": 128000
+    },
+    "extra_body": {
+      "thinking": {
+        "type": "enabled",
+        "clear_thinking": false
+      },
+      "reasoning_effort": "max"
+    },
+    "input_modalities": [
+      "text",
+      "image",
+      "pdf"
+    ],
+    "reasoning_efforts": [
+      "low",
+      "high",
       "max"
     ],
     "reasoning_effort_default": "max"

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -805,7 +805,7 @@
       "pdf",
       "video"
     ],
-    "extra_body": {
+    "parameters": {
       "reasoning": {
         "effort": "xhigh"
       }
@@ -834,7 +834,7 @@
       "pdf",
       "video"
     ],
-    "extra_body": {
+    "parameters": {
       "reasoning": {
         "effort": "medium"
       }
@@ -863,7 +863,7 @@
       "pdf",
       "video"
     ],
-    "extra_body": {
+    "parameters": {
       "reasoning": {
         "effort": "xhigh"
       }
@@ -893,7 +893,7 @@
       "pdf",
       "video"
     ],
-    "extra_body": {
+    "parameters": {
       "reasoning": {
         "effort": "xhigh"
       }
@@ -922,7 +922,7 @@
       "pdf",
       "video"
     ],
-    "extra_body": {
+    "parameters": {
       "reasoning": {
         "effort": "medium"
       }
@@ -951,7 +951,7 @@
       "pdf",
       "video"
     ],
-    "extra_body": {
+    "parameters": {
       "reasoning": {
         "effort": "xhigh"
       }

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -5,7 +5,7 @@
     "provider": "openai",
     "display_name": "GPT-5.5",
     "visible": true,
-    "speed": 2,
+    "speed": 3,
     "intelligence": 5,
     "context": 400000,
     "input_modalities": [
@@ -34,7 +34,7 @@
     "provider": "openai",
     "display_name": "GPT-5.6 Sol",
     "visible": true,
-    "speed": 2,
+    "speed": 3,
     "intelligence": 5,
     "context": 1050000,
     "input_modalities": [
@@ -67,7 +67,7 @@
     "provider": "openai",
     "display_name": "GPT-5.6 Terra",
     "visible": true,
-    "speed": 3,
+    "speed": 4,
     "intelligence": 5,
     "context": 1050000,
     "input_modalities": [
@@ -131,7 +131,7 @@
     "model_id": "claude-fable-5",
     "provider": "anthropic",
     "visible": true,
-    "speed": 2,
+    "speed": 3,
     "intelligence": 5,
     "context": 1000000,
     "input_modalities": [
@@ -259,7 +259,7 @@
     "provider": "anthropic",
     "visible": true,
     "speed": 2,
-    "intelligence": 4,
+    "intelligence": 3,
     "context": 200000,
     "input_modalities": [
       "text",
@@ -288,7 +288,7 @@
     "provider": "anthropic",
     "visible": true,
     "speed": 3,
-    "intelligence": 2,
+    "intelligence": 1,
     "context": 200000,
     "input_modalities": [
       "text",
@@ -314,7 +314,7 @@
     "provider": "gemini",
     "visible": true,
     "speed": 4,
-    "intelligence": 5,
+    "intelligence": 3,
     "context": 1000000,
     "input_modalities": [
       "text",
@@ -338,7 +338,7 @@
     "provider": "gemini",
     "visible": true,
     "speed": 5,
-    "intelligence": 4,
+    "intelligence": 5,
     "context": 1000000,
     "input_modalities": [
       "text",
@@ -566,8 +566,8 @@
     "model_id": "deepseek-v4-flash",
     "provider": "deepseek",
     "visible": true,
-    "speed": 3,
-    "intelligence": 3,
+    "speed": 4,
+    "intelligence": 4,
     "context": 1000000,
     "input_modalities": [
       "text"
@@ -593,8 +593,8 @@
     "model_id": "deepseek-v4-flash-vision-exp",
     "provider": "deepseek",
     "visible": true,
-    "speed": 3,
-    "intelligence": 3,
+    "speed": 4,
+    "intelligence": 4,
     "context": 1000000,
     "input_modalities": [
       "text",
@@ -623,7 +623,7 @@
     "provider": "z-ai",
     "visible": true,
     "speed": 3,
-    "intelligence": 5,
+    "intelligence": 4,
     "context": 1000000,
     "parameters": {
       "max_tokens": 128000
@@ -678,8 +678,8 @@
     "model_id": "glm-5.3-flash",
     "provider": "z-ai",
     "visible": true,
-    "speed": 4,
-    "intelligence": 4,
+    "speed": 1,
+    "intelligence": 5,
     "context": 1000000,
     "parameters": {
       "max_tokens": 128000
@@ -709,7 +709,7 @@
     "provider": "z-ai-cn",
     "visible": true,
     "speed": 3,
-    "intelligence": 5,
+    "intelligence": 4,
     "context": 1000000,
     "parameters": {
       "max_tokens": 128000
@@ -764,8 +764,8 @@
     "model_id": "glm-5.3-flash",
     "provider": "z-ai-cn",
     "visible": true,
-    "speed": 4,
-    "intelligence": 4,
+    "speed": 1,
+    "intelligence": 5,
     "context": 1000000,
     "parameters": {
       "max_tokens": 128000
@@ -793,8 +793,8 @@
     "model_id": "MiniMax-M3",
     "provider": "minimax",
     "visible": true,
-    "speed": 1,
-    "intelligence": 4,
+    "speed": 4,
+    "intelligence": 3,
     "context": 512000,
     "parameters": {
       "max_tokens": 128000,
@@ -817,7 +817,7 @@
     "model_id": "qwen3.8-max",
     "provider": "dashscope",
     "visible": true,
-    "speed": 4,
+    "speed": 1,
     "intelligence": 5,
     "context": 1000000,
     "input_modalities": [
@@ -846,8 +846,8 @@
     "model_id": "qwen3.8-flash",
     "provider": "dashscope",
     "visible": true,
-    "speed": 5,
-    "intelligence": 4,
+    "speed": 3,
+    "intelligence": 5,
     "context": 1000000,
     "input_modalities": [
       "text",
@@ -876,7 +876,7 @@
     "provider": "dashscope",
     "visible": true,
     "speed": 2,
-    "intelligence": 4,
+    "intelligence": 2,
     "context": 1000000,
     "input_modalities": [
       "text",
@@ -905,7 +905,7 @@
     "model_id": "qwen3.8-max",
     "provider": "dashscope-intl",
     "visible": true,
-    "speed": 4,
+    "speed": 1,
     "intelligence": 5,
     "context": 1000000,
     "input_modalities": [
@@ -934,8 +934,8 @@
     "model_id": "qwen3.8-flash",
     "provider": "dashscope-intl",
     "visible": true,
-    "speed": 5,
-    "intelligence": 4,
+    "speed": 3,
+    "intelligence": 5,
     "context": 1000000,
     "input_modalities": [
       "text",
@@ -964,7 +964,7 @@
     "provider": "dashscope-intl",
     "visible": true,
     "speed": 2,
-    "intelligence": 4,
+    "intelligence": 2,
     "context": 1000000,
     "input_modalities": [
       "text",
@@ -993,7 +993,7 @@
     "model_id": "kimi-k3",
     "provider": "moonshot",
     "visible": true,
-    "speed": 2,
+    "speed": 1,
     "intelligence": 5,
     "context": 1000000,
     "input_modalities": [
@@ -1015,7 +1015,7 @@
     "model_id": "kimi-k3",
     "provider": "moonshot-coding",
     "visible": true,
-    "speed": 2,
+    "speed": 1,
     "intelligence": 5,
     "context": 1000000,
     "input_modalities": [
@@ -1038,7 +1038,7 @@
     "oauth_plans": ["pro", "prolite"],
     "visible": true,
     "speed": 5,
-    "intelligence": 4,
+    "intelligence": 3,
     "context": 400000,
     "input_modalities": [
       "text",
@@ -1067,7 +1067,7 @@
     "model_id": "gpt-5.5",
     "provider": "codex-oauth",
     "visible": true,
-    "speed": 2,
+    "speed": 3,
     "intelligence": 5,
     "context": 400000,
     "input_modalities": [
@@ -1099,7 +1099,7 @@
     "model_id": "gpt-5.6-sol",
     "provider": "codex-oauth",
     "visible": true,
-    "speed": 2,
+    "speed": 3,
     "intelligence": 5,
     "context": 1050000,
     "input_modalities": [
@@ -1132,7 +1132,7 @@
     "model_id": "gpt-5.6-terra",
     "provider": "codex-oauth",
     "visible": true,
-    "speed": 3,
+    "speed": 4,
     "intelligence": 5,
     "context": 1050000,
     "input_modalities": [
@@ -1197,7 +1197,7 @@
     "provider": "claude-oauth",
     "visible": true,
     "speed": 2,
-    "intelligence": 4,
+    "intelligence": 3,
     "context": 200000,
     "input_modalities": [
       "text",
@@ -1226,7 +1226,7 @@
     "model_id": "claude-fable-5",
     "provider": "claude-oauth",
     "visible": true,
-    "speed": 2,
+    "speed": 3,
     "intelligence": 5,
     "context": 1000000,
     "input_modalities": [
@@ -1354,7 +1354,7 @@
     "provider": "claude-oauth",
     "visible": true,
     "speed": 3,
-    "intelligence": 2,
+    "intelligence": 1,
     "context": 200000,
     "input_modalities": [
       "text",

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -466,6 +466,30 @@
         }
       },
       {
+        "id": "glm-5.3",
+        "name": "GLM-5.3",
+        "is_reasoning": true,
+        "description": "Z.AI's flagship GLM-5.3 model with 1M context and always-on thinking",
+        "pricing": {
+          "input": 1.4,
+          "cached_input": 0.26,
+          "output": 4.4,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "glm-5.3-flash",
+        "name": "GLM-5.3-Flash",
+        "is_reasoning": true,
+        "description": "Z.AI's natively multimodal GLM-5.3-Flash with 1M context",
+        "pricing": {
+          "input": 0.15,
+          "cached_input": 0.03,
+          "output": 0.5,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
         "id": "glm-5v-turbo",
         "name": "GLM-5V-Turbo",
         "is_reasoning": true,
@@ -544,6 +568,30 @@
           "input": 1.14,
           "cached_input": 0.29,
           "output": 4.0,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "glm-5.3",
+        "name": "GLM-5.3",
+        "is_reasoning": true,
+        "description": "Z.AI's flagship GLM-5.3 model with 1M context, flat domestic pricing",
+        "pricing": {
+          "input": 1.14,
+          "cached_input": 0.29,
+          "output": 4.0,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "glm-5.3-flash",
+        "name": "GLM-5.3-Flash",
+        "is_reasoning": true,
+        "description": "Z.AI's natively multimodal GLM-5.3-Flash with 1M context, flat domestic pricing",
+        "pricing": {
+          "input": 0.114,
+          "cached_input": 0.033,
+          "output": 0.4,
           "unit": "per_1m_tokens"
         }
       },

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -296,17 +296,6 @@
         }
       },
       {
-        "id": "gemini-3.1-flash-image-preview",
-        "name": "Gemini 3.1 Flash Image Preview",
-        "description": "Designed for speed and efficiency, effective for quick interactive responses and high throughput image generation",
-        "pricing": {
-          "input": 0.25,
-          "output": 1.5,
-          "output_image": 60.0,
-          "unit": "per_1m_tokens"
-        }
-      },
-      {
         "id": "gemini-3.7-flash",
         "name": "Gemini 3.7 Flash",
         "is_reasoning": true,

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -442,18 +442,6 @@
     "vllm": [],
     "z-ai": [
       {
-        "id": "glm-5.1",
-        "name": "GLM-5.1",
-        "is_reasoning": true,
-        "description": "Z.AI's latest GLM-5.1 model with extended thinking capabilities",
-        "pricing": {
-          "input": 1.4,
-          "cached_input": 0.26,
-          "output": 4.4,
-          "unit": "per_1m_tokens"
-        }
-      },
-      {
         "id": "glm-5.2",
         "name": "GLM-5.2",
         "is_reasoning": true,
@@ -490,30 +478,6 @@
         }
       },
       {
-        "id": "glm-5v-turbo",
-        "name": "GLM-5V-Turbo",
-        "is_reasoning": true,
-        "description": "Z.AI's GLM-5V-Turbo multimodal Agent model with vision and tool calling",
-        "pricing": {
-          "input": 1.2,
-          "cached_input": 0.24,
-          "output": 4.0,
-          "unit": "per_1m_tokens"
-        }
-      },
-      {
-        "id": "glm-5-turbo",
-        "name": "GLM-5-Turbo",
-        "is_reasoning": true,
-        "description": "Z.AI's GLM-5 Turbo model optimized for agentic tasks and tool calling",
-        "pricing": {
-          "input": 1.2,
-          "cached_input": 0.24,
-          "output": 4.0,
-          "unit": "per_1m_tokens"
-        }
-      },
-      {
         "id": "glm-4.7",
         "name": "GLM-4.7",
         "is_reasoning": false,
@@ -527,38 +491,6 @@
       }
     ],
     "z-ai-cn": [
-      {
-        "id": "glm-5.1",
-        "name": "GLM-5.1",
-        "is_reasoning": true,
-        "description": "Z.AI's latest GLM-5.1 model with input-dependent tiered pricing",
-        "pricing": {
-          "input_tiers": [
-            {
-              "max_tokens": 32000,
-              "rate": 0.83,
-              "cached_input": 0.18
-            },
-            {
-              "max_tokens": null,
-              "rate": 1.1,
-              "cached_input": 0.28
-            }
-          ],
-          "output_tiers": [
-            {
-              "max_tokens": 32000,
-              "rate": 3.31
-            },
-            {
-              "max_tokens": null,
-              "rate": 3.87
-            }
-          ],
-          "output_pricing_mode": "input_dependent",
-          "unit": "per_1m_tokens"
-        }
-      },
       {
         "id": "glm-5.2",
         "name": "GLM-5.2",
@@ -592,70 +524,6 @@
           "input": 0.114,
           "cached_input": 0.033,
           "output": 0.4,
-          "unit": "per_1m_tokens"
-        }
-      },
-      {
-        "id": "glm-5v-turbo",
-        "name": "GLM-5V-Turbo",
-        "is_reasoning": true,
-        "description": "Z.AI's GLM-5V-Turbo multimodal Agent model with vision, tiered pricing",
-        "pricing": {
-          "input_tiers": [
-            {
-              "max_tokens": 32000,
-              "rate": 0.69,
-              "cached_input": 0.17
-            },
-            {
-              "max_tokens": null,
-              "rate": 0.97,
-              "cached_input": 0.25
-            }
-          ],
-          "output_tiers": [
-            {
-              "max_tokens": 32000,
-              "rate": 3.04
-            },
-            {
-              "max_tokens": null,
-              "rate": 3.59
-            }
-          ],
-          "output_pricing_mode": "input_dependent",
-          "unit": "per_1m_tokens"
-        }
-      },
-      {
-        "id": "glm-5-turbo",
-        "name": "GLM-5-Turbo",
-        "is_reasoning": true,
-        "description": "Z.AI's GLM-5 Turbo model optimized for agentic tasks, tiered pricing",
-        "pricing": {
-          "input_tiers": [
-            {
-              "max_tokens": 32000,
-              "rate": 0.69,
-              "cached_input": 0.17
-            },
-            {
-              "max_tokens": null,
-              "rate": 0.97,
-              "cached_input": 0.25
-            }
-          ],
-          "output_tiers": [
-            {
-              "max_tokens": 32000,
-              "rate": 3.03
-            },
-            {
-              "max_tokens": null,
-              "rate": 3.59
-            }
-          ],
-          "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
         }
       },

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -437,6 +437,43 @@
             "output": 0.66
           }
         }
+      },
+      {
+        "id": "deepseek-v4-flash-vision-exp",
+        "name": "DeepSeek V4 Flash Vision (Exp)",
+        "is_reasoning": true,
+        "description": "DeepSeek's V4 Flash with image input, priced identically to the text model; experimental, and the vendor may change or withdraw it",
+        "context_window": 1000000,
+        "max_output": 384000,
+        "pricing": {
+          "input": 0.44,
+          "cached_input": 0.014,
+          "output": 1.32,
+          "unit": "per_1m_tokens",
+          "peak_utc": [
+            [
+              1,
+              4
+            ],
+            [
+              6,
+              10
+            ]
+          ],
+          "peak_days": [
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "peak_days_utc_offset": 8,
+          "off_peak": {
+            "input": 0.22,
+            "cached_input": 0.007,
+            "output": 0.66
+          }
+        }
       }
     ],
     "vllm": [],

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -597,6 +597,21 @@
         }
       },
       {
+        "id": "qwen3.8-flash",
+        "name": "Qwen3.8 Flash",
+        "is_reasoning": true,
+        "description": "Alibaba's Qwen3.8 Flash — multimodal with a 1M context window, aimed at coding assistance and agent workflows at a fraction of Max's cost",
+        "context_window": 1000000,
+        "max_output": 131072,
+        "pricing": {
+          "input": 0.114,
+          "cached_input": 0.014,
+          "cache_5m": 0.179,
+          "output": 0.386,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
         "id": "qwen3.7-plus",
         "name": "Qwen3.7 Plus",
         "is_reasoning": true,
@@ -629,53 +644,6 @@
           "output_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
         }
-      },
-      {
-        "id": "qwen3.7-flash",
-        "name": "Qwen3.7 Flash",
-        "is_reasoning": true,
-        "description": "Alibaba's Qwen3.7 Flash — native vision-language model with stronger multimodal grounding, search/CI agent execution, and vibe coding over 3.6-Flash",
-        "context_window": 1000000,
-        "max_output": 65536,
-        "pricing": {
-          "input_tiers": [
-            {
-              "max_tokens": 32000,
-              "rate": 0.029,
-              "cached_input": 0.006,
-              "cache_5m": 0.036
-            },
-            {
-              "max_tokens": 256000,
-              "rate": 0.086,
-              "cached_input": 0.017,
-              "cache_5m": 0.107
-            },
-            {
-              "max_tokens": 1000000,
-              "rate": 0.171,
-              "cached_input": 0.034,
-              "cache_5m": 0.214
-            }
-          ],
-          "output_tiers": [
-            {
-              "max_tokens": 32000,
-              "rate": 0.114
-            },
-            {
-              "max_tokens": 256000,
-              "rate": 0.343
-            },
-            {
-              "max_tokens": 1000000,
-              "rate": 0.686
-            }
-          ],
-          "output_pricing_mode": "input_dependent",
-          "input_pricing_mode": "input_dependent",
-          "unit": "per_1m_tokens"
-        }
       }
     ],
     "dashscope-intl": [
@@ -691,6 +659,21 @@
           "cached_input": 0.268,
           "cache_5m": 2.677,
           "output": 6.424,
+          "unit": "per_1m_tokens"
+        }
+      },
+      {
+        "id": "qwen3.8-flash",
+        "name": "Qwen3.8 Flash (SG)",
+        "is_reasoning": true,
+        "description": "Alibaba's Qwen3.8 Flash — Singapore international region",
+        "context_window": 1000000,
+        "max_output": 131072,
+        "pricing": {
+          "input": 0.156,
+          "cached_input": 0.017,
+          "cache_5m": 0.208,
+          "output": 0.49,
           "unit": "per_1m_tokens"
         }
       },
@@ -725,53 +708,6 @@
             }
           ],
           "output_pricing_mode": "input_dependent",
-          "unit": "per_1m_tokens"
-        }
-      },
-      {
-        "id": "qwen3.7-flash",
-        "name": "Qwen3.7 Flash (SG)",
-        "is_reasoning": true,
-        "description": "Alibaba's Qwen3.7 Flash — Singapore international region",
-        "context_window": 1000000,
-        "max_output": 65536,
-        "pricing": {
-          "input_tiers": [
-            {
-              "max_tokens": 32000,
-              "rate": 0.032,
-              "cached_input": 0.006,
-              "cache_5m": 0.04
-            },
-            {
-              "max_tokens": 256000,
-              "rate": 0.107,
-              "cached_input": 0.021,
-              "cache_5m": 0.134
-            },
-            {
-              "max_tokens": 1000000,
-              "rate": 0.214,
-              "cached_input": 0.043,
-              "cache_5m": 0.268
-            }
-          ],
-          "output_tiers": [
-            {
-              "max_tokens": 32000,
-              "rate": 0.139
-            },
-            {
-              "max_tokens": 256000,
-              "rate": 0.428
-            },
-            {
-              "max_tokens": 1000000,
-              "rate": 0.856
-            }
-          ],
-          "output_pricing_mode": "input_dependent",
-          "input_pricing_mode": "input_dependent",
           "unit": "per_1m_tokens"
         }
       }

--- a/src/server/services/llm/user_models.py
+++ b/src/server/services/llm/user_models.py
@@ -115,7 +115,7 @@ async def classify_model(
 
     Custom is checked first. When a user's ``custom_models`` entry shadows a
     built-in of the same name, the custom entry wins — lets users route a
-    built-in model name (e.g. ``glm-5.1``) through a variant's own key.
+    built-in model name (e.g. ``glm-5.2``) through a variant's own key.
     ``_pref_cache`` keeps the chat hot path free of extra DB reads.
     """
     from src.llms.llm import LLM as LLMFactory

--- a/tests/unit/llms/test_input_modalities.py
+++ b/tests/unit/llms/test_input_modalities.py
@@ -28,11 +28,6 @@ class TestGetInputModalities:
         assert "image" in result
         assert "pdf" in result
 
-    def test_gemini_flash_image_no_pdf(self, model_config):
-        result = model_config.get_input_modalities("gemini-3.1-flash-image")
-        assert "image" in result
-        assert "pdf" not in result
-
     def test_deepseek_text_only(self, model_config):
         result = model_config.get_input_modalities("deepseek-v4-flash")
         assert result == ["text"]

--- a/tests/unit/server/app/test_preferences_validation.py
+++ b/tests/unit/server/app/test_preferences_validation.py
@@ -77,7 +77,7 @@ class TestValidateCustomModels:
         """Custom model name may collide with a built-in — the resolver
         checks custom first, so the user's entry shadows the built-in. This
         is the normal path for routing built-in model names (e.g.
-        ``glm-5.1``) through a user's variant-specific key."""
+        ``glm-5.2``) through a user's variant-specific key."""
         mc = _mock_model_config(system_models={"gpt-4o": {"model_id": "gpt-4o"}})
         # Should not raise.
         self._validate(

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -2463,7 +2463,7 @@
     "addModel": "Add model",
     "modelIdInputPlaceholder": "Enter model ID (e.g. GPT-5.4)",
     "customModelNameLabel": "Display name",
-    "customModelNamePlaceholder": "How this model appears in menus (e.g. glm-5.1)",
+    "customModelNamePlaceholder": "How this model appears in menus (e.g. glm-5.3)",
     "customModelNameSlugPreview": "Saved as: {{slug}}",
     "customModelNameSlugEmpty": "Add letters or numbers — spaces and symbols will be stripped.",
     "customModelIdLabel": "Upstream model ID",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -2442,7 +2442,7 @@
     "addModel": "添加模型",
     "modelIdInputPlaceholder": "输入模型 ID（如 GPT-5.4）",
     "customModelNameLabel": "显示名称",
-    "customModelNamePlaceholder": "在菜单中如何显示（如 glm-5.1）",
+    "customModelNamePlaceholder": "在菜单中如何显示（如 glm-5.3）",
     "customModelNameSlugPreview": "将保存为：{{slug}}",
     "customModelNameSlugEmpty": "请输入字母或数字 — 空格和符号会被自动移除。",
     "customModelIdLabel": "上游模型 ID",


### PR DESCRIPTION
## Overview

Refreshes the model catalog to the current generation. Seven model keys are added, nine
retired, `speed` / `intelligence` are taken from
[Artificial Analysis](https://artificialanalysis.ai), and the six Qwen entries send their
reasoning effort as a typed parameter instead of an opaque `extra_body` passthrough.

| Category              | Files | +LOC | −LOC |
|-----------------------|------:|-----:|-----:|
| Modified              |     8 |  261 |  394 |
| New                   |     0 |    0 |    0 |
| Tests (excluded)      |     2 |    1 |    6 |
| **Net (excl. tests)** |     6 |  260 |  388 |

### `src/llms/manifest/` (net −153)

- `models.json` (+132 / −163): catalog keys 54 to 52, visible 45 to 43. Adds GLM-5.3 and
  GLM-5.3-Flash (CN and intl), Qwen3.8 Flash (CN and intl), DeepSeek V4 Flash Vision;
  retires GLM-5.1, the GLM-5 turbo pair, Qwen3.7 Flash, and Gemini 3.1 Flash Image.
  Rewrites `speed` / `intelligence` on 25 of the 45 carried-over models, and moves the six
  Qwen entries' `reasoning` block from `extra_body` to `parameters`.
- `providers.json` (+91 / −213): pricing entries 41 to 39, matching the catalog change.

### `scripts/ops/` (net +25)

- `calibrate_model_ratings.py` (+34 / −9): band thresholds re-placed, `MANUAL` emptied, and
  a new `AA_SLUG_ALIASES` map added. The writer now preserves the manifest's hand-inlined
  short arrays so a ratings pass produces a values-only diff.

### `src/server/` and `web/src/locales/` (net 0)

- `user_models.py`, `en-US.json`, `zh-CN.json` (+1 / −1 each): docstring and placeholder copy
  cited `glm-5.1`, which this branch retires. Repointed to models that still resolve.

### `tests/` (net −5)

- `test_input_modalities.py` (−5): drops the Gemini 3.1 Flash Image modality case with the model.
- `test_preferences_validation.py` (+1 / −1): the same retired-model citation in a docstring.

**What this introduces:** the catalog moves to the current model generation, with the speed
and intelligence ratings taken from Artificial Analysis.

## Ratings

`speed` and `intelligence` are taken from [Artificial Analysis](https://artificialanalysis.ai):
`median_output_tokens_per_second` and `artificial_analysis_intelligence_index`, applied by
`scripts/ops/calibrate_model_ratings.py`.

```
python scripts/ops/calibrate_model_ratings.py --basis ceiling --apply --fields intelligence,speed
```

## Gemini 3.1 Flash Image is retired

It is an image generation model, and there are no image generation tools for it to reach. Two
details confirmed that rather than assumed it: its 32k context was the smallest in the catalog
by a wide margin, and the `output_image` rate its pricing carried is a field no code reads, so
the per-image cost was never billed by anything.

Coverage of the image-without-pdf modality case is unaffected. `kimi-k3` already pins it, and
every remaining Gemini model accepts pdf, so repointing the deleted test would have inverted it
into a duplicate of `test_gemini_supports_video`.

## Qwen reasoning effort moves to `parameters`

The six DashScope entries declared their ladder under `extra_body.reasoning.effort`, which
the SDK forwards as an unchecked dict. DashScope documents `reasoning` as a first-class
Responses API object and we already route through that endpoint, so the block moves to
`parameters`, where `ChatOpenAI` declares `reasoning` as a real field.

The mapper needed no change: `apply_reasoning_effort`'s `parameters.reasoning` and
`extra_body.reasoning` branches were already the same five lines. Qwen now shares a write
path with the gpt-5.x models rather than being the one surface with the same shape in both
lanes.

The old lane was quietly failure-prone. A probe confirmed DashScope answers a *flat*
`extra_body.reasoning_effort` with 200 and ignores it, so one wrong key there produces an
effort control that renders, reports a level, and sends nothing. On the typed lane that key
does not exist and fails at construction.

## Verification

- Full unit suite green: 9578 passed, 1 xfailed.
- Each commit is independently green; the ratings commit was run on its own before the
  retirement commit was applied on top.
- The ratings pass produces a values-only diff. Every changed line in that commit is a `speed`
  or `intelligence` value, with no reformatting churn, confirmed by a byte-identical JSON
  round-trip before editing.
- A removed key resolves to `None` and its pricing lookup returns `None`; the successor models
  resolve normally.
- The Qwen move was verified end-to-end, not just in units. All 42 rungs (6 entries x 7 levels)
  write the level verbatim to `parameters.reasoning.effort` and leave `extra_body` empty, and
  live calls through `create_llm` on both the CN and intl routes returned reasoning-token
  counts that scale with the level (0 / 80 / 126 and 0 / 59 / 142 for none / medium / max).
  A junk effort round-trips to a real 400 naming `reasoning.effort`, which proves the typed
  field reaches the wire rather than being dropped.

## Risks

- **Stored model preferences naming a retired key stop resolving.** Nine keys are gone, so any
  saved preference or scheduled job still pointing at one needs repointing. This is the same
  exposure as the earlier retirements in this branch, now covering `gemini-3.1-flash-image`.
- **Ceiling basis is a deliberate choice.** Reading a model at its best published configuration
  flatters models with a wide effort range. The alternative, matching the exact row to how we
  configure the model, was tried and rejected: the row matcher does not recognise every effort
  label Artificial Analysis publishes, so it silently fell back to non-reasoning rows and
  understated several models badly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790950957&installation_model_id=432753&pr_number=386&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F386&signature=692ea358ce013d2a5db45b791b5623d67b1c13bbcd5b222beff2cb07ba00e391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for GLM-5.3, Qwen 3.8 Flash, and DeepSeek vision models.
  - Added regional and international model variants with updated pricing, context, modality, and reasoning options.

- **Updates**
  - Revised model speed, intelligence, and reasoning defaults.
  - Improved model matching for supported aliases.
  - Updated provider catalogs and pricing information.

- **Documentation**
  - Updated model-name examples in setup and validation text.

- **Removals**
  - Removed obsolete Gemini image, legacy GLM-5, and Qwen 3.7 Flash entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
