### PR TITLE
refactor(models): declare where each model's reasoning level is written

### DIFF
--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -225,10 +225,3 @@ web_fetch:
   sitemap_max_urls: 100 # Max URLs to fetch from sitemap
   sitemap_max_examples: 3 # Max example URLs per path prefix in summary
   sitemap_timeout: 10 # Timeout in seconds for sitemap fetch
-
-# Embedding Model Configuration (Currently not in use)
-embedding:
-  model: embedding-small # Options: embedding-small, embedding-large (see src/llms/llm_config.json)
-  batch_size: 100 # Number of texts to embed in a single batch
-  enable_auto_embedding: true
-  hybrid_search_alpha: 0.5 # Balance between semantic (0.0) and keyword search (1.0)

--- a/src/config/core.py
+++ b/src/config/core.py
@@ -6,7 +6,7 @@ and adds server-specific infrastructure config loading.
 
 Config Files:
 - config.yaml: Infrastructure settings (server, Redis, background tasks, logging, CORS)
-- agent_config.yaml: Agent capabilities (LLM, MCP, tools, crawler, web_fetch, embedding, security)
+- agent_config.yaml: Agent capabilities (LLM, MCP, tools, crawler, web_fetch, security)
 """
 
 import logging

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -16,6 +16,7 @@ from .model_spec import (
     canonical_reasoning_efforts,
     clamp_reasoning_effort,
     default_reasoning_effort,
+    reasoning_block,
 )
 from .preferences import compaction_profile_for
 from .pricing_utils import get_price_tier
@@ -252,14 +253,14 @@ class ModelConfig:
         reason this returns a list rather than a default ladder.
         """
         entry = self.llm_config.get(model_name) or {}
-        return list(canonical_reasoning_efforts(entry.get("reasoning_efforts")))
+        return list(canonical_reasoning_efforts(reasoning_block(entry).get("efforts")))
 
     def get_reasoning_effort_default(self, model_name: str) -> str | None:
         """Manifest-entry wrapper over :func:`default_reasoning_effort`."""
         entry = self.llm_config.get(model_name) or {}
         return default_reasoning_effort(
             self.get_reasoning_efforts(model_name),
-            entry.get("reasoning_effort_default"),
+            reasoning_block(entry).get("default"),
         )
 
     def resolve_reasoning_effort(self, model_name: str, requested: str) -> str | None:
@@ -428,17 +429,22 @@ class LLM:
         # which is what a user-defined model would miss.
         # The resolved level, not the requested one, is what the call reports:
         # a request above the model's ladder is stepped down here, so the two
-        # differ. With no request at all the parameters already encode the
-        # model's own default, which is what that case reports.
+        # differ. With no request at all the model's own default resolves here
+        # and takes the same path, so it is reported and sent as one value.
         if reasoning_effort:
             effort = clamp_reasoning_effort(
                 spec.reasoning_efforts, spec.reasoning_effort_default, reasoning_effort
             )
-            if effort:
-                apply_reasoning_effort(effort, self.parameters, self.extra_body)
-            self.resolved_reasoning_effort = effort
         else:
-            self.resolved_reasoning_effort = spec.reasoning_effort_default
+            effort = spec.reasoning_effort_default
+
+        # Applied on both paths. The entry carries no pre-set level of its own,
+        # so a turn that skipped the mapper would report a default it never sent.
+        if effort:
+            apply_reasoning_effort(
+                effort, self.parameters, self.extra_body, spec.reasoning_surface
+            )
+        self.resolved_reasoning_effort = effort
 
         # Store optional API key override (BYOK)
         self.api_key_override = api_key

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -416,9 +416,6 @@ class LLM:
         self.parameters = copy.deepcopy(spec.parameters)
         self.extra_body = copy.deepcopy(spec.extra_body)
 
-        # Override with any provided parameters
-        self.parameters.update(override_params)
-
         # Apply reasoning effort override (before provider resolution).
         # Validation lives here because this is the only point that sees both
         # the requested level and the model's declared enum; past it the mapper
@@ -436,11 +433,24 @@ class LLM:
                 spec.reasoning_efforts, spec.reasoning_effort_default, reasoning_effort
             )
         else:
+            # Not a request, so it is written *under* the caller's own
+            # parameters. The manifest used to seed its default level into
+            # `parameters`, where an override naming that key directly replaced
+            # it; the mapper now writes what the seed held, and inherits its
+            # place in the order.
             effort = spec.reasoning_effort_default
+            if effort:
+                apply_reasoning_effort(
+                    effort, self.parameters, self.extra_body, spec.reasoning_surface
+                )
 
-        # Applied on both paths. The entry carries no pre-set level of its own,
-        # so a turn that skipped the mapper would report a default it never sent.
-        if effort:
+        # Override with any provided parameters
+        self.parameters.update(override_params)
+
+        # A level the caller asked for outright is the request being answered,
+        # so it goes over the overrides -- where it already went when the mapper
+        # ran on this side of the update and the seed sat underneath.
+        if reasoning_effort and effort:
             apply_reasoning_effort(
                 effort, self.parameters, self.extra_body, spec.reasoning_surface
             )

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -1390,27 +1390,6 @@
       }
     }
   },
-  "embedding-small": {
-    "model_id": "text-embedding-3-small",
-    "provider": "openai",
-    "parameters": {
-      "dimensions": 1536
-    }
-  },
-  "embedding-large": {
-    "model_id": "text-embedding-3-large",
-    "provider": "openai",
-    "parameters": {
-      "dimensions": 3072
-    }
-  },
-  "embedding-cn": {
-    "model_id": "text-embedding-v4",
-    "provider": "dashscope",
-    "parameters": {
-      "dimensions": 1536
-    }
-  },
   "claude-opus-4-8-oauth-1m": {
     "prompt_guidance": "lean",
     "model_id": "claude-opus-4-8",

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -15,18 +15,20 @@
     ],
     "parameters": {
       "reasoning": {
-        "effort": "medium",
         "summary": "auto"
       }
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "medium",
-      "high",
-      "xhigh"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "gpt-5.6-sol": {
     "prompt_guidance": "lean",
@@ -44,22 +46,24 @@
     ],
     "parameters": {
       "reasoning": {
-        "effort": "medium",
         "summary": "auto"
       },
       "prompt_cache_options": {
         "mode": "implicit"
       }
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "gpt-5.6-terra": {
     "prompt_guidance": "lean",
@@ -77,22 +81,24 @@
     ],
     "parameters": {
       "reasoning": {
-        "effort": "medium",
         "summary": "auto"
       },
       "prompt_cache_options": {
         "mode": "implicit"
       }
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "gpt-5.6-luna": {
     "model_id": "gpt-5.6-luna",
@@ -109,22 +115,24 @@
     ],
     "parameters": {
       "reasoning": {
-        "effort": "medium",
         "summary": "auto"
       },
       "prompt_cache_options": {
         "mode": "implicit"
       }
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "claude-fable-5": {
     "prompt_guidance": "lean",
@@ -144,19 +152,19 @@
       "thinking": {
         "type": "adaptive",
         "display": "summarized"
-      },
-      "output_config": {
-        "effort": "high"
       }
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "high",
+      "write": "parameters.output_config.effort"
+    }
   },
   "claude-opus-5": {
     "prompt_guidance": "lean",
@@ -176,19 +184,19 @@
       "thinking": {
         "type": "adaptive",
         "display": "summarized"
-      },
-      "output_config": {
-        "effort": "high"
       }
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "high",
+      "write": "parameters.output_config.effort"
+    }
   },
   "claude-sonnet-5": {
     "prompt_guidance": "lean",
@@ -208,19 +216,19 @@
       "thinking": {
         "type": "adaptive",
         "display": "summarized"
-      },
-      "output_config": {
-        "effort": "medium"
       }
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "medium",
+      "write": "parameters.output_config.effort"
+    }
   },
   "claude-opus-4-8": {
     "prompt_guidance": "lean",
@@ -240,19 +248,19 @@
       "thinking": {
         "type": "adaptive",
         "display": "summarized"
-      },
-      "output_config": {
-        "effort": "xhigh"
       }
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "xhigh"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "xhigh",
+      "write": "parameters.output_config.effort"
+    }
   },
   "claude-sonnet-4-6": {
     "model_id": "claude-sonnet-4-6",
@@ -270,18 +278,18 @@
       "max_tokens": 64000,
       "thinking": {
         "type": "adaptive"
-      },
-      "output_config": {
-        "effort": "high"
       }
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "max"
+      ],
+      "default": "high",
+      "write": "parameters.output_config.effort"
+    }
   },
   "claude-haiku-4-5": {
     "model_id": "claude-haiku-4-5-20251001",
@@ -300,13 +308,7 @@
       "thinking": {
         "type": "enabled"
       }
-    },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "medium"
+    }
   },
   "gemini-3.1-pro": {
     "prompt_guidance": "lean",
@@ -323,15 +325,17 @@
       "video"
     ],
     "parameters": {
-      "include_thoughts": true,
-      "thinking_level": "high"
+      "include_thoughts": true
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "high",
+      "write": "parameters.thinking_level"
+    }
   },
   "gemini-3.7-flash": {
     "model_id": "gemini-3.7-flash",
@@ -347,15 +351,17 @@
       "video"
     ],
     "parameters": {
-      "include_thoughts": true,
-      "thinking_level": "medium"
+      "include_thoughts": true
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "medium",
+      "write": "parameters.thinking_level"
+    }
   },
   "gemini-3.1-flash-lite": {
     "model_id": "gemini-3.1-flash-lite-preview",
@@ -371,54 +377,55 @@
       "video"
     ],
     "parameters": {
-      "include_thoughts": true,
-      "thinking_level": "medium"
+      "include_thoughts": true
     },
-    "reasoning_efforts": [
-      "minimal",
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "minimal",
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "medium",
+      "write": "parameters.thinking_level"
+    }
   },
   "gpt-oss-120b": {
     "model_id": "gpt-oss-120b",
     "provider": "vllm",
-    "parameters": {
-      "reasoning_effort": "low"
-    },
     "input_modalities": [
       "text"
     ],
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "low"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "low",
+      "write": "parameters.reasoning_effort"
+    }
   },
   "gpt-oss-20b": {
     "model_id": "gpt-oss-20b",
     "provider": "vllm",
-    "parameters": {
-      "reasoning_effort": "low"
-    },
     "input_modalities": [
       "text"
     ],
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "low"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "low",
+      "write": "parameters.reasoning_effort"
+    }
   },
   "gpt-oss-20b-safe-groq": {
     "model_id": "openai/gpt-oss-safeguard-20b",
     "provider": "openrouter",
     "parameters": {
-      "reasoning_effort": "low",
       "use_previous_response_id": false,
       "extra_body": {
         "provider": {
@@ -432,18 +439,20 @@
     "input_modalities": [
       "text"
     ],
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "low"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "low",
+      "write": "parameters.reasoning_effort"
+    }
   },
   "gpt-oss-20b-deepinfra": {
     "model_id": "openai/gpt-oss-20b",
     "provider": "deepinfra",
     "parameters": {
-      "reasoning_effort": "low",
       "use_previous_response_id": false,
       "extra_body": {
         "provider": {
@@ -457,18 +466,20 @@
     "input_modalities": [
       "text"
     ],
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "low"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "low",
+      "write": "parameters.reasoning_effort"
+    }
   },
   "gpt-oss-safeguard-20b-deepinfra": {
     "model_id": "openai/gpt-oss-safeguard-20b",
     "provider": "deepinfra",
     "parameters": {
-      "reasoning_effort": "low",
       "use_previous_response_id": false,
       "extra_body": {
         "provider": {
@@ -482,18 +493,20 @@
     "input_modalities": [
       "text"
     ],
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "low"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "low",
+      "write": "parameters.reasoning_effort"
+    }
   },
   "gpt-oss-120b-groq": {
     "model_id": "openai/gpt-oss-120b",
     "provider": "openrouter",
     "parameters": {
-      "reasoning_effort": "low",
       "use_previous_response_id": false,
       "extra_body": {
         "provider": {
@@ -507,12 +520,15 @@
     "input_modalities": [
       "text"
     ],
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "low"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "low",
+      "write": "parameters.reasoning_effort"
+    }
   },
   "deepseek-v4-pro": {
     "model_id": "deepseek-v4-pro",
@@ -525,21 +541,24 @@
       "text"
     ],
     "parameters": {
-      "max_tokens": 384000,
-      "thinking": {
-        "type": "enabled"
-      },
-      "output_config": {
-        "effort": "high"
-      }
+      "max_tokens": 384000
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "high",
+        "max"
+      ],
+      "default": "high",
+      "write": "parameters.output_config.effort",
+      "on": {
+        "parameters.thinking.type": "enabled"
+      },
+      "off": {
+        "parameters.thinking.type": "disabled"
+      }
+    }
   },
   "deepseek-v4-flash": {
     "model_id": "deepseek-v4-flash",
@@ -552,21 +571,24 @@
       "text"
     ],
     "parameters": {
-      "max_tokens": 384000,
-      "thinking": {
-        "type": "enabled"
-      },
-      "output_config": {
-        "effort": "high"
-      }
+      "max_tokens": 384000
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "high",
+        "max"
+      ],
+      "default": "high",
+      "write": "parameters.output_config.effort",
+      "on": {
+        "parameters.thinking.type": "enabled"
+      },
+      "off": {
+        "parameters.thinking.type": "disabled"
+      }
+    }
   },
   "deepseek-v4-flash-vision-exp": {
     "model_id": "deepseek-v4-flash-vision-exp",
@@ -580,21 +602,24 @@
       "image"
     ],
     "parameters": {
-      "max_tokens": 384000,
-      "thinking": {
-        "type": "enabled"
-      },
-      "output_config": {
-        "effort": "high"
-      }
+      "max_tokens": 384000
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "high",
+        "max"
+      ],
+      "default": "high",
+      "write": "parameters.output_config.effort",
+      "on": {
+        "parameters.thinking.type": "enabled"
+      },
+      "off": {
+        "parameters.thinking.type": "disabled"
+      }
+    }
   },
   "glm-5.2": {
     "prompt_guidance": "lean",
@@ -607,22 +632,25 @@
     "parameters": {
       "max_tokens": 128000
     },
-    "extra_body": {
-      "thinking": {
-        "type": "enabled",
-        "clear_thinking": false
-      },
-      "reasoning_effort": "max"
-    },
     "input_modalities": [
       "text"
     ],
-    "reasoning_efforts": [
-      "none",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "max"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "high",
+        "max"
+      ],
+      "default": "max",
+      "write": "extra_body.reasoning_effort",
+      "on": {
+        "extra_body.thinking.clear_thinking": false,
+        "extra_body.thinking.type": "enabled"
+      },
+      "off": {
+        "extra_body.thinking.type": "disabled"
+      }
+    }
   },
   "glm-5.3": {
     "prompt_guidance": "lean",
@@ -639,18 +667,20 @@
       "thinking": {
         "type": "enabled",
         "clear_thinking": false
-      },
-      "reasoning_effort": "max"
+      }
     },
     "input_modalities": [
       "text"
     ],
-    "reasoning_efforts": [
-      "low",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "max"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "high",
+        "max"
+      ],
+      "default": "max",
+      "write": "extra_body.reasoning_effort"
+    }
   },
   "glm-5.3-flash": {
     "prompt_guidance": "lean",
@@ -667,20 +697,22 @@
       "thinking": {
         "type": "enabled",
         "clear_thinking": false
-      },
-      "reasoning_effort": "max"
+      }
     },
     "input_modalities": [
       "text",
       "image",
       "pdf"
     ],
-    "reasoning_efforts": [
-      "low",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "max"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "high",
+        "max"
+      ],
+      "default": "max",
+      "write": "extra_body.reasoning_effort"
+    }
   },
   "glm-5.2-cn": {
     "prompt_guidance": "lean",
@@ -693,22 +725,25 @@
     "parameters": {
       "max_tokens": 128000
     },
-    "extra_body": {
-      "thinking": {
-        "type": "enabled",
-        "clear_thinking": false
-      },
-      "reasoning_effort": "max"
-    },
     "input_modalities": [
       "text"
     ],
-    "reasoning_efforts": [
-      "none",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "max"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "high",
+        "max"
+      ],
+      "default": "max",
+      "write": "extra_body.reasoning_effort",
+      "on": {
+        "extra_body.thinking.clear_thinking": false,
+        "extra_body.thinking.type": "enabled"
+      },
+      "off": {
+        "extra_body.thinking.type": "disabled"
+      }
+    }
   },
   "glm-5.3-cn": {
     "prompt_guidance": "lean",
@@ -725,18 +760,20 @@
       "thinking": {
         "type": "enabled",
         "clear_thinking": false
-      },
-      "reasoning_effort": "max"
+      }
     },
     "input_modalities": [
       "text"
     ],
-    "reasoning_efforts": [
-      "low",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "max"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "high",
+        "max"
+      ],
+      "default": "max",
+      "write": "extra_body.reasoning_effort"
+    }
   },
   "glm-5.3-flash-cn": {
     "prompt_guidance": "lean",
@@ -753,20 +790,22 @@
       "thinking": {
         "type": "enabled",
         "clear_thinking": false
-      },
-      "reasoning_effort": "max"
+      }
     },
     "input_modalities": [
       "text",
       "image",
       "pdf"
     ],
-    "reasoning_efforts": [
-      "low",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "max"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "high",
+        "max"
+      ],
+      "default": "max",
+      "write": "extra_body.reasoning_effort"
+    }
   },
   "minimax-m3": {
     "model_id": "MiniMax-M3",
@@ -776,20 +815,25 @@
     "intelligence": 3,
     "context": 512000,
     "parameters": {
-      "max_tokens": 128000,
-      "thinking": {
-        "type": "adaptive"
-      }
+      "max_tokens": 128000
     },
     "input_modalities": [
       "text",
       "image"
     ],
-    "reasoning_efforts": [
-      "none",
-      "high"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "high"
+      ],
+      "default": "high",
+      "on": {
+        "parameters.thinking.type": "adaptive"
+      },
+      "off": {
+        "parameters.thinking.type": "disabled"
+      }
+    }
   },
   "qwen3.8-max": {
     "prompt_guidance": "lean",
@@ -805,21 +849,19 @@
       "pdf",
       "video"
     ],
-    "parameters": {
-      "reasoning": {
-        "effort": "xhigh"
-      }
-    },
-    "reasoning_efforts": [
-      "none",
-      "minimal",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "xhigh"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "xhigh",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "qwen3.8-flash": {
     "model_id": "qwen3.8-flash",
@@ -834,21 +876,19 @@
       "pdf",
       "video"
     ],
-    "parameters": {
-      "reasoning": {
-        "effort": "medium"
-      }
-    },
-    "reasoning_efforts": [
-      "none",
-      "minimal",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "qwen3.7-plus": {
     "model_id": "qwen3.7-plus",
@@ -863,21 +903,19 @@
       "pdf",
       "video"
     ],
-    "parameters": {
-      "reasoning": {
-        "effort": "xhigh"
-      }
-    },
-    "reasoning_efforts": [
-      "none",
-      "minimal",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "xhigh"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "xhigh",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "qwen3.8-max-intl": {
     "prompt_guidance": "lean",
@@ -893,21 +931,19 @@
       "pdf",
       "video"
     ],
-    "parameters": {
-      "reasoning": {
-        "effort": "xhigh"
-      }
-    },
-    "reasoning_efforts": [
-      "none",
-      "minimal",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "xhigh"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "xhigh",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "qwen3.8-flash-intl": {
     "model_id": "qwen3.8-flash",
@@ -922,21 +958,19 @@
       "pdf",
       "video"
     ],
-    "parameters": {
-      "reasoning": {
-        "effort": "medium"
-      }
-    },
-    "reasoning_efforts": [
-      "none",
-      "minimal",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "qwen3.7-plus-intl": {
     "model_id": "qwen3.7-plus",
@@ -951,21 +985,19 @@
       "pdf",
       "video"
     ],
-    "parameters": {
-      "reasoning": {
-        "effort": "xhigh"
-      }
-    },
-    "reasoning_efforts": [
-      "none",
-      "minimal",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "xhigh"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "xhigh",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "kimi-k3": {
     "prompt_guidance": "lean",
@@ -979,15 +1011,15 @@
       "text",
       "image"
     ],
-    "extra_body": {
-      "reasoning_effort": "max"
-    },
-    "reasoning_efforts": [
-      "low",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "max"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "high",
+        "max"
+      ],
+      "default": "max",
+      "write": "extra_body.reasoning_effort"
+    }
   },
   "kimi-k3-coding": {
     "prompt_guidance": "lean",
@@ -1001,15 +1033,15 @@
       "text",
       "image"
     ],
-    "extra_body": {
-      "reasoning_effort": "max"
-    },
-    "reasoning_efforts": [
-      "low",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "max"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "high",
+        "max"
+      ],
+      "default": "max",
+      "write": "extra_body.reasoning_effort"
+    }
   },
   "gpt-5.3-codex-spark-oauth": {
     "model_id": "gpt-5.3-codex-spark",
@@ -1026,7 +1058,6 @@
     ],
     "parameters": {
       "reasoning": {
-        "effort": "medium",
         "summary": "auto"
       },
       "include": [
@@ -1034,12 +1065,15 @@
       ],
       "store": false
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "gpt-5.5-oauth": {
     "prompt_guidance": "lean",
@@ -1056,7 +1090,6 @@
     ],
     "parameters": {
       "reasoning": {
-        "effort": "medium",
         "summary": "auto"
       },
       "include": [
@@ -1064,14 +1097,17 @@
       ],
       "store": false
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "medium",
-      "high",
-      "xhigh"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "gpt-5.6-sol-oauth": {
     "prompt_guidance": "lean",
@@ -1088,7 +1124,6 @@
     ],
     "parameters": {
       "reasoning": {
-        "effort": "medium",
         "summary": "auto"
       },
       "include": [
@@ -1096,15 +1131,18 @@
       ],
       "store": false
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "gpt-5.6-terra-oauth": {
     "prompt_guidance": "lean",
@@ -1121,7 +1159,6 @@
     ],
     "parameters": {
       "reasoning": {
-        "effort": "medium",
         "summary": "auto"
       },
       "include": [
@@ -1129,15 +1166,18 @@
       ],
       "store": false
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "gpt-5.6-luna-oauth": {
     "model_id": "gpt-5.6-luna",
@@ -1153,7 +1193,6 @@
     ],
     "parameters": {
       "reasoning": {
-        "effort": "medium",
         "summary": "auto"
       },
       "include": [
@@ -1161,15 +1200,18 @@
       ],
       "store": false
     },
-    "reasoning_efforts": [
-      "none",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "medium",
+      "write": "parameters.reasoning.effort"
+    }
   },
   "claude-sonnet-4-6-oauth": {
     "model_id": "claude-sonnet-4-6",
@@ -1187,18 +1229,18 @@
       "max_tokens": 64000,
       "thinking": {
         "type": "adaptive"
-      },
-      "output_config": {
-        "effort": "high"
       }
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "max"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "max"
+      ],
+      "default": "high",
+      "write": "parameters.output_config.effort"
+    }
   },
   "claude-fable-5-oauth": {
     "prompt_guidance": "lean",
@@ -1218,19 +1260,19 @@
       "thinking": {
         "type": "adaptive",
         "display": "summarized"
-      },
-      "output_config": {
-        "effort": "high"
       }
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "high",
+      "write": "parameters.output_config.effort"
+    }
   },
   "claude-opus-5-oauth": {
     "prompt_guidance": "lean",
@@ -1250,19 +1292,19 @@
       "thinking": {
         "type": "adaptive",
         "display": "summarized"
-      },
-      "output_config": {
-        "effort": "high"
       }
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "high"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "high",
+      "write": "parameters.output_config.effort"
+    }
   },
   "claude-sonnet-5-oauth": {
     "prompt_guidance": "lean",
@@ -1282,19 +1324,19 @@
       "thinking": {
         "type": "adaptive",
         "display": "summarized"
-      },
-      "output_config": {
-        "effort": "medium"
       }
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "medium"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "medium",
+      "write": "parameters.output_config.effort"
+    }
   },
   "claude-opus-4-8-oauth": {
     "prompt_guidance": "lean",
@@ -1314,19 +1356,19 @@
       "thinking": {
         "type": "adaptive",
         "display": "summarized"
-      },
-      "output_config": {
-        "effort": "xhigh"
       }
     },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "xhigh"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "xhigh",
+      "write": "parameters.output_config.effort"
+    }
   },
   "claude-haiku-4-5-oauth": {
     "model_id": "claude-haiku-4-5-20251001",
@@ -1346,13 +1388,7 @@
         "type": "enabled",
         "budget_tokens": 8000
       }
-    },
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high"
-    ],
-    "reasoning_effort_default": "medium"
+    }
   },
   "embedding-small": {
     "model_id": "text-embedding-3-small",
@@ -1393,22 +1429,22 @@
       "thinking": {
         "type": "adaptive",
         "display": "summarized"
-      },
-      "output_config": {
-        "effort": "xhigh"
       }
     },
     "context_window": 1000000,
     "additional_betas": [
       "context-1m-2025-08-07"
     ],
-    "reasoning_efforts": [
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max"
-    ],
-    "reasoning_effort_default": "xhigh"
+    "reasoning": {
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default": "xhigh",
+      "write": "parameters.output_config.effort"
+    }
   }
 }

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -1,43 +1,4 @@
 {
-  "embedding_models": {
-    "openai": [
-      {
-        "id": "text-embedding-3-small",
-        "name": "Text Embedding 3 Small",
-        "description": "OpenAI's latest small embedding model with 1536 dimensions",
-        "dimensions": 1536,
-        "max_tokens": 8191,
-        "pricing": {
-          "input": 0.02,
-          "unit": "per_1m_tokens"
-        }
-      },
-      {
-        "id": "text-embedding-3-large",
-        "name": "Text Embedding 3 Large",
-        "description": "OpenAI's latest large embedding model with 3072 dimensions for higher accuracy",
-        "dimensions": 3072,
-        "max_tokens": 8191,
-        "pricing": {
-          "input": 0.13,
-          "unit": "per_1m_tokens"
-        }
-      }
-    ],
-    "dashscope": [
-      {
-        "id": "text-embedding-v4",
-        "name": "Text Embedding V4",
-        "description": "Alibaba's latest multilingual embedding model (Qwen3-Embedding) with flexible dimensions",
-        "dimensions": 1536,
-        "max_tokens": 8192,
-        "pricing": {
-          "input": 0.007,
-          "unit": "per_1m_tokens"
-        }
-      }
-    ]
-  },
   "models": {
     "openai": [
       {

--- a/src/llms/model_spec.py
+++ b/src/llms/model_spec.py
@@ -217,6 +217,9 @@ class ModelSpec:
         """
         declared = with_inherited_declarations(config, shadowed)
         reasoning = reasoning_block(declared)
+        # The entry's own half of that, kept apart: what it says about itself
+        # outranks anything it borrowed from the name it took.
+        own = reasoning_block(config)
         efforts = canonical_reasoning_efforts(reasoning.get("efforts"))
         declared_response_api = config.get("_use_response_api")
         # Deep-copied because the mapper writes into these in place, and they
@@ -226,7 +229,7 @@ class ModelSpec:
         # Gated on the ladder: an entry declaring no levels wants no effort
         # control at all, not the shadowed model's surface.
         surface = reasoning if efforts else None
-        if efforts and not any(k in reasoning_block(config) for k in SURFACE_KEYS):
+        if efforts and not any(k in own for k in SURFACE_KEYS):
             # Read against the entry's own block, not the merged one, so the
             # order below is seed first and borrowed path second. An entry that
             # spelled a control in its own parameters is routing somewhere that
@@ -241,9 +244,14 @@ class ModelSpec:
         # it back keeps that turn on the same rung instead of the ladder's
         # midpoint. Only graded dials seed a level name, which is the whole of
         # WRITE_PATHS, so there is nothing here to misread.
-        declared_default = reasoning.get("default")
+        # It is read before the shadowed default for the same reason the surface
+        # is: a borrowed default belongs to the wider ladder this entry narrowed,
+        # so taking it first moves a default turn off the rung the entry ran.
+        declared_default = own.get("default")
         if declared_default is None:
             declared_default = _seeded_level(surface, parameters, extra_body)
+        if declared_default is None:
+            declared_default = reasoning.get("default")
         default = default_reasoning_effort(efforts, declared_default)
         return cls(
             name=config.get("name", config["model_id"]),

--- a/src/llms/model_spec.py
+++ b/src/llms/model_spec.py
@@ -59,11 +59,13 @@ def reasoning_block(entry: dict | None) -> dict:
     The manifest states it as a single ``reasoning`` block. Custom models saved
     before that block existed carry the same facts as flat ``reasoning_efforts``
     / ``reasoning_effort_default`` keys, so both are read here rather than
-    migrating a preferences column.
+    migrating a preferences column. An empty block declares nothing and so does
+    not answer for the entry: preferring it would strand a stored entry's flat
+    keys, unread by everything downstream of a save that validated them.
     """
     entry = entry or {}
     block = entry.get("reasoning")
-    if isinstance(block, dict):
+    if isinstance(block, dict) and block:
         return block
     flat = {}
     if "reasoning_efforts" in entry:
@@ -222,11 +224,17 @@ class ModelSpec:
         parameters = copy.deepcopy(config.get("parameters") or {})
         extra_body = copy.deepcopy(config.get("extra_body") or {})
         # Gated on the ladder: an entry declaring no levels wants no effort
-        # control at all, not the shadowed model's surface. Inference is the
-        # last resort, for a standalone entry that predates the block.
+        # control at all, not the shadowed model's surface.
         surface = reasoning if efforts else None
-        if efforts and not any(k in reasoning for k in SURFACE_KEYS):
+        if efforts and not any(k in reasoning_block(config) for k in SURFACE_KEYS):
+            # Read against the entry's own block, not the merged one, so the
+            # order below is seed first and borrowed path second. An entry that
+            # spelled a control in its own parameters is routing somewhere that
+            # reads it; writing the level to the built-in's path instead leaves
+            # that seed stale and puts a second control on the wire beside it.
             surface = infer_surface(parameters, extra_body)
+            if not surface and any(k in reasoning for k in SURFACE_KEYS):
+                surface = reasoning
         # An entry that seeded a level into its own parameters and named no
         # default has already said which rung it runs: the mapper used to skip
         # the no-request turn entirely, so that seed was what went out. Reading

--- a/src/llms/model_spec.py
+++ b/src/llms/model_spec.py
@@ -10,7 +10,12 @@ import copy
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from .reasoning import REASONING_LEVELS, infer_surface, validate_surface
+from .reasoning import (
+    REASONING_LEVELS,
+    SURFACE_KEYS,
+    infer_surface,
+    validate_surface,
+)
 
 
 class ManifestSource(Protocol):
@@ -90,9 +95,16 @@ def clamp_reasoning_effort(
     return at_or_below[-1] if at_or_below else efforts[0]
 
 
-#: The keys of a ``reasoning`` block that say where a level is written, as
-#: opposed to which levels exist.
-SURFACE_KEYS = ("write", "on", "off")
+def _seeded_level(surface: dict | None, parameters: dict, extra_body: dict) -> Any:
+    """The level already sitting at a surface's own write path, if any."""
+    write = (surface or {}).get("write")
+    if not isinstance(write, str):
+        return None
+    lane, *rest = write.split(".")
+    node = {"parameters": parameters, "extra_body": extra_body}.get(lane)
+    for segment in rest:
+        node = node.get(segment) if isinstance(node, dict) else None
+    return node
 
 
 def _checked_surface(name: str, reasoning: dict | None) -> dict:
@@ -205,8 +217,8 @@ class ModelSpec:
         reasoning = reasoning_block(declared)
         efforts = canonical_reasoning_efforts(reasoning.get("efforts"))
         declared_response_api = config.get("_use_response_api")
-        # Deep-copied because the borrowed block shares its nested dicts with
-        # the process-wide manifest, and the mapper writes into these.
+        # Deep-copied because the mapper writes into these in place, and they
+        # would otherwise be the caller's own stored preference dicts.
         parameters = copy.deepcopy(config.get("parameters") or {})
         extra_body = copy.deepcopy(config.get("extra_body") or {})
         # Gated on the ladder: an entry declaring no levels wants no effort
@@ -215,7 +227,16 @@ class ModelSpec:
         surface = reasoning if efforts else None
         if efforts and not any(k in reasoning for k in SURFACE_KEYS):
             surface = infer_surface(parameters, extra_body)
-        default = default_reasoning_effort(efforts, reasoning.get("default"))
+        # An entry that seeded a level into its own parameters and named no
+        # default has already said which rung it runs: the mapper used to skip
+        # the no-request turn entirely, so that seed was what went out. Reading
+        # it back keeps that turn on the same rung instead of the ladder's
+        # midpoint. Only graded dials seed a level name, which is the whole of
+        # WRITE_PATHS, so there is nothing here to misread.
+        declared_default = reasoning.get("default")
+        if declared_default is None:
+            declared_default = _seeded_level(surface, parameters, extra_body)
+        default = default_reasoning_effort(efforts, declared_default)
         return cls(
             name=config.get("name", config["model_id"]),
             model_id=config["model_id"],

--- a/src/llms/model_spec.py
+++ b/src/llms/model_spec.py
@@ -10,7 +10,7 @@ import copy
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from .reasoning import REASONING_LEVELS, apply_reasoning_effort
+from .reasoning import REASONING_LEVELS, infer_surface, validate_surface
 
 
 class ManifestSource(Protocol):
@@ -48,6 +48,26 @@ def default_reasoning_effort(
     return efforts[len(efforts) // 2]
 
 
+def reasoning_block(entry: dict | None) -> dict:
+    """One model's reasoning declaration, from either shape it may be stored in.
+
+    The manifest states it as a single ``reasoning`` block. Custom models saved
+    before that block existed carry the same facts as flat ``reasoning_efforts``
+    / ``reasoning_effort_default`` keys, so both are read here rather than
+    migrating a preferences column.
+    """
+    entry = entry or {}
+    block = entry.get("reasoning")
+    if isinstance(block, dict):
+        return block
+    flat = {}
+    if "reasoning_efforts" in entry:
+        flat["efforts"] = entry["reasoning_efforts"]
+    if "reasoning_effort_default" in entry:
+        flat["default"] = entry["reasoning_effort_default"]
+    return flat
+
+
 def clamp_reasoning_effort(
     efforts: tuple[str, ...] | list[str], default: str | None, requested: str
 ) -> str | None:
@@ -77,31 +97,32 @@ def clamp_reasoning_effort(
 #: the only compaction declaration the manifest actually makes:
 #: ``compaction_profile_for`` reads the named profile first and the window's
 #: band second, and every manifest row answers by window.
+#: The keys of a ``reasoning`` block that say where a level is written, as
+#: opposed to which levels exist.
+SURFACE_KEYS = ("write", "on", "off")
+
+
+def _checked_surface(name: str, reasoning: dict | None) -> dict:
+    """Just the write half of a ``reasoning`` block, validated.
+
+    Validated at spec-build time rather than on the request path so an unknown
+    path is a startup error naming the model, not a silent no-op on the wire.
+    """
+    if not reasoning:
+        return {}
+    validate_surface(name, reasoning)
+    return {k: reasoning[k] for k in SURFACE_KEYS if k in reasoning}
+
+
+#: ``reasoning`` is inherited whole: a borrowed ladder needs somewhere to be
+#: written, and an entry taking the levels but not the write path would resolve
+#: a level that lands nowhere.
 SHADOW_INHERITED = (
-    "reasoning_efforts",
-    "reasoning_effort_default",
+    "reasoning",
     "prompt_guidance",
     "compaction_profile",
     "context",
 )
-
-
-#: Where a level is written, per vendor. ``apply_reasoning_effort`` dispatches on
-#: whichever of these the model already declares and has no default branch, so a
-#: shadow that borrowed a ladder has to borrow the surface too or the level it
-#: resolves lands nowhere.
-REASONING_SURFACE_KEYS = (
-    "reasoning",
-    "output_config",
-    "thinking",
-    "thinking_level",
-    "reasoning_effort",
-)
-
-
-def _surface_of(declared: dict | None) -> dict:
-    """Just the reasoning keys out of a model's parameters or extra_body."""
-    return {k: v for k, v in (declared or {}).items() if k in REASONING_SURFACE_KEYS}
 
 
 def with_inherited_declarations(entry: dict, shadowed: dict | None) -> dict:
@@ -129,6 +150,8 @@ class ModelSpec:
     additional_betas: tuple[str, ...] = ()
     reasoning_efforts: tuple[str, ...] = ()
     reasoning_effort_default: str | None = None
+    #: Where this model's effort level is written. Empty means no effort control.
+    reasoning_surface: dict[str, Any] = field(default_factory=dict)
     #: Platform proxy to route through when the caller brings no key of its own.
     system_provider: str | None = None
     #: SDK to assume when the provider is not in the manifest at all. A manifest
@@ -143,7 +166,8 @@ class ModelSpec:
         info = model_config.get_model_config(model_name)
         if not info:
             raise ValueError(f"Model {model_name} not found in models.json")
-        efforts = canonical_reasoning_efforts(info.get("reasoning_efforts"))
+        reasoning = reasoning_block(info)
+        efforts = canonical_reasoning_efforts(reasoning.get("efforts"))
         return cls(
             name=model_name,
             model_id=info["model_id"],
@@ -153,8 +177,9 @@ class ModelSpec:
             additional_betas=tuple(info.get("additional_betas") or ()),
             reasoning_efforts=efforts,
             reasoning_effort_default=default_reasoning_effort(
-                efforts, info.get("reasoning_effort_default")
+                efforts, reasoning.get("default")
             ),
+            reasoning_surface=_checked_surface(model_name, reasoning),
             system_provider=info.get("system_provider"),
         )
 
@@ -167,38 +192,20 @@ class ModelSpec:
         itself is the built-in's to declare.
         """
         declared = with_inherited_declarations(config, shadowed)
-        efforts = canonical_reasoning_efforts(declared.get("reasoning_efforts"))
+        reasoning = reasoning_block(declared)
+        efforts = canonical_reasoning_efforts(reasoning.get("efforts"))
         declared_response_api = config.get("_use_response_api")
-        own_params = config.get("parameters") or {}
-        own_extra = config.get("extra_body") or {}
-        # All or nothing, and across both containers, because one model can
-        # spell its control in either: an entry naming any reasoning key owns
-        # the surface, and filling in the vendors it left out would put a
-        # second, never-written control on the wire beside the one it declared.
-        # Gated on the ladder too -- an entry declaring no levels wants no
-        # reasoning key at all, not the shadowed model's default.
-        inherits_surface = (
-            bool(efforts)
-            and shadowed is not None
-            and not any(k in own_params or k in own_extra for k in REASONING_SURFACE_KEYS)
-        )
-        # Deep-copied before anything writes to them: the borrowed surface shares
-        # its nested dicts with the process-wide manifest.
-        parameters = copy.deepcopy(
-            {**own_params, **_surface_of(shadowed.get("parameters"))} if inherits_surface else own_params
-        )
-        extra_body = copy.deepcopy(
-            {**own_extra, **_surface_of(shadowed.get("extra_body"))} if inherits_surface else own_extra
-        )
-        default = default_reasoning_effort(efforts, declared.get("reasoning_effort_default"))
-        if inherits_surface and default:
-            # A borrowed surface carries the built-in's level, which is not this
-            # entry's answer: an entry may narrow the ladder or name its own
-            # default. Writing the resolved default into it keeps what a call
-            # with no request reports and what the wire carries from disagreeing,
-            # which is the invariant every manifest row already satisfies. Only
-            # for a surface we seeded; a level the entry typed itself is its own.
-            apply_reasoning_effort(default, parameters, extra_body)
+        # Deep-copied because the borrowed block shares its nested dicts with
+        # the process-wide manifest, and the mapper writes into these.
+        parameters = copy.deepcopy(config.get("parameters") or {})
+        extra_body = copy.deepcopy(config.get("extra_body") or {})
+        # Gated on the ladder: an entry declaring no levels wants no effort
+        # control at all, not the shadowed model's surface. Inference is the
+        # last resort, for a standalone entry that predates the block.
+        surface = reasoning if efforts else None
+        if efforts and not (reasoning.get("write") or reasoning.get("on") or reasoning.get("off")):
+            surface = infer_surface(parameters, extra_body)
+        default = default_reasoning_effort(efforts, reasoning.get("default"))
         return cls(
             name=config.get("name", config["model_id"]),
             model_id=config["model_id"],
@@ -208,6 +215,9 @@ class ModelSpec:
             additional_betas=tuple(config.get("additional_betas") or ()),
             reasoning_efforts=efforts,
             reasoning_effort_default=default,
+            reasoning_surface=_checked_surface(
+                config.get("name", config["model_id"]), copy.deepcopy(surface)
+            ),
             sdk_fallback="openai",
             use_response_api_override=(
                 None if declared_response_api is None else bool(declared_response_api)

--- a/src/llms/model_spec.py
+++ b/src/llms/model_spec.py
@@ -116,11 +116,9 @@ def _checked_surface(name: str, reasoning: dict | None) -> dict:
 #: the only compaction declaration the manifest actually makes:
 #: ``compaction_profile_for`` reads the named profile first and the window's
 #: band second, and every manifest row answers by window. ``reasoning`` is
-#: inherited whole: a borrowed ladder needs somewhere to be written, and an
-#: entry taking the levels but not the write path would resolve a level that
-#: lands nowhere.
+#: handled separately by :func:`with_inherited_declarations`, because it is the
+#: one declaration that is really two.
 SHADOW_INHERITED = (
-    "reasoning",
     "prompt_guidance",
     "compaction_profile",
     "context",
@@ -133,10 +131,20 @@ def with_inherited_declarations(entry: dict, shadowed: dict | None) -> dict:
     Presence, not truthiness: an entry declaring ``reasoning_efforts: []`` is
     saying the model honors no levels, and the shadowed ladder must not
     overwrite that answer.
+
+    ``reasoning`` fills in key by key rather than whole, because the block
+    bundles two declarations -- which levels exist, and where the chosen one is
+    written -- and an entry that names one still needs the other. Inheriting it
+    whole discards a ladder stored in the flat shape, which carries no
+    ``reasoning`` key to block the inheritance; inheriting nothing when the
+    entry names any key at all strands a partial block with no surface.
     """
     if not shadowed:
         return entry
     inherited = {k: shadowed[k] for k in SHADOW_INHERITED if k not in entry and k in shadowed}
+    reasoning = {**reasoning_block(shadowed), **reasoning_block(entry)}
+    if reasoning:
+        inherited["reasoning"] = reasoning
     return {**entry, **inherited} if inherited else entry
 
 

--- a/src/llms/model_spec.py
+++ b/src/llms/model_spec.py
@@ -90,13 +90,6 @@ def clamp_reasoning_effort(
     return at_or_below[-1] if at_or_below else efforts[0]
 
 
-#: What a custom entry inherits from a built-in whose name it takes. Routing --
-#: model_id, provider, parameters -- is the entry's whole reason to exist and
-#: never inherits. These say what the model honors, and a shadow is the same
-#: model reached through the user's own key. ``context`` is here because it is
-#: the only compaction declaration the manifest actually makes:
-#: ``compaction_profile_for`` reads the named profile first and the window's
-#: band second, and every manifest row answers by window.
 #: The keys of a ``reasoning`` block that say where a level is written, as
 #: opposed to which levels exist.
 SURFACE_KEYS = ("write", "on", "off")
@@ -105,8 +98,10 @@ SURFACE_KEYS = ("write", "on", "off")
 def _checked_surface(name: str, reasoning: dict | None) -> dict:
     """Just the write half of a ``reasoning`` block, validated.
 
-    Validated at spec-build time rather than on the request path so an unknown
-    path is a startup error naming the model, not a silent no-op on the wire.
+    Raises rather than dropping the bad path, so a typo is a loud error naming
+    the model instead of a silent no-op on the wire. Spec-building is per
+    request, so for manifest rows the suite is what catches one first:
+    ``test_reasoning_efforts_manifest`` builds every entry.
     """
     if not reasoning:
         return {}
@@ -114,9 +109,16 @@ def _checked_surface(name: str, reasoning: dict | None) -> dict:
     return {k: reasoning[k] for k in SURFACE_KEYS if k in reasoning}
 
 
-#: ``reasoning`` is inherited whole: a borrowed ladder needs somewhere to be
-#: written, and an entry taking the levels but not the write path would resolve
-#: a level that lands nowhere.
+#: What a custom entry inherits from a built-in whose name it takes. Routing --
+#: model_id, provider, parameters -- is the entry's whole reason to exist and
+#: never inherits. These say what the model honors, and a shadow is the same
+#: model reached through the user's own key. ``context`` is here because it is
+#: the only compaction declaration the manifest actually makes:
+#: ``compaction_profile_for`` reads the named profile first and the window's
+#: band second, and every manifest row answers by window. ``reasoning`` is
+#: inherited whole: a borrowed ladder needs somewhere to be written, and an
+#: entry taking the levels but not the write path would resolve a level that
+#: lands nowhere.
 SHADOW_INHERITED = (
     "reasoning",
     "prompt_guidance",
@@ -203,7 +205,7 @@ class ModelSpec:
         # control at all, not the shadowed model's surface. Inference is the
         # last resort, for a standalone entry that predates the block.
         surface = reasoning if efforts else None
-        if efforts and not (reasoning.get("write") or reasoning.get("on") or reasoning.get("off")):
+        if efforts and not any(k in reasoning for k in SURFACE_KEYS):
             surface = infer_surface(parameters, extra_body)
         default = default_reasoning_effort(efforts, reasoning.get("default"))
         return cls(
@@ -216,7 +218,7 @@ class ModelSpec:
             reasoning_efforts=efforts,
             reasoning_effort_default=default,
             reasoning_surface=_checked_surface(
-                config.get("name", config["model_id"]), copy.deepcopy(surface)
+                config.get("name", config["model_id"]), surface
             ),
             sdk_fallback="openai",
             use_response_api_override=(

--- a/src/llms/reasoning.py
+++ b/src/llms/reasoning.py
@@ -43,6 +43,7 @@ WRITE_PATHS = (
     "parameters.output_config.effort",
     "parameters.thinking_level",
     "parameters.reasoning_effort",
+    "extra_body.reasoning.effort",
     "extra_body.reasoning_effort",
 )
 
@@ -57,6 +58,12 @@ PATCH_PATHS = frozenset(
         "extra_body.thinking.clear_thinking",
     }
 )
+
+
+#: The keys that say *where* a level goes, as opposed to which levels exist.
+#: Beside the allowlists they partition, because a key added to the mapper and
+#: not to this tuple is dropped by ``_checked_surface`` without a word.
+SURFACE_KEYS = ("write", "on", "off")
 
 
 class ReasoningSurfaceError(ValueError):

--- a/src/llms/reasoning.py
+++ b/src/llms/reasoning.py
@@ -1,15 +1,15 @@
 """Unified reasoning effort mapper.
 
-Translates a level the manifest has **already guaranteed** the model accepts
-into that provider's native parameter. Detection-based: the shape of the model's
-``parameters``/``extra_body`` says which surface it speaks, so adding a model
-never means editing a list in here.
+Translates a level the manifest has **already guaranteed** the model accepts into
+that provider's native parameter. Each entry names its own surface in a
+``reasoning_surface`` block, so the mapping is a declaration rather than a guess
+about which key the entry happened to carry.
 
 Nothing is clamped here. A level outside the model's declared
 ``reasoning_efforts`` is resolved upstream by ``clamp_reasoning_effort`` in
-``llm.py``, the only place that can see the enum, which steps down to the
-nearest level the model does offer. By the time a request reaches this function
-the level is known-good, so a lossy fallback here would only hide a bug.
+``llm.py``, the only place that can see the enum, which steps down to the nearest
+level the model does offer. By the time a request reaches this function the level
+is known-good, so a lossy fallback here would only hide a bug.
 """
 
 from typing import Literal, get_args
@@ -30,150 +30,136 @@ REASONING_LEVELS: tuple[ReasoningLevel, ...] = get_args(ReasoningLevel)
 #: than off ``low``, which is a real thinking level everywhere that grades.
 OFF_LEVELS = frozenset({"none"})
 
-# Anthropic-compatible endpoints take a token budget rather than a level name.
-_ANTHROPIC_BUDGETS = {
-    "minimal": 2000,
-    "low": 5000,
-    "medium": 10000,
-    "high": 32000,
-    "xhigh": 64000,
-    "max": 128000,
-}
+#: Paths a ``write`` may target: graded dials that take a level name verbatim.
+#: Closed on purpose. A dotted string makes a typo look structurally valid, and
+#: a write to a misspelled path lands somewhere the vendor ignores and returns
+#: 200 for, which is the exact silent failure this block exists to remove.
+WRITE_PATHS = frozenset(
+    {
+        "parameters.reasoning.effort",
+        "parameters.output_config.effort",
+        "parameters.reasoning_effort",
+        "parameters.thinking_level",
+        "extra_body.reasoning_effort",
+    }
+)
+
+#: Paths an ``on``/``off`` patch may target. Wider than :data:`WRITE_PATHS`
+#: because a patch also flips mode switches, and narrower in intent: a patch
+#: carries a literal from the manifest, never the level.
+PATCH_PATHS = frozenset(
+    {
+        "parameters.output_config.effort",
+        "parameters.thinking.type",
+        "extra_body.reasoning_effort",
+        "extra_body.thinking.type",
+        "extra_body.thinking.clear_thinking",
+    }
+)
 
 
-def _budget(table: dict[str, int], level: str) -> int:
-    """Nearest declared budget at or below ``level``.
+class ReasoningSurfaceError(ValueError):
+    """A ``reasoning`` block names a path outside the allowlists."""
 
-    A model may declare a level this ladder has no rung for; walking down the
-    canonical order is still honest, because the level came from that model's
-    own enum and the ladder only decides how many tokens to spend.
+
+def validate_surface(name: str, surface: dict) -> None:
+    """Reject an unknown path at load time, where the manifest author sees it."""
+    write = surface.get("write")
+    if write is not None and write not in WRITE_PATHS:
+        raise ReasoningSurfaceError(
+            f"{name}: reasoning.write={write!r} is not a known write path"
+        )
+    for key in ("on", "off"):
+        for path in surface.get(key) or {}:
+            if path not in PATCH_PATHS:
+                raise ReasoningSurfaceError(
+                    f"{name}: reasoning.{key} path {path!r} is not a known patch path"
+                )
+    if write is None and not (surface.get("on") or surface.get("off")):
+        raise ReasoningSurfaceError(
+            f"{name}: reasoning declares efforts with nowhere to write them"
+        )
+
+
+def infer_surface(parameters: dict | None, extra_body: dict | None) -> dict:
+    """Guess the surface of a user-supplied entry that declared none.
+
+    Only for BYOK entries. A manifest row states its surface outright; a user
+    pasting an OpenAI-compatible config cannot be asked to name a write path, and
+    entries stored before the block existed carry only the seed. Graded dials
+    only — a mode switch or a token budget has to be declared, because there is
+    no seed value that distinguishes one from a dial's starting point.
     """
-    if level in table:
-        return table[level]
-    idx = REASONING_LEVELS.index(level)
-    for candidate in reversed(REASONING_LEVELS[:idx]):
-        if candidate in table:
-            return table[candidate]
-    return min(table.values())
+    lanes = {"parameters": parameters or {}, "extra_body": extra_body or {}}
+    for path in sorted(WRITE_PATHS):
+        lane, *rest = path.split(".")
+        node = lanes[lane]
+        for segment in rest[:-1]:
+            node = node.get(segment) if isinstance(node, dict) else None
+        if isinstance(node, dict) and rest[-1] in node:
+            return {"write": path}
+    return {}
 
 
-def _switch_off(container: dict) -> bool:
-    """Flip a declared ``thinking`` mode switch to off; report whether there was one.
-
-    The graded effort key is deliberately left at its declared value. ``none`` is
-    not universally accepted as an effort — DeepSeek rejects it with a 400, and
-    GLM keeps on thinking through it — so on a surface carrying both a switch and
-    a dial, only the switch reliably means off.
-    """
-    declared = container.get("thinking")
-    if not isinstance(declared, dict):
-        return False
-    # Bare, not merged: Anthropic's `thinking` is a discriminated union, and the
-    # disabled variant rejects the `budget_tokens` the enabled one requires.
-    # Siblings only ever describe reasoning output, which off does not produce.
-    container["thinking"] = {"type": "disabled"}
-    return True
+def _put(lanes: dict[str, dict], path: str, value) -> None:
+    lane, *rest = path.split(".")
+    node = lanes[lane]
+    for segment in rest[:-1]:
+        child = node.get(segment)
+        if not isinstance(child, dict):
+            child = {}
+            node[segment] = child
+        node = child
+    node[rest[-1]] = value
 
 
 def apply_reasoning_effort(
     level: str,
     parameters: dict,
     extra_body: dict,
+    surface: dict | None = None,
 ) -> tuple[dict, dict]:
     """Apply a reasoning effort level to a model's request parameters.
+
+    ``off`` replaces the graded write rather than layering over it: on a surface
+    carrying both a switch and a dial, only the switch reliably means off, and
+    the two would otherwise contradict each other in the same payload.
 
     Args:
         level: A level from :data:`REASONING_LEVELS`, already validated against
             the model's declared ``reasoning_efforts``.
         parameters: Model parameters dict (mutated in place).
         extra_body: Extra body dict (mutated in place).
+        surface: The model's ``reasoning_surface`` block. Absent means the model
+            offers no effort control, and nothing is written.
 
     Returns:
         Tuple of (parameters, extra_body) — the same objects, mutated.
     """
-    if level not in REASONING_LEVELS:
+    if not surface or level not in REASONING_LEVELS:
         return parameters, extra_body
 
-    off = level in OFF_LEVELS
+    lanes = {"parameters": parameters, "extra_body": extra_body}
+    off_patch = surface.get("off")
 
-    # --- parameters-based surfaces ---
+    if level in OFF_LEVELS and off_patch:
+        # `off` states the whole reasoning payload rather than layering over
+        # what is there: a mode switch sits in a discriminated union whose
+        # disabled variant rejects the siblings the enabled one requires, so a
+        # caller-supplied `budget_tokens` must not survive next to it. Cleared
+        # in its own pass first, or two paths sharing a container would wipe
+        # each other's write.
+        for path in off_patch:
+            lane, *rest = path.split(".")
+            if len(rest) > 1:
+                lanes[lane][rest[0]] = {}
+        for path, value in off_patch.items():
+            _put(lanes, path, value)
+        return parameters, extra_body
 
-    # OpenAI: parameters.reasoning.effort
-    if "reasoning" in parameters:
-        if isinstance(parameters["reasoning"], dict):
-            parameters["reasoning"]["effort"] = level
-        else:
-            parameters["reasoning"] = {"effort": level}
-
-    # Anthropic graded: output_config.effort carries the level natively. Declaring
-    # it is what marks the surface as graded — a model whose only control is a
-    # `thinking` switch falls through to the mode-switch branch below.
-    elif "output_config" in parameters:
-        if not (off and _switch_off(parameters)):
-            parameters.setdefault("output_config", {})["effort"] = level
-
-    # Anthropic-compatible `thinking`: a budget dial, unless the declared type is
-    # `adaptive` (MiniMax), which is a bare on/off switch the vendor sizes itself.
-    elif "thinking" in parameters:
-        declared = (
-            parameters["thinking"] if isinstance(parameters["thinking"], dict) else {}
-        )
-        if off:
-            parameters["thinking"] = {"type": "disabled"}
-        elif declared.get("type") != "adaptive":
-            parameters["thinking"] = {
-                **declared,
-                "type": "enabled",
-                "budget_tokens": _budget(_ANTHROPIC_BUDGETS, level),
-            }
-
-    # Gemini 3.x: parameters.thinking_level
-    elif "thinking_level" in parameters:
-        parameters["thinking_level"] = level
-
-    # vLLM / Groq / Cerebras: parameters.reasoning_effort
-    elif "reasoning_effort" in parameters:
-        parameters["reasoning_effort"] = level
-
-    # --- extra_body surfaces ---
-    #
-    # Chained, not independent `if`s. glm-5.2 declares both `thinking.type` and
-    # `reasoning_effort`; when both fired, one of the two keys was dead weight.
-    # `reasoning_effort` is the graded control, so it wins for every thinking
-    # level — but not for off, which it does not honor (`reasoning_effort:
-    # "none"` still returned ~165 reasoning tokens; the switch returned zero).
-
-    # Zhipu / Z.ai GLM: extra_body.reasoning_effort, native level names.
-    if "reasoning_effort" in extra_body:
-        if not (off and _switch_off(extra_body)):
-            extra_body["reasoning_effort"] = level
-
-    # Dashscope / Qwen: extra_body.reasoning.effort, native level names.
-    # Same seven levels as our canonical vocabulary, `none` included, so the
-    # level goes out verbatim. Nested rather than flat, which is the only thing
-    # separating this from the GLM surface above.
-    elif "reasoning" in extra_body:
-        if isinstance(extra_body["reasoning"], dict):
-            extra_body["reasoning"]["effort"] = level
-        else:
-            extra_body["reasoning"] = {"effort": level}
-
-    # extra_body.thinking.type is a mode switch, not a dial. The on-value comes
-    # from the manifest rather than a constant: vendors spell it differently
-    # (`enabled` on GLM, `adaptive` on MiniMax) and a hardcoded one is silently
-    # wrong on the other.
-    elif "thinking" in extra_body:
-        declared = (
-            extra_body["thinking"] if isinstance(extra_body["thinking"], dict) else {}
-        )
-        # A declared `disabled` is a seed meaning "off unless asked", not a
-        # usable on-value, so it falls back rather than pinning thinking off.
-        declared_type = declared.get("type")
-        on_value = (
-            declared_type if declared_type not in (None, "disabled") else "enabled"
-        )
-        extra_body["thinking"] = (
-            {"type": "disabled"} if off else {**declared, "type": on_value}
-        )
+    for path, value in (surface.get("on") or {}).items():
+        _put(lanes, path, value)
+    if write := surface.get("write"):
+        _put(lanes, write, level)
 
     return parameters, extra_body

--- a/src/llms/reasoning.py
+++ b/src/llms/reasoning.py
@@ -1,9 +1,9 @@
 """Unified reasoning effort mapper.
 
 Translates a level the manifest has **already guaranteed** the model accepts into
-that provider's native parameter. Each entry names its own surface in a
-``reasoning_surface`` block, so the mapping is a declaration rather than a guess
-about which key the entry happened to carry.
+that provider's native parameter. Each entry names its own surface in its
+``reasoning`` block, so the mapping is a declaration rather than a guess about
+which key the entry happened to carry.
 
 Nothing is clamped here. A level outside the model's declared
 ``reasoning_efforts`` is resolved upstream by ``clamp_reasoning_effort`` in
@@ -34,24 +34,25 @@ OFF_LEVELS = frozenset({"none"})
 #: Closed on purpose. A dotted string makes a typo look structurally valid, and
 #: a write to a misspelled path lands somewhere the vendor ignores and returns
 #: 200 for, which is the exact silent failure this block exists to remove.
-WRITE_PATHS = frozenset(
-    {
-        "parameters.reasoning.effort",
-        "parameters.output_config.effort",
-        "parameters.reasoning_effort",
-        "parameters.thinking_level",
-        "extra_body.reasoning_effort",
-    }
+#:
+#: Ordered, not a set: :func:`infer_surface` takes the first seed it finds, so
+#: an entry seeded on two dials resolves to the ``parameters`` lane, where a
+#: typed SDK field lives, rather than to whichever path sorts first.
+WRITE_PATHS = (
+    "parameters.reasoning.effort",
+    "parameters.output_config.effort",
+    "parameters.thinking_level",
+    "parameters.reasoning_effort",
+    "extra_body.reasoning_effort",
 )
 
-#: Paths an ``on``/``off`` patch may target. Wider than :data:`WRITE_PATHS`
-#: because a patch also flips mode switches, and narrower in intent: a patch
-#: carries a literal from the manifest, never the level.
+#: Paths an ``on``/``off`` patch may target: mode switches, which take a vendor
+#: literal rather than a level. Disjoint from :data:`WRITE_PATHS` on purpose --
+#: a patch that could name a dial is how an ``off`` block ends up restating the
+#: entry's own graded write, which then contradicts the switch beside it.
 PATCH_PATHS = frozenset(
     {
-        "parameters.output_config.effort",
         "parameters.thinking.type",
-        "extra_body.reasoning_effort",
         "extra_body.thinking.type",
         "extra_body.thinking.clear_thinking",
     }
@@ -63,7 +64,12 @@ class ReasoningSurfaceError(ValueError):
 
 
 def validate_surface(name: str, surface: dict) -> None:
-    """Reject an unknown path at load time, where the manifest author sees it."""
+    """Reject a block that cannot do what its ladder advertises.
+
+    Runs where the author is still holding it: the manifest suite builds every
+    entry, and the preferences endpoint checks a custom one on save. Past here
+    a bad path is a 200 the vendor ignores.
+    """
     write = surface.get("write")
     if write is not None and write not in WRITE_PATHS:
         raise ReasoningSurfaceError(
@@ -80,6 +86,23 @@ def validate_surface(name: str, surface: dict) -> None:
             f"{name}: reasoning declares efforts with nowhere to write them"
         )
 
+    # Checked against the ladder, which only a full block carries: an inferred
+    # surface has no efforts and no rung to be wrong about.
+    efforts = surface.get("efforts") or ()
+    if not efforts:
+        return
+    off_rungs = sorted(OFF_LEVELS.intersection(efforts))
+    if surface.get("on") and not surface.get("off") and off_rungs:
+        raise ReasoningSurfaceError(
+            f"{name}: reasoning offers {off_rungs} but declares no `off`, so the "
+            f"off rung would apply `on` and turn thinking on"
+        )
+    if surface.get("off") and not off_rungs:
+        raise ReasoningSurfaceError(
+            f"{name}: reasoning declares `off` but no level in efforts means off, "
+            f"so the patch can never be applied"
+        )
+
 
 def infer_surface(parameters: dict | None, extra_body: dict | None) -> dict:
     """Guess the surface of a user-supplied entry that declared none.
@@ -91,7 +114,7 @@ def infer_surface(parameters: dict | None, extra_body: dict | None) -> dict:
     no seed value that distinguishes one from a dial's starting point.
     """
     lanes = {"parameters": parameters or {}, "extra_body": extra_body or {}}
-    for path in sorted(WRITE_PATHS):
+    for path in WRITE_PATHS:
         lane, *rest = path.split(".")
         node = lanes[lane]
         for segment in rest[:-1]:
@@ -130,8 +153,8 @@ def apply_reasoning_effort(
             the model's declared ``reasoning_efforts``.
         parameters: Model parameters dict (mutated in place).
         extra_body: Extra body dict (mutated in place).
-        surface: The model's ``reasoning_surface`` block. Absent means the model
-            offers no effort control, and nothing is written.
+        surface: The write half of the model's ``reasoning`` block. Absent means
+            the model offers no effort control, and nothing is written.
 
     Returns:
         Tuple of (parameters, extra_body) — the same objects, mutated.
@@ -143,12 +166,11 @@ def apply_reasoning_effort(
     off_patch = surface.get("off")
 
     if level in OFF_LEVELS and off_patch:
-        # `off` states the whole reasoning payload rather than layering over
-        # what is there: a mode switch sits in a discriminated union whose
-        # disabled variant rejects the siblings the enabled one requires, so a
-        # caller-supplied `budget_tokens` must not survive next to it. Cleared
-        # in its own pass first, or two paths sharing a container would wipe
-        # each other's write.
+        # Each container the patch touches is reset, not merged into: a mode
+        # switch sits in a discriminated union whose disabled variant rejects
+        # the siblings the enabled one requires, so a caller-supplied
+        # `budget_tokens` must not survive next to it. Reset in its own pass
+        # first, or two paths sharing a container would wipe each other's write.
         for path in off_patch:
             lane, *rest = path.split(".")
             if len(rest) > 1:

--- a/src/llms/reasoning.py
+++ b/src/llms/reasoning.py
@@ -102,9 +102,27 @@ def validate_surface(name: str, surface: dict) -> None:
     efforts = surface.get("efforts") or ()
     if not efforts:
         return
+    # Before any set operation: the levels arrive from a stored preferences bag,
+    # and one unhashable element would raise out of the intersection below,
+    # turning a save this function exists to answer with a 400 into a 500.
+    unknown = [lv for lv in efforts if not isinstance(lv, str) or lv not in REASONING_LEVELS]
+    if unknown:
+        raise ReasoningSurfaceError(
+            f"{name}: reasoning.efforts must be drawn from {list(REASONING_LEVELS)}, "
+            f"got {unknown!r}"
+        )
     if write is None and not (surface.get("on") or surface.get("off")):
         raise ReasoningSurfaceError(
             f"{name}: reasoning declares efforts with nowhere to write them"
+        )
+    # A patch is one payload, so a surface with no graded write can tell exactly
+    # two states apart. More rungs than that is the lie the block exists to
+    # remove: buttons the UI renders as distinct that emit the same request.
+    on_rungs = [lv for lv in efforts if lv not in OFF_LEVELS]
+    if write is None and len(on_rungs) > 1:
+        raise ReasoningSurfaceError(
+            f"{name}: reasoning declares no `write`, so {on_rungs} all apply the "
+            f"same `on` patch and reach the provider identically"
         )
     off_rungs = sorted(OFF_LEVELS.intersection(efforts))
     if surface.get("on") and not surface.get("off") and off_rungs:
@@ -181,6 +199,19 @@ def apply_reasoning_effort(
     off_patch = surface.get("off")
 
     if level in OFF_LEVELS and off_patch:
+        # The graded write goes first, wherever it came from -- the entry's own
+        # seed or a caller override merged in above. Leaving it is the payload
+        # this branch exists to prevent: a live effort beside the instruction
+        # not to think. Only that one key, since its container is the entry's
+        # own transport config.
+        write = surface.get("write")
+        if write:
+            lane, *rest = write.split(".")
+            node = lanes[lane]
+            for segment in rest[:-1]:
+                node = node.get(segment) if isinstance(node, dict) else None
+            if isinstance(node, dict):
+                node.pop(rest[-1], None)
         # Each container the patch touches is reset, not merged into: a mode
         # switch sits in a discriminated union whose disabled variant rejects
         # the siblings the enabled one requires, so a caller-supplied

--- a/src/llms/reasoning.py
+++ b/src/llms/reasoning.py
@@ -68,8 +68,16 @@ def validate_surface(name: str, surface: dict) -> None:
 
     Runs where the author is still holding it: the manifest suite builds every
     entry, and the preferences endpoint checks a custom one on save. Past here
-    a bad path is a 200 the vendor ignores.
+    a bad path is a 200 the vendor ignores, and a wrongly typed one is an
+    exception raised on every turn from data that was accepted once.
     """
+    for key, expected in (("write", str), ("on", dict), ("off", dict), ("efforts", list)):
+        value = surface.get(key)
+        if value is not None and not isinstance(value, expected):
+            raise ReasoningSurfaceError(
+                f"{name}: reasoning.{key} must be a {expected.__name__}, "
+                f"got {type(value).__name__}"
+            )
     write = surface.get("write")
     if write is not None and write not in WRITE_PATHS:
         raise ReasoningSurfaceError(
@@ -81,16 +89,16 @@ def validate_surface(name: str, surface: dict) -> None:
                 raise ReasoningSurfaceError(
                     f"{name}: reasoning.{key} path {path!r} is not a known patch path"
                 )
+    # The rest is the block checked against its own ladder. Only a full block
+    # carries one -- an inferred surface has no efforts and no rung to be wrong
+    # about -- and a surface with no levels behind it writes nothing anyway.
+    efforts = surface.get("efforts") or ()
+    if not efforts:
+        return
     if write is None and not (surface.get("on") or surface.get("off")):
         raise ReasoningSurfaceError(
             f"{name}: reasoning declares efforts with nowhere to write them"
         )
-
-    # Checked against the ladder, which only a full block carries: an inferred
-    # surface has no efforts and no rung to be wrong about.
-    efforts = surface.get("efforts") or ()
-    if not efforts:
-        return
     off_rungs = sorted(OFF_LEVELS.intersection(efforts))
     if surface.get("on") and not surface.get("off") and off_rungs:
         raise ReasoningSurfaceError(

--- a/src/server/app/users.py
+++ b/src/server/app/users.py
@@ -383,10 +383,10 @@ def _validate_custom_models(custom_models: list, custom_providers: list | None =
             )
 
         # Either shape: a `reasoning` block, or the flat keys entries saved
-        # before it existed still carry. Whichever it used is written back to.
-        # Truthiness, not isinstance: `reasoning: {}` declares nothing, and
-        # binding to it would leave the entry's flat keys unread by every check
-        # below while `reasoning_block` still preferred the empty dict.
+        # before it existed still carry. Whichever it used is written back to,
+        # which is why the shapes are read apart here rather than through
+        # `reasoning_block`: its normalized view cannot say which key to
+        # rewrite. Empty means unused, on the same terms as that function.
         block = cm.get("reasoning")
         declared = block if isinstance(block, dict) and block else cm
         efforts_key = "efforts" if declared is not cm else "reasoning_efforts"

--- a/src/server/app/users.py
+++ b/src/server/app/users.py
@@ -267,7 +267,12 @@ def _validate_custom_models(custom_models: list, custom_providers: list | None =
     from ptc_agent.agent.prompts.guidance import VALID_GUIDANCE
 
     from src.llms.llm import LLM, CUSTOM_MODEL_NAME_RE
-    from src.llms.reasoning import REASONING_LEVELS
+    from src.llms.model_spec import reasoning_block
+    from src.llms.reasoning import (
+        REASONING_LEVELS,
+        ReasoningSurfaceError,
+        validate_surface,
+    )
 
     if not isinstance(custom_models, list):
         raise HTTPException(status_code=400, detail="custom_models must be a list")
@@ -333,13 +338,22 @@ def _validate_custom_models(custom_models: list, custom_providers: list | None =
                 detail=f"custom_models[{idx}]: provider '{provider}' is not a known BYOK-eligible or custom provider",
             )
 
-        for field in ("parameters", "extra_body"):
+        for field in ("parameters", "extra_body", "reasoning"):
             val = cm.get(field)
             if val is not None and not isinstance(val, dict):
                 raise HTTPException(
                     status_code=400,
                     detail=f"custom_models[{idx}]: {field} must be a JSON object",
                 )
+
+        # Rejected here rather than at request time: an unknown write path is
+        # accepted by the vendor and ignored, so the entry would render an
+        # effort control that reports a level and sends nothing.
+        if isinstance(cm.get("reasoning"), dict) and cm["reasoning"].get("efforts"):
+            try:
+                validate_surface(f"custom_models[{idx}]", cm["reasoning"])
+            except ReasoningSurfaceError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         modalities = cm.get("input_modalities")
         if modalities is not None:
@@ -368,23 +382,29 @@ def _validate_custom_models(custom_models: list, custom_providers: list | None =
                 detail=f"custom_models[{idx}]: prompt_guidance must be one of {sorted(VALID_GUIDANCE)}",
             )
 
-        efforts = cm.get("reasoning_efforts")
+        # Either shape: a `reasoning` block, or the flat keys entries saved
+        # before it existed still carry. Whichever it used is written back to.
+        declared = cm.get("reasoning") if isinstance(cm.get("reasoning"), dict) else cm
+        efforts_key = "efforts" if declared is not cm else "reasoning_efforts"
+        default_key = "default" if declared is not cm else "reasoning_effort_default"
+
+        efforts = declared.get(efforts_key)
         if efforts is not None:
             if not isinstance(efforts, list) or any(e not in REASONING_LEVELS for e in efforts):
                 raise HTTPException(
                     status_code=400,
-                    detail=f"custom_models[{idx}]: reasoning_efforts must be a list drawn from {list(REASONING_LEVELS)}",
+                    detail=f"custom_models[{idx}]: {efforts_key} must be a list drawn from {list(REASONING_LEVELS)}",
                 )
             # Store in canonical order so the UI renders a ladder, not the
             # order the client happened to send.
-            cm["reasoning_efforts"] = [lv for lv in REASONING_LEVELS if lv in set(efforts)]
+            declared[efforts_key] = [lv for lv in REASONING_LEVELS if lv in set(efforts)]
 
         # An entry shadowing a built-in inherits that model's ladder, so a
         # default may name a level this entry does not list itself.
-        effective_efforts = cm.get("reasoning_efforts")
+        effective_efforts = declared.get(efforts_key)
         if effective_efforts is None:
-            effective_efforts = (mc.get_model_config(name) or {}).get("reasoning_efforts") or []
-        default_effort = cm.get("reasoning_effort_default")
+            effective_efforts = reasoning_block(mc.get_model_config(name)).get("efforts") or []
+        default_effort = declared.get(default_key)
         if default_effort is not None and default_effort not in effective_efforts:
             raise HTTPException(
                 status_code=400,
@@ -469,7 +489,7 @@ def _validate_model_tuning(model_pref: dict, effective: dict) -> None:
     profile is checked against its own model's ladder, which is the whole point
     of the per-model layer.
     """
-    from src.llms.model_spec import canonical_reasoning_efforts
+    from src.llms.model_spec import canonical_reasoning_efforts, reasoning_block
     from src.server.services.llm.user_models import model_entry
 
     try:
@@ -503,7 +523,7 @@ def _validate_model_tuning(model_pref: dict, effective: dict) -> None:
             # model shadows a built-in of the same name, so reading the
             # manifest first would check a shadowed ladder the turn never runs.
             entry = model_entry(effective, model) or {}
-            efforts = list(canonical_reasoning_efforts(entry.get("reasoning_efforts")))
+            efforts = list(canonical_reasoning_efforts(reasoning_block(entry).get("efforts")))
             validate_tuning(profile, where=f"profiles[{model}]", reasoning_efforts=efforts)
     except TuningError as exc:
         raise _tuning_400(exc) from exc
@@ -518,7 +538,7 @@ def _clear_unhonored_efforts(
     the patch never mentions, and nothing else revisits those, so the level
     would sit in Settings naming a step no turn runs.
     """
-    from src.llms.model_spec import canonical_reasoning_efforts
+    from src.llms.model_spec import canonical_reasoning_efforts, reasoning_block
     from src.server.services.llm.user_models import model_entry
 
     # Merged by hand: ``_effective_model_preference`` replaces ``profiles``
@@ -532,7 +552,7 @@ def _clear_unhonored_efforts(
         if effort is None:
             continue
         entry = model_entry(effective, model) or {}
-        if effort in canonical_reasoning_efforts(entry.get("reasoning_efforts")):
+        if effort in canonical_reasoning_efforts(reasoning_block(entry).get("efforts")):
             continue
         patch = model_pref.setdefault("profiles", {})
         patch[model] = {**(patch.get(model) or {}), "reasoning_effort": None}

--- a/src/server/app/users.py
+++ b/src/server/app/users.py
@@ -384,7 +384,11 @@ def _validate_custom_models(custom_models: list, custom_providers: list | None =
 
         # Either shape: a `reasoning` block, or the flat keys entries saved
         # before it existed still carry. Whichever it used is written back to.
-        declared = cm.get("reasoning") if isinstance(cm.get("reasoning"), dict) else cm
+        # Truthiness, not isinstance: `reasoning: {}` declares nothing, and
+        # binding to it would leave the entry's flat keys unread by every check
+        # below while `reasoning_block` still preferred the empty dict.
+        block = cm.get("reasoning")
+        declared = block if isinstance(block, dict) and block else cm
         efforts_key = "efforts" if declared is not cm else "reasoning_efforts"
         default_key = "default" if declared is not cm else "reasoning_effort_default"
 
@@ -408,7 +412,7 @@ def _validate_custom_models(custom_models: list, custom_providers: list | None =
         if default_effort is not None and default_effort not in effective_efforts:
             raise HTTPException(
                 status_code=400,
-                detail=f"custom_models[{idx}]: reasoning_effort_default must be one of {sorted(effective_efforts)}",
+                detail=f"custom_models[{idx}]: {default_key} must be one of {sorted(effective_efforts)}",
             )
 
 

--- a/src/server/app/users.py
+++ b/src/server/app/users.py
@@ -349,7 +349,7 @@ def _validate_custom_models(custom_models: list, custom_providers: list | None =
         # Rejected here rather than at request time: an unknown write path is
         # accepted by the vendor and ignored, so the entry would render an
         # effort control that reports a level and sends nothing.
-        if isinstance(cm.get("reasoning"), dict) and cm["reasoning"].get("efforts"):
+        if isinstance(cm.get("reasoning"), dict) and cm["reasoning"]:
             try:
                 validate_surface(f"custom_models[{idx}]", cm["reasoning"])
             except ReasoningSurfaceError as exc:

--- a/tests/unit/llms/test_custom_model_reasoning_effort.py
+++ b/tests/unit/llms/test_custom_model_reasoning_effort.py
@@ -51,3 +51,46 @@ class TestDeclaredLadderIsHonored:
         )
         assert getattr(client, "reasoning", None) is None
         assert "reasoning_effort" not in client.metadata
+
+
+class TestSurfaceResolution:
+    """Where a BYOK entry's level gets written, now that the manifest declares
+    it rather than leaving it to be guessed from the seed."""
+
+    def test_a_declared_surface_is_used(self):
+        client = _build(
+            {
+                **_CONFIG,
+                "parameters": {"reasoning": {"summary": "auto"}},
+                "reasoning": {
+                    "efforts": ["low", "medium", "high"],
+                    "default": "medium",
+                    "write": "parameters.reasoning.effort",
+                },
+            },
+            reasoning_effort="high",
+        )
+        assert client.reasoning == {"effort": "high", "summary": "auto"}
+
+    def test_a_seed_only_entry_still_works(self):
+        """Entries stored before the block existed carry only the flat keys and
+        the seed. They keep their effort control instead of going quiet."""
+        assert "reasoning" not in _CONFIG
+        client = _build(reasoning_effort="high")
+        assert client.reasoning == {"effort": "high", "summary": "auto"}
+
+    def test_a_shadowing_entry_borrows_the_built_ins_surface(self):
+        """It declares no surface of its own and has no seed to guess from, so
+        the built-in whose name it took is the only thing that can say where
+        the level goes."""
+        client = _build(
+            {
+                "name": "gpt-5.6-sol",
+                "model_id": "gpt-5.6-sol",
+                "provider": "openai",
+                "reasoning_efforts": ["low", "high"],
+            },
+            reasoning_effort="high",
+        )
+        assert client.reasoning == {"effort": "high"}
+        assert client.metadata["reasoning_effort"] == "high"

--- a/tests/unit/llms/test_custom_model_reasoning_effort.py
+++ b/tests/unit/llms/test_custom_model_reasoning_effort.py
@@ -141,6 +141,15 @@ class TestAShadowInheritsTheHalfItDidNotDeclare:
         )
         assert client.reasoning == {"effort": "high"}
 
+    def test_a_seeded_rung_outranks_the_shadowed_default(self):
+        """The entry seeded the rung it runs and named no default of its own,
+        so the built-in's default is not its answer: taking that first resolves
+        to the narrowed ladder's midpoint and moves every default turn up a
+        rung. The pre-block code never did, having skipped the no-request apply
+        entirely and sent the seed."""
+        client = _build({**self.SHADOW, "parameters": {"reasoning_effort": "low"}})
+        assert client.reasoning_effort == "low"
+
     def test_the_entrys_own_seed_outranks_the_borrowed_write_path(self):
         """A shadow that spelled its control itself routes somewhere that reads
         it. Borrowing the built-in's path put the level there instead and left

--- a/tests/unit/llms/test_custom_model_reasoning_effort.py
+++ b/tests/unit/llms/test_custom_model_reasoning_effort.py
@@ -140,3 +140,46 @@ class TestAShadowInheritsTheHalfItDidNotDeclare:
             reasoning_effort="max",
         )
         assert client.reasoning == {"effort": "high"}
+
+    def test_the_entrys_own_seed_outranks_the_borrowed_write_path(self):
+        """A shadow that spelled its control itself routes somewhere that reads
+        it. Borrowing the built-in's path put the level there instead and left
+        the entry's seed stale, so two controls went out and the endpoint read
+        the wrong one -- the case the pre-block code guarded outright."""
+        client = _build(
+            {**self.SHADOW, "parameters": {"reasoning_effort": "high"}},
+            reasoning_effort="low",
+        )
+        assert client.reasoning_effort == "low"
+        assert client.reasoning is None
+
+
+class TestAnEmptyBlockDoesNotAnswerForTheEntry:
+    """``reasoning: {}`` declares nothing, so an entry's flat keys are still its
+    declaration. Reading the block on presence stranded them: the save
+    validated the flat ladder, and every reader after it saw no ladder at all,
+    down to wiping the level the user had already picked.
+    """
+
+    ENTRY = {
+        "name": "my-own-gpt",
+        "model_id": "gpt-5.5",
+        "provider": "openai",
+        "parameters": {"reasoning": {"effort": "medium"}},
+        "reasoning": {},
+        "reasoning_efforts": ["low", "medium", "high"],
+        "reasoning_effort_default": "medium",
+    }
+
+    def test_the_flat_ladder_is_read_past_it(self):
+        client = _build(self.ENTRY, reasoning_effort="high")
+        assert client.reasoning == {"effort": "high"}
+        assert client.metadata["reasoning_effort"] == "high"
+
+    def test_an_empty_ladder_is_a_declaration_and_still_wins(self):
+        """The distinction the check has to keep: an empty block is an absent
+        declaration, an empty ``efforts`` is a declared one. Only the seed the
+        entry wrote itself goes out."""
+        client = _build({**self.ENTRY, "reasoning_efforts": []}, reasoning_effort="high")
+        assert client.reasoning == {"effort": "medium"}
+        assert client.metadata.get("reasoning_effort") is None

--- a/tests/unit/llms/test_custom_model_reasoning_effort.py
+++ b/tests/unit/llms/test_custom_model_reasoning_effort.py
@@ -94,3 +94,49 @@ class TestSurfaceResolution:
         )
         assert client.reasoning == {"effort": "high"}
         assert client.metadata["reasoning_effort"] == "high"
+
+
+class TestAShadowInheritsTheHalfItDidNotDeclare:
+    """A ``reasoning`` block bundles two declarations -- which levels exist and
+    where the chosen one is written -- so a shadow inherits it key by key. The
+    regression these pin came from inheriting it whole: an entry storing its
+    ladder in the flat shape carries no ``reasoning`` key to block that, so the
+    built-in's block arrived intact and answered for the ladder too.
+    """
+
+    #: Its own ladder is a strict subset of the built-in's, so a level only the
+    #: built-in offers is what tells the two apart.
+    SHADOW = {
+        "name": "gpt-5.6-sol",
+        "model_id": "gpt-5.6-sol",
+        "provider": "openai",
+        "reasoning_efforts": ["low", "high"],
+    }
+
+    def test_a_flat_ladder_is_not_replaced_by_the_built_ins(self):
+        client = _build(self.SHADOW, reasoning_effort="max")
+        assert client.reasoning == {"effort": "high"}
+        assert client.metadata["reasoning_effort"] == "high"
+
+    def test_an_empty_flat_ladder_still_means_no_control(self):
+        """Presence, not truthiness: the entry is answering "no levels", and a
+        borrowed ladder must not overrule the answer."""
+        client = _build({**self.SHADOW, "reasoning_efforts": []}, reasoning_effort="high")
+        assert client.reasoning is None
+        assert client.metadata.get("reasoning_effort") is None
+
+    def test_a_block_naming_only_a_default_keeps_the_built_ins_ladder(self):
+        """The other half of the same seam: naming one key of the block used to
+        block the whole inheritance, leaving the entry with no ladder at all."""
+        client = _build(
+            {**self.SHADOW, "reasoning_efforts": None, "reasoning": {"default": "low"}},
+            reasoning_effort="xhigh",
+        )
+        assert client.reasoning == {"effort": "xhigh"}
+
+    def test_a_block_naming_only_a_ladder_still_borrows_the_write_path(self):
+        client = _build(
+            {**self.SHADOW, "reasoning_efforts": None, "reasoning": {"efforts": ["low", "high"]}},
+            reasoning_effort="max",
+        )
+        assert client.reasoning == {"effort": "high"}

--- a/tests/unit/llms/test_llm_call_metadata.py
+++ b/tests/unit/llms/test_llm_call_metadata.py
@@ -62,8 +62,10 @@ class TestResolvedEffortIsWhatRan:
         assert llm.resolved_reasoning_effort != requested
 
     def test_no_request_reports_the_models_own_default(self):
-        """The manifest parameters already encode it, so the call is not silent
-        about its effort merely because nobody named one."""
+        """The mapper writes it on this path too, so the call is not silent
+        about its effort merely because nobody named one. That the level also
+        reaches the wire is pinned in ``test_reasoning_efforts_manifest``; this
+        is about what the call reports."""
         config = self._model_config()
         with_default = [
             model

--- a/tests/unit/llms/test_reasoning.py
+++ b/tests/unit/llms/test_reasoning.py
@@ -123,7 +123,16 @@ class TestOnAndOff:
     def test_off_replaces_the_write_rather_than_layering_over_it(self):
         """On a surface carrying both a switch and a dial, only the switch
         reliably means off; emitting both puts a live effort next to the
-        instruction not to think."""
+        instruction not to think.
+
+        Verified live on 2026-09-02, one turn per rung. deepseek-v4-flash at
+        `none` takes `thinking.type: disabled` with no `output_config` at all
+        and returns no thinking block; at `high` it takes both and does. GLM
+        5.2 at `none` takes `thinking.type: disabled` with no `reasoning_effort`
+        and returns no reasoning; at `high` it takes the pair plus
+        `clear_thinking: false` and reads 234 characters of reasoning back, so
+        the gate still works carried per request rather than seeded.
+        """
         p, _ = run("none", self.SURFACE)
         assert p == {"thinking": {"type": "disabled"}}
 

--- a/tests/unit/llms/test_reasoning.py
+++ b/tests/unit/llms/test_reasoning.py
@@ -18,6 +18,7 @@ from src.llms.reasoning import (
     WRITE_PATHS,
     ReasoningSurfaceError,
     apply_reasoning_effort,
+    infer_surface,
     validate_surface,
 )
 
@@ -244,6 +245,39 @@ class TestPassthrough:
             "high", params, extra, {"write": "parameters.reasoning.effort"}
         )
         assert out_p is params and out_b is extra
+
+
+# ---------------------------------------------------------------------------
+# infer_surface
+# ---------------------------------------------------------------------------
+
+
+class TestInferSurface:
+    """Entries stored before the block existed name no surface, so the seed
+    they carry is the only evidence of where their level goes."""
+
+    @pytest.mark.parametrize("path", WRITE_PATHS)
+    def test_every_dial_is_recognized_from_its_seed(self, path):
+        lane, *rest = path.split(".")
+        seed = "medium"
+        for segment in reversed(rest):
+            seed = {segment: seed}
+        lanes = {"parameters": {}, "extra_body": {}}
+        lanes[lane] = seed
+        assert infer_surface(lanes["parameters"], lanes["extra_body"]) == {"write": path}
+
+    def test_two_seeded_dials_resolve_to_the_typed_lane(self):
+        """WRITE_PATHS is ordered for exactly this: `parameters` holds typed SDK
+        fields, so an entry seeded in both lanes writes there rather than
+        wherever the paths happen to sort."""
+        surface = infer_surface({"reasoning_effort": "low"}, {"reasoning_effort": "low"})
+        assert surface == {"write": "parameters.reasoning_effort"}
+
+    def test_a_seed_the_allowlist_does_not_name_infers_nothing(self):
+        """A mode switch and a token budget are not dials, so no seed value of
+        theirs distinguishes one from a dial's starting point."""
+        assert infer_surface({"thinking": {"type": "enabled"}}, {}) == {}
+        assert infer_surface({"max_tokens": 8}, {}) == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/llms/test_reasoning.py
+++ b/tests/unit/llms/test_reasoning.py
@@ -1,7 +1,7 @@
 """Tests for src.llms.reasoning — the declared-surface effort mapper.
 
 The mapper no longer guesses a vendor from the keys an entry happens to carry.
-Each entry names its own ``reasoning_surface``, so what is worth locking here is
+Each entry names its own surface, so what is worth locking here is
 the block's contract: ``write`` takes the level verbatim, ``on`` layers under it,
 ``off`` replaces both rather than layering over them, and a path outside the
 allowlists is refused rather than written somewhere the vendor ignores.
@@ -70,7 +70,7 @@ class TestWrite:
         p, _ = run(level, {"write": "parameters.reasoning.effort"})
         assert p == {"reasoning": {"effort": level}}
 
-    @pytest.mark.parametrize("path", sorted(WRITE_PATHS))
+    @pytest.mark.parametrize("path", WRITE_PATHS)
     def test_every_allowed_path_is_reachable(self, path):
         """A path in the allowlist no branch can reach would be a dead
         declaration that reports a level and sends nothing."""
@@ -278,3 +278,44 @@ class TestValidateSurface:
         buttons, and no path for the chosen one to be written to."""
         with pytest.raises(ReasoningSurfaceError, match="nowhere to write"):
             validate_surface("m", {"efforts": ["low", "high"], "default": "high"})
+
+    def test_a_dial_is_not_a_patch_target(self):
+        """The two allowlists are disjoint: an `off` free to name the entry's
+        own graded write is how a switch and a dial end up contradicting each
+        other in one payload."""
+        assert not set(WRITE_PATHS) & PATCH_PATHS
+        with pytest.raises(ReasoningSurfaceError, match="not a known patch path"):
+            validate_surface("m", {"off": {"parameters.output_config.effort": "high"}})
+
+    def test_an_on_without_an_off_is_refused(self):
+        """Verified against the mapper before it was refused: at `none` this
+        emits `thinking.type: enabled` beside `effort: none`, which is the
+        surface enabling thinking on the rung that asks for none."""
+        with pytest.raises(ReasoningSurfaceError, match="declares no `off`"):
+            validate_surface(
+                "m",
+                {
+                    "efforts": ["none", "high"],
+                    "write": "parameters.output_config.effort",
+                    "on": {"parameters.thinking.type": "enabled"},
+                },
+            )
+
+    def test_an_unreachable_off_is_refused(self):
+        """The clamp never hands the mapper a level outside the ladder, so an
+        `off` with no off rung above it is a branch no request can enter."""
+        with pytest.raises(ReasoningSurfaceError, match="never be applied"):
+            validate_surface(
+                "m",
+                {
+                    "efforts": ["low", "high"],
+                    "write": "parameters.output_config.effort",
+                    "off": {"parameters.thinking.type": "disabled"},
+                },
+            )
+
+    def test_a_surface_with_no_ladder_skips_the_rung_checks(self):
+        """An inferred surface carries no efforts, so there is no rung for the
+        cross-field checks to be about."""
+        validate_surface("m", {"off": {"parameters.thinking.type": "disabled"}})
+        validate_surface("m", {"on": {"parameters.thinking.type": "enabled"}})

--- a/tests/unit/llms/test_reasoning.py
+++ b/tests/unit/llms/test_reasoning.py
@@ -136,6 +136,25 @@ class TestOnAndOff:
         p, _ = run("none", self.SURFACE)
         assert p == {"thinking": {"type": "disabled"}}
 
+    def test_off_clears_a_level_the_caller_supplied_at_the_write_path(self):
+        """The manifest no longer seeds one, but a caller override lands in the
+        same place and is merged in before the mapper runs. Left alone it is
+        the payload this branch exists to prevent, arriving by the one route
+        the seed's removal did not close."""
+        p, _ = run("none", self.SURFACE, parameters={"output_config": {"effort": "high"}})
+        assert p["thinking"] == {"type": "disabled"}
+        assert "effort" not in p["output_config"]
+
+    def test_off_leaves_the_containers_own_siblings_alone(self):
+        """Only the graded key is the contradiction. The rest of that container
+        is the entry's transport config, which the switch says nothing about."""
+        p, _ = run(
+            "none",
+            self.SURFACE,
+            parameters={"output_config": {"effort": "high", "verbosity": "low"}},
+        )
+        assert p["output_config"] == {"verbosity": "low"}
+
     def test_off_without_an_off_patch_is_just_the_level(self):
         """A surface whose vendor accepts `none` as an effort needs no patch."""
         p, _ = run("none", {"write": "parameters.reasoning.effort"})
@@ -372,6 +391,32 @@ class TestValidateSurface:
         a 500 on data the save accepted."""
         with pytest.raises(ReasoningSurfaceError, match=f"reasoning.{wrong} must be"):
             validate_surface("m", block)
+
+    def test_an_unhashable_effort_is_refused_before_the_set_math(self):
+        """The ladder arrives from a stored preferences bag, so an element can
+        be any JSON value. One unhashable one raised out of the ``OFF_LEVELS``
+        intersection: a 500 from the function whose job is the 400."""
+        with pytest.raises(ReasoningSurfaceError, match="reasoning.efforts must be drawn"):
+            validate_surface("m", {"efforts": [{}], "write": "parameters.reasoning.effort"})
+
+    def test_a_bare_switch_may_not_wear_more_than_two_rungs(self):
+        """A patch is one payload, so every non-off rung on a surface with no
+        graded write emits the same request. Three buttons, two outcomes, and
+        nothing downstream can tell -- the shape the block exists to refuse."""
+        with pytest.raises(ReasoningSurfaceError, match="all apply the same `on` patch"):
+            validate_surface("m", {
+                "efforts": ["none", "high", "max"],
+                "on": {"parameters.thinking.type": "adaptive"},
+                "off": {"parameters.thinking.type": "disabled"},
+            })
+
+    def test_a_two_rung_switch_is_still_fine(self):
+        """The shape `minimax-m3` actually ships: off, and on."""
+        validate_surface("m", {
+            "efforts": ["none", "high"],
+            "on": {"parameters.thinking.type": "adaptive"},
+            "off": {"parameters.thinking.type": "disabled"},
+        })
 
     def test_a_surface_with_no_ladder_skips_the_rung_checks(self):
         """An inferred surface carries no efforts, so there is no rung for the

--- a/tests/unit/llms/test_reasoning.py
+++ b/tests/unit/llms/test_reasoning.py
@@ -314,6 +314,22 @@ class TestValidateSurface:
                 },
             )
 
+    @pytest.mark.parametrize(
+        "block, wrong",
+        [
+            ({"efforts": 1, "write": "parameters.reasoning.effort"}, "efforts"),
+            ({"write": ["parameters.reasoning.effort"]}, "write"),
+            ({"on": ["parameters.thinking.type"]}, "on"),
+            ({"off": "parameters.thinking.type"}, "off"),
+        ],
+    )
+    def test_a_wrongly_typed_key_is_refused(self, block, wrong):
+        """The block is user input on the preferences path, and every one of
+        these otherwise reaches the mapper as an exception raised per turn --
+        a 500 on data the save accepted."""
+        with pytest.raises(ReasoningSurfaceError, match=f"reasoning.{wrong} must be"):
+            validate_surface("m", block)
+
     def test_a_surface_with_no_ladder_skips_the_rung_checks(self):
         """An inferred surface carries no efforts, so there is no rung for the
         cross-field checks to be about."""

--- a/tests/unit/llms/test_reasoning.py
+++ b/tests/unit/llms/test_reasoning.py
@@ -1,17 +1,10 @@
-"""
-Tests for src.llms.reasoning — apply_reasoning_effort() multi-provider mapper.
+"""Tests for src.llms.reasoning — the declared-surface effort mapper.
 
-Covers all provider detection patterns:
-- OpenAI: parameters.reasoning.effort
-- Anthropic graded: output_config.effort (declared output_config key)
-- Anthropic enabled: thinking.budget_tokens
-- Anthropic adaptive (bare): thinking.type as an on/off switch
-- Gemini 3.x: thinking_level
-- vLLM/Groq/Cerebras: reasoning_effort
-- Binary switch: extra_body.thinking.type
-- Dashscope/Qwen: extra_body.reasoning.effort
-- Combined extra_body patterns (always run regardless of parameters branch)
-- Invalid level passthrough
+The mapper no longer guesses a vendor from the keys an entry happens to carry.
+Each entry names its own ``reasoning_surface``, so what is worth locking here is
+the block's contract: ``write`` takes the level verbatim, ``on`` layers under it,
+``off`` replaces both rather than layering over them, and a path outside the
+allowlists is refused rather than written somewhere the vendor ignores.
 """
 
 import copy
@@ -20,32 +13,28 @@ import pytest
 
 from src.llms.reasoning import (
     OFF_LEVELS,
+    PATCH_PATHS,
     REASONING_LEVELS,
-    _ANTHROPIC_BUDGETS,
-    _budget,
+    WRITE_PATHS,
+    ReasoningSurfaceError,
     apply_reasoning_effort,
+    validate_surface,
 )
 
 
+def run(level, surface, parameters=None, extra_body=None):
+    p, b = copy.deepcopy(parameters or {}), copy.deepcopy(extra_body or {})
+    apply_reasoning_effort(level, p, b, surface)
+    return p, b
+
+
 # ---------------------------------------------------------------------------
-# Invalid / passthrough
+# Vocabulary
 # ---------------------------------------------------------------------------
 
 
-class TestReasoningInvalidLevel:
-    def test_invalid_level_returns_unchanged(self):
-        params = {"reasoning": {"effort": "medium"}}
-        extra = {}
-        result_params, result_extra = apply_reasoning_effort("invalid", params, extra)
-        assert result_params["reasoning"]["effort"] == "medium"  # Unchanged
-
-    def test_empty_string_returns_unchanged(self):
-        params = {"reasoning": {"effort": "medium"}}
-        extra = {}
-        apply_reasoning_effort("", params, extra)
-        assert params["reasoning"]["effort"] == "medium"
-
-    def test_constants(self):
+class TestVocabulary:
+    def test_levels(self):
         assert REASONING_LEVELS == (
             "none",
             "minimal",
@@ -55,12 +44,10 @@ class TestReasoningInvalidLevel:
             "xhigh",
             "max",
         )
-        assert "low" in _ANTHROPIC_BUDGETS
 
     def test_levels_are_ordered_weakest_first(self):
-        """The UI renders a model's declared subset in this order, and the
-        budget ladders walk down it — an unordered tuple would silently pick
-        the wrong rung."""
+        """The UI renders a model's declared subset in this order, and the clamp
+        walks down it — an unordered tuple would silently pick the wrong rung."""
         assert REASONING_LEVELS.index("none") < REASONING_LEVELS.index("low")
         assert REASONING_LEVELS.index("low") < REASONING_LEVELS.index("high")
         assert REASONING_LEVELS.index("high") < REASONING_LEVELS.index("max")
@@ -73,341 +60,221 @@ class TestReasoningInvalidLevel:
 
 
 # ---------------------------------------------------------------------------
-# OpenAI: parameters.reasoning.effort
+# write
 # ---------------------------------------------------------------------------
 
 
-class TestOpenAIReasoning:
-    @pytest.mark.parametrize("level", ["low", "medium", "high"])
-    def test_sets_effort(self, level):
-        params = {"reasoning": {"effort": "medium", "summary": "auto"}}
-        extra = {}
-        apply_reasoning_effort(level, params, extra)
-        assert params["reasoning"]["effort"] == level
-        assert params["reasoning"]["summary"] == "auto"  # Other keys preserved
-
-    def test_non_dict_reasoning_replaced(self):
-        """If reasoning is not a dict, replace with dict containing effort."""
-        params = {"reasoning": True}
-        extra = {}
-        apply_reasoning_effort("high", params, extra)
-        assert params["reasoning"] == {"effort": "high"}
-
-
-# ---------------------------------------------------------------------------
-# Anthropic adaptive: output_config.effort
-# ---------------------------------------------------------------------------
-
-
-class TestAnthropicAdaptive:
-    def test_output_config_present(self):
-        """When output_config key exists, sets effort on it."""
-        params = {"output_config": {"effort": "medium"}}
-        extra = {}
-        apply_reasoning_effort("high", params, extra)
-        assert params["output_config"]["effort"] == "high"
-
-    def test_bare_adaptive_is_a_switch_not_the_graded_surface(self):
-        """Declaring `output_config` is what marks a surface graded. MiniMax
-        spells its on/off switch `adaptive` too but has no `output_config`, and
-        inferring one from the word alone sent it a field it does not accept."""
-        params = {"thinking": {"type": "adaptive"}}
-        extra = {}
-        apply_reasoning_effort("low", params, extra)
-        assert "output_config" not in params
-        assert params["thinking"] == {"type": "adaptive"}
-
-    @pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh"])
-    def test_all_levels(self, level):
-        params = {
-            "thinking": {"type": "adaptive"},
-            "output_config": {"effort": "medium"},
-        }
-        extra = {}
-        apply_reasoning_effort(level, params, extra)
-        assert params["output_config"]["effort"] == level
-
-    def test_off_rides_the_switch_and_leaves_the_effort_alone(self):
-        """DeepSeek 400s on `output_config.effort: "none"` — its accepted set is
-        low..max with no off rung — while `thinking.type: "disabled"` returns
-        zero reasoning. So off is the switch, and the effort keeps its value."""
-        params = {
-            "thinking": {"type": "enabled"},
-            "output_config": {"effort": "medium"},
-        }
-        apply_reasoning_effort("none", params, {})
-        assert params["thinking"] == {"type": "disabled"}
-        assert params["output_config"] == {"effort": "medium"}
-
-    def test_xhigh_passes_through(self):
-        """Anthropic adaptive natively supports xhigh — must pass through, not clamp."""
-        params = {"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}}
-        extra = {}
-        apply_reasoning_effort("xhigh", params, extra)
-        assert params["output_config"]["effort"] == "xhigh"
-
-
-# ---------------------------------------------------------------------------
-# Anthropic enabled: thinking.budget_tokens
-# ---------------------------------------------------------------------------
-
-
-class TestAnthropicEnabled:
-    @pytest.mark.parametrize("level", ["low", "medium", "high"])
-    def test_sets_budget_tokens(self, level):
-        params = {"thinking": {"type": "enabled", "budget_tokens": 10000}}
-        extra = {}
-        apply_reasoning_effort(level, params, extra)
-        assert params["thinking"]["budget_tokens"] == _ANTHROPIC_BUDGETS[level]
-
-    def test_non_dict_thinking_replaced(self):
-        params = {"thinking": True}
-        extra = {}
-        apply_reasoning_effort("medium", params, extra)
-        assert params["thinking"]["type"] == "enabled"
-        assert params["thinking"]["budget_tokens"] == _ANTHROPIC_BUDGETS["medium"]
-
-
-# ---------------------------------------------------------------------------
-# Gemini 3.x: thinking_level
-# ---------------------------------------------------------------------------
-
-
-class TestGemini3xThinkingLevel:
-    @pytest.mark.parametrize("level", ["low", "medium", "high"])
-    def test_sets_level(self, level):
-        params = {"thinking_level": "medium"}
-        extra = {}
-        apply_reasoning_effort(level, params, extra)
-        assert params["thinking_level"] == level
-
-
-# ---------------------------------------------------------------------------
-# vLLM / Groq / Cerebras: reasoning_effort
-# ---------------------------------------------------------------------------
-
-
-class TestVLLMReasoningEffort:
-    @pytest.mark.parametrize("level", ["low", "medium", "high"])
-    def test_sets_effort(self, level):
-        params = {"reasoning_effort": "medium"}
-        extra = {}
-        apply_reasoning_effort(level, params, extra)
-        assert params["reasoning_effort"] == level
-
-
-# ---------------------------------------------------------------------------
-# Binary mode switch: extra_body.thinking.type
-# ---------------------------------------------------------------------------
-
-
-class TestBinaryThinkingSwitch:
-    """A switch, not a dial — the only honest offer is off/on. The on-value is
-    whatever the manifest declared, because vendors spell it differently."""
-
-    def test_declared_on_value_is_preserved(self):
-        params = {}
-        extra = {"thinking": {"type": "adaptive"}}
-        apply_reasoning_effort("high", params, extra)
-        assert extra["thinking"]["type"] == "adaptive"
-
-    def test_sibling_keys_survive_while_on(self):
-        params = {}
-        extra = {"thinking": {"type": "enabled", "clear_thinking": False}}
-        apply_reasoning_effort("high", params, extra)
-        assert extra["thinking"] == {"type": "enabled", "clear_thinking": False}
-
-    def test_off_is_the_bare_disabled_shape(self):
-        """Anthropic's `thinking` is a discriminated union whose disabled variant
-        rejects `budget_tokens`, so off emits the bare shape rather than merging
-        over the on-state. Siblings only describe reasoning output there is none of."""
-        params = {}
-        extra = {"thinking": {"type": "enabled", "clear_thinking": False}}
-        apply_reasoning_effort("none", params, extra)
-        assert extra["thinking"] == {"type": "disabled"}
-
-    def test_none_disables(self):
-        params = {}
-        extra = {"thinking": {"type": "enabled"}}
-        apply_reasoning_effort("none", params, extra)
-        assert extra["thinking"]["type"] == "disabled"
-
-    @pytest.mark.parametrize("level", ["low", "medium", "high", "max"])
-    def test_every_other_level_enables(self, level):
-        params = {}
-        extra = {"thinking": {"type": "disabled"}}
-        apply_reasoning_effort(level, params, extra)
-        assert extra["thinking"]["type"] == "enabled"
-
-    def test_non_dict_thinking(self):
-        params = {}
-        extra = {"thinking": True}
-        apply_reasoning_effort("none", params, extra)
-        assert extra["thinking"]["type"] == "disabled"
-
-
-# ---------------------------------------------------------------------------
-# Dashscope / Qwen: extra_body.reasoning.effort
-# ---------------------------------------------------------------------------
-
-
-class TestDashscopeReasoningEffort:
-    """Qwen publishes the same seven increasing levels as our canonical
-    vocabulary, so the level goes out verbatim. It replaced `enable_thinking`,
-    a binary switch that had been wearing a graded ladder built out of
-    `thinking_budget` — a cap the vendor never documented as honored."""
-
+class TestWrite:
     @pytest.mark.parametrize("level", REASONING_LEVELS)
-    def test_every_level_passes_through_verbatim(self, level):
-        params = {}
-        extra = {"reasoning": {"effort": "xhigh"}}
-        apply_reasoning_effort(level, params, extra)
-        assert extra["reasoning"] == {"effort": level}
+    def test_level_goes_out_verbatim(self, level):
+        p, _ = run(level, {"write": "parameters.reasoning.effort"})
+        assert p == {"reasoning": {"effort": level}}
 
-    def test_off_is_a_level_not_a_removal(self):
-        """`none` is one of the seven the vendor accepts, so turning thinking
-        off means sending it — never dropping the key, which would restore the
-        `xhigh` default instead."""
-        params = {}
-        extra = {"reasoning": {"effort": "high"}}
-        apply_reasoning_effort("none", params, extra)
-        assert extra["reasoning"] == {"effort": "none"}
+    @pytest.mark.parametrize("path", sorted(WRITE_PATHS))
+    def test_every_allowed_path_is_reachable(self, path):
+        """A path in the allowlist no branch can reach would be a dead
+        declaration that reports a level and sends nothing."""
+        p, b = run("high", {"write": path})
+        lanes = {"parameters": p, "extra_body": b}
+        node = lanes[path.split(".")[0]]
+        for segment in path.split(".")[1:]:
+            node = node[segment]
+        assert node == "high"
 
-    def test_non_dict_reasoning(self):
-        params = {}
-        extra = {"reasoning": True}
-        apply_reasoning_effort("medium", params, extra)
-        assert extra["reasoning"] == {"effort": "medium"}
+    def test_nested_containers_are_created(self):
+        p, _ = run("low", {"write": "parameters.reasoning.effort"})
+        assert p["reasoning"] == {"effort": "low"}
 
     def test_sibling_keys_survive(self):
-        params = {}
-        extra = {"reasoning": {"effort": "xhigh", "summary": "auto"}}
-        apply_reasoning_effort("low", params, extra)
-        assert extra["reasoning"] == {"effort": "low", "summary": "auto"}
+        """`reasoning.summary` and friends are transport config that happens to
+        share a container with the dial; the write must not flatten them."""
+        p, _ = run(
+            "max",
+            {"write": "parameters.reasoning.effort"},
+            parameters={"reasoning": {"summary": "auto"}, "max_tokens": 8},
+        )
+        assert p == {"reasoning": {"summary": "auto", "effort": "max"}, "max_tokens": 8}
+
+    def test_non_dict_container_is_replaced(self):
+        p, _ = run(
+            "low", {"write": "parameters.reasoning.effort"}, parameters={"reasoning": 3}
+        )
+        assert p == {"reasoning": {"effort": "low"}}
 
 
 # ---------------------------------------------------------------------------
-# GLM 5.2+: extra_body.reasoning_effort
+# on / off
 # ---------------------------------------------------------------------------
 
 
-class TestGLMReasoningEffort:
-    """Zhipu enumerated its own accepted set in a 400: none, minimal, low,
-    medium, high, xhigh, max — the widest of any provider, and identical to our
-    canonical vocabulary. So the level goes out verbatim."""
+class TestOnAndOff:
+    SURFACE = {
+        "write": "parameters.output_config.effort",
+        "on": {"parameters.thinking.type": "enabled"},
+        "off": {"parameters.thinking.type": "disabled"},
+    }
 
-    @pytest.mark.parametrize("level", REASONING_LEVELS)
-    def test_every_level_passes_through_verbatim(self, level):
-        params = {}
-        extra = {"reasoning_effort": "max"}
-        apply_reasoning_effort(level, params, extra)
-        assert extra["reasoning_effort"] == level
+    @pytest.mark.parametrize("level", ["low", "high", "max"])
+    def test_on_layers_under_the_write(self, level):
+        p, _ = run(level, self.SURFACE)
+        assert p == {"thinking": {"type": "enabled"}, "output_config": {"effort": level}}
 
-    def test_reasoning_effort_wins_over_thinking_type(self):
-        """The real glm-5.2 entry declares both keys. They used to be
-        independent `if`s, so both fired and which one Zhipu honors was never
-        established. The graded control wins and the mode switch is left alone."""
-        params = {"max_tokens": 128000}
-        extra = {
-            "thinking": {"type": "enabled", "clear_thinking": False},
-            "reasoning_effort": "high",
+    def test_off_replaces_the_write_rather_than_layering_over_it(self):
+        """On a surface carrying both a switch and a dial, only the switch
+        reliably means off; emitting both puts a live effort next to the
+        instruction not to think."""
+        p, _ = run("none", self.SURFACE)
+        assert p == {"thinking": {"type": "disabled"}}
+
+    def test_off_without_an_off_patch_is_just_the_level(self):
+        """A surface whose vendor accepts `none` as an effort needs no patch."""
+        p, _ = run("none", {"write": "parameters.reasoning.effort"})
+        assert p == {"reasoning": {"effort": "none"}}
+
+    def test_surface_with_no_write_is_a_bare_switch(self):
+        surface = {
+            "on": {"parameters.thinking.type": "adaptive"},
+            "off": {"parameters.thinking.type": "disabled"},
         }
-        apply_reasoning_effort("xhigh", params, extra)
-        assert extra["reasoning_effort"] == "xhigh"
-        assert extra["thinking"] == {"type": "enabled", "clear_thinking": False}
+        assert run("high", surface)[0] == {"thinking": {"type": "adaptive"}}
+        assert run("none", surface)[0] == {"thinking": {"type": "disabled"}}
 
-    def test_off_rides_the_switch_not_the_graded_key(self):
-        """`reasoning_effort: "none"` is accepted but not honored — glm-5.2 still
-        returned ~165 reasoning tokens through it, while `thinking.type:
-        "disabled"` returned zero. So off is the switch, and the graded key
-        keeps the value the manifest declared."""
-        params = {}
-        extra = {
-            "thinking": {"type": "enabled", "clear_thinking": False},
-            "reasoning_effort": "max",
+    def test_off_spans_both_lanes(self):
+        p, b = run(
+            "none",
+            {
+                "write": "extra_body.reasoning_effort",
+                "off": {
+                    "extra_body.thinking.type": "disabled",
+                    "parameters.thinking.type": "disabled",
+                },
+            },
+        )
+        assert p == {"thinking": {"type": "disabled"}}
+        assert b == {"thinking": {"type": "disabled"}}
+
+
+# ---------------------------------------------------------------------------
+# Merging with what the caller already supplied
+# ---------------------------------------------------------------------------
+
+
+class TestMergesWithSuppliedParams:
+    """A model's `parameters`/`extra_body` carry transport config, and a caller
+    may add more through override params. The level is written into that, not
+    over it."""
+
+    SWITCHED = {
+        "write": "parameters.output_config.effort",
+        "on": {"parameters.thinking.type": "enabled"},
+        "off": {"parameters.thinking.type": "disabled"},
+    }
+
+    def test_write_merges_into_a_supplied_container(self):
+        p, _ = run(
+            "high",
+            {"write": "parameters.reasoning.effort"},
+            parameters={"reasoning": {"summary": "auto"}, "max_tokens": 8},
+        )
+        assert p == {"reasoning": {"summary": "auto", "effort": "high"}, "max_tokens": 8}
+
+    def test_on_merges_and_leaves_unrelated_keys(self):
+        p, _ = run(
+            "high",
+            self.SWITCHED,
+            parameters={"output_config": {"verbosity": "low"}, "max_tokens": 8},
+        )
+        assert p == {
+            "output_config": {"verbosity": "low", "effort": "high"},
+            "thinking": {"type": "enabled"},
+            "max_tokens": 8,
         }
-        apply_reasoning_effort("none", params, extra)
-        assert extra["thinking"]["type"] == "disabled"
-        assert extra["reasoning_effort"] == "max"
+
+    def test_off_replaces_its_container_rather_than_merging(self):
+        """`thinking` is a discriminated union: the disabled variant rejects the
+        `budget_tokens` the enabled one requires, so a supplied sibling must not
+        survive the switch being turned off."""
+        p, _ = run(
+            "none",
+            self.SWITCHED,
+            parameters={"thinking": {"type": "enabled", "budget_tokens": 5000}, "max_tokens": 8},
+        )
+        assert p == {"thinking": {"type": "disabled"}, "max_tokens": 8}
+
+    def test_off_leaves_keys_it_does_not_name(self):
+        p, _ = run("none", self.SWITCHED, parameters={"max_tokens": 8})
+        assert p == {"thinking": {"type": "disabled"}, "max_tokens": 8}
+
+    def test_two_off_paths_sharing_a_container_both_land(self):
+        """The container is cleared once, before either write, or the second
+        path would wipe the first."""
+        _, b = run(
+            "none",
+            {
+                "write": "extra_body.reasoning_effort",
+                "off": {
+                    "extra_body.thinking.type": "disabled",
+                    "extra_body.thinking.clear_thinking": False,
+                },
+            },
+            extra_body={"thinking": {"type": "enabled", "stale": 1}},
+        )
+        assert b == {"thinking": {"type": "disabled", "clear_thinking": False}}
 
 
 # ---------------------------------------------------------------------------
-# Combined: extra_body patterns run INDEPENDENTLY of parameters branch
+# Passthrough
 # ---------------------------------------------------------------------------
 
 
-class TestCombinedPatterns:
-    def test_openai_plus_binary_switch(self):
-        """A parameters surface and an extra_body surface are independent axes
-        and both still apply."""
-        params = {"reasoning": {"effort": "medium"}}
-        extra = {"thinking": {"type": "enabled"}}
-        apply_reasoning_effort("none", params, extra)
-        assert params["reasoning"]["effort"] == "none"
-        assert extra["thinking"]["type"] == "disabled"
+class TestPassthrough:
+    def test_no_surface_writes_nothing(self):
+        """A model with no effort control must not acquire one."""
+        assert run("high", None, parameters={"max_tokens": 8}) == ({"max_tokens": 8}, {})
 
-    def test_anthropic_plus_dashscope(self):
-        params = {"thinking": {"type": "enabled", "budget_tokens": 10000}}
-        extra = {"reasoning": {"effort": "xhigh"}}
-        apply_reasoning_effort("low", params, extra)
-        assert params["thinking"]["budget_tokens"] == _ANTHROPIC_BUDGETS["low"]
-        assert extra["reasoning"]["effort"] == "low"
+    def test_level_outside_the_vocabulary_writes_nothing(self):
+        assert run("invalid", {"write": "parameters.reasoning.effort"}) == ({}, {})
 
-    def test_anthropic_budget_surface_can_be_turned_off(self):
-        params = {"thinking": {"type": "enabled", "budget_tokens": 10000}}
-        apply_reasoning_effort("none", params, {})
-        assert params["thinking"] == {"type": "disabled"}
+    def test_empty_level_writes_nothing(self):
+        assert run("", {"write": "parameters.reasoning.effort"}) == ({}, {})
 
     def test_mutates_in_place(self):
-        """apply_reasoning_effort should mutate and return the same objects."""
-        params = {"reasoning": {"effort": "low"}}
-        extra = {}
-        result_params, result_extra = apply_reasoning_effort("high", params, extra)
-        assert result_params is params
-        assert result_extra is extra
-
-    def test_no_matching_pattern_no_change(self):
-        """If no pattern matches, parameters and extra_body stay unchanged."""
-        params = {"temperature": 0.7, "max_tokens": 1000}
-        extra = {"custom_field": True}
-        original_params = copy.deepcopy(params)
-        original_extra = copy.deepcopy(extra)
-        apply_reasoning_effort("high", params, extra)
-        assert params == original_params
-        assert extra == original_extra
+        params, extra = {}, {}
+        out_p, out_b = apply_reasoning_effort(
+            "high", params, extra, {"write": "parameters.reasoning.effort"}
+        )
+        assert out_p is params and out_b is extra
 
 
 # ---------------------------------------------------------------------------
-# Nothing is clamped — the manifest decides what a model is offered
+# validate_surface
 # ---------------------------------------------------------------------------
 
 
-class TestNothingIsClamped:
-    """The mapper used to silently drop `xhigh` to `high` on five surfaces, so
-    a user picking the top level got the one below it with no signal. A level
-    can no longer arrive unless the model's own enum listed it, which makes a
-    downgrade here a bug rather than a safety net."""
+class TestValidateSurface:
+    def test_known_paths_pass(self):
+        validate_surface("m", {"write": "parameters.reasoning.effort"})
+        validate_surface("m", {"off": {"parameters.thinking.type": "disabled"}})
 
-    @pytest.mark.parametrize("level", ["xhigh", "max"])
-    def test_named_surfaces_pass_the_level_through(self, level):
-        for params, key in (
-            ({"reasoning": {"effort": "medium"}}, None),
-            ({"thinking_level": "medium"}, "thinking_level"),
-            ({"reasoning_effort": "medium"}, "reasoning_effort"),
-        ):
-            apply_reasoning_effort(level, params, {})
-            actual = params["reasoning"]["effort"] if key is None else params[key]
-            assert actual == level
+    def test_typo_in_a_write_is_refused(self):
+        """The whole point of the allowlist: a misspelled path is structurally
+        valid JSON that lands somewhere the vendor answers 200 for and ignores."""
+        with pytest.raises(ReasoningSurfaceError, match="not a known write path"):
+            validate_surface("m", {"write": "parmeters.reasoning.effort"})
 
-    def test_budget_surface_climbs_past_the_old_ceiling(self):
-        params = {"thinking": {"type": "enabled", "budget_tokens": 10000}}
-        apply_reasoning_effort("max", params, {})
-        assert params["thinking"]["budget_tokens"] > _ANTHROPIC_BUDGETS["high"]
+    def test_typo_in_a_patch_is_refused(self):
+        with pytest.raises(ReasoningSurfaceError, match="not a known patch path"):
+            validate_surface("m", {"off": {"parameters.thinking.mode": "off"}})
 
-    def test_budget_ladder_walks_down_to_the_nearest_rung(self):
-        """A numeric ladder need not have a rung for every canonical level; it
-        takes the nearest one at or below, never one above."""
-        sparse = {"low": 1024, "high": 32768}
-        assert _budget(sparse, "max") == sparse["high"]
-        assert _budget(sparse, "medium") == sparse["low"]
-        assert _budget(sparse, "minimal") == sparse["low"]
+    def test_a_mode_switch_is_not_a_write_target(self):
+        """`thinking.type` takes a vendor literal, never a level name."""
+        assert "parameters.thinking.type" in PATCH_PATHS
+        assert "parameters.thinking.type" not in WRITE_PATHS
+        with pytest.raises(ReasoningSurfaceError):
+            validate_surface("m", {"write": "parameters.thinking.type"})
+
+    def test_a_ladder_with_nowhere_to_write_is_refused(self):
+        """The failure the block exists to make loud: levels the UI renders as
+        buttons, and no path for the chosen one to be written to."""
+        with pytest.raises(ReasoningSurfaceError, match="nowhere to write"):
+            validate_surface("m", {"efforts": ["low", "high"], "default": "high"})

--- a/tests/unit/llms/test_reasoning_efforts_manifest.py
+++ b/tests/unit/llms/test_reasoning_efforts_manifest.py
@@ -68,7 +68,8 @@ class TestUnhonoredLevelsDegrade:
         assert config.resolve_reasoning_effort("claude-opus-5", "xhigh") == "xhigh"
 
     def test_model_with_no_control_resolves_to_nothing(self, config):
-        assert config.resolve_reasoning_effort("embedding-small", "high") is None
+        """A chat model that declares no ladder, not a model of another kind."""
+        assert config.resolve_reasoning_effort("claude-haiku-4-5", "high") is None
 
     def test_above_the_ceiling_steps_down_one(self, config):
         """max on a low/medium/high model runs high, not that model's middle."""

--- a/tests/unit/llms/test_reasoning_efforts_manifest.py
+++ b/tests/unit/llms/test_reasoning_efforts_manifest.py
@@ -31,13 +31,22 @@ def config():
 
 class TestDeclaredSetsAreWellFormed:
     def test_every_declared_level_exists(self, config):
-        bad = {
-            name: [
-                lvl for lvl in entry["reasoning_efforts"] if lvl not in REASONING_LEVELS
-            ]
+        """Read through ``reasoning_block``, not off a fixed key: a typo inside
+        the block is dropped by ``canonical_reasoning_efforts`` without a word,
+        so a check reading a key no entry carries any more passes on an empty
+        set and proves nothing."""
+        from src.llms.model_spec import reasoning_block
+
+        ladders = {
+            name: reasoning_block(entry).get("efforts")
             for name, entry in config.llm_config.items()
             if isinstance(entry, dict)
-            and isinstance(entry.get("reasoning_efforts"), list)
+        }
+        assert any(ladders.values()), "no entry declares a ladder -- check is vacuous"
+        bad = {
+            name: [lvl for lvl in efforts if lvl not in REASONING_LEVELS]
+            for name, efforts in ladders.items()
+            if isinstance(efforts, list)
         }
         assert not {k: v for k, v in bad.items() if v}
 
@@ -211,8 +220,24 @@ class TestWhoWinsWhenTwoThingsNameTheLevel:
         assert client.parameters["reasoning"]["effort"] == "low"
         assert client.resolved_reasoning_effort == "low"
 
-    def test_the_default_is_still_written_when_nothing_overrides_it(self):
+    def test_the_default_is_still_written_when_nothing_overrides_it(self, config):
         """The level is no longer sitting in `parameters` waiting to be sent, so
-        skipping the mapper here reports a level the request never carried."""
-        client = LLM("gpt-5.5")
-        assert client.parameters["reasoning"]["effort"] == client.resolved_reasoning_effort
+        skipping the mapper on this path reports a level the request never
+        carried. Walked over the catalog rather than one model: dropping the
+        no-request apply leaves every other test in this file green."""
+        from src.llms.model_spec import ModelSpec
+
+        checked = 0
+        for name in config.llm_config:
+            spec = ModelSpec.from_manifest(config, name)
+            write = spec.reasoning_surface.get("write")
+            if not (write and spec.reasoning_effort_default):
+                continue  # no dial, or no ladder to have a default on
+            client = LLM(name, api_key="dummy-key")
+            lanes = {"parameters": client.parameters, "extra_body": client.extra_body}
+            node = lanes[write.split(".")[0]]
+            for segment in write.split(".")[1:]:
+                node = node[segment]
+            assert node == client.resolved_reasoning_effort == spec.reasoning_effort_default, name
+            checked += 1
+        assert checked > 10, f"only {checked} models exercised the no-request path"

--- a/tests/unit/llms/test_reasoning_efforts_manifest.py
+++ b/tests/unit/llms/test_reasoning_efforts_manifest.py
@@ -72,12 +72,12 @@ class TestUnhonoredLevelsDegrade:
 
     def test_above_the_ceiling_steps_down_one(self, config):
         """max on a low/medium/high model runs high, not that model's middle."""
-        assert config.get_reasoning_efforts("claude-haiku-4-5") == [
+        assert config.get_reasoning_efforts("gemini-3.1-pro") == [
             "low",
             "medium",
             "high",
         ]
-        assert config.resolve_reasoning_effort("claude-haiku-4-5", "max") == "high"
+        assert config.resolve_reasoning_effort("gemini-3.1-pro", "max") == "high"
 
     def test_below_the_floor_takes_the_lowest(self, config):
         """Nothing at or under the request — the model's minimum is as close as it gets."""
@@ -141,7 +141,7 @@ class TestManifestAgreesWithTheMapper:
             for level in efforts:
                 params = copy.deepcopy(entry.get("parameters", {}))
                 extra = copy.deepcopy(entry.get("extra_body", {}))
-                apply_reasoning_effort(level, params, extra)
+                apply_reasoning_effort(level, params, extra, entry.get("reasoning"))
                 seen[level] = json.dumps([params, extra], sort_keys=True)
             assert len(set(seen.values())) == len(efforts), (
                 f"{name}: levels emit duplicate payloads -> {seen}"
@@ -157,7 +157,9 @@ class TestManifestAgreesWithTheMapper:
         for name, entry in config.llm_config.items():
             if not isinstance(entry, dict):
                 continue
-            if "reasoning" not in (entry.get("extra_body") or {}):
+            # Keyed off the provider family, not the surface shape: the surface
+            # is shared with OpenAI, which does serve the top of the ladder.
+            if not str(entry.get("provider", "")).startswith("dashscope"):
                 continue
             top = set(config.get_reasoning_efforts(name)) & {"xhigh", "max"}
             if top:

--- a/tests/unit/llms/test_reasoning_efforts_manifest.py
+++ b/tests/unit/llms/test_reasoning_efforts_manifest.py
@@ -124,6 +124,28 @@ class TestUnhonoredLevelsDegrade:
                     assert got == efforts[0], f"{name}: {level} -> {got}"
 
 
+class TestEveryEntryBuilds:
+    """``ModelSpec.from_manifest`` is where a declared surface is checked, and
+    it runs per request, so a typo in a rarely-picked model would otherwise
+    first surface as a 500 for whoever picked it. Walking the whole catalog
+    here is what makes the allowlist a load-time guarantee."""
+
+    def test_every_entry_builds_a_spec(self, config):
+        from src.llms.model_spec import ModelSpec
+
+        for name in config.llm_config:
+            ModelSpec.from_manifest(config, name)
+
+    def test_every_declared_ladder_has_somewhere_to_write(self, config):
+        """The failure the block exists to make loud, checked against the real
+        catalog rather than a fixture: buttons with no path behind them."""
+        from src.llms.model_spec import ModelSpec
+
+        for name in config.llm_config:
+            spec = ModelSpec.from_manifest(config, name)
+            assert bool(spec.reasoning_efforts) == bool(spec.reasoning_surface), name
+
+
 class TestManifestAgreesWithTheMapper:
     """A declared level must actually reach the provider. These two drifting
     apart is the failure the enum exists to prevent."""
@@ -134,15 +156,18 @@ class TestManifestAgreesWithTheMapper:
         import copy
         import json
 
-        for name, entry in config.llm_config.items():
+        from src.llms.model_spec import ModelSpec
+
+        for name in config.llm_config:
             efforts = config.get_reasoning_efforts(name)
             if len(efforts) < 2:
                 continue
+            spec = ModelSpec.from_manifest(config, name)
             seen = {}
             for level in efforts:
-                params = copy.deepcopy(entry.get("parameters", {}))
-                extra = copy.deepcopy(entry.get("extra_body", {}))
-                apply_reasoning_effort(level, params, extra, entry.get("reasoning"))
+                params = copy.deepcopy(spec.parameters)
+                extra = copy.deepcopy(spec.extra_body)
+                apply_reasoning_effort(level, params, extra, spec.reasoning_surface)
                 seen[level] = json.dumps([params, extra], sort_keys=True)
             assert len(set(seen.values())) == len(efforts), (
                 f"{name}: levels emit duplicate payloads -> {seen}"

--- a/tests/unit/llms/test_reasoning_efforts_manifest.py
+++ b/tests/unit/llms/test_reasoning_efforts_manifest.py
@@ -193,3 +193,26 @@ class TestManifestAgreesWithTheMapper:
                     f"{name}: declares {sorted(top)} on provider "
                     f"{entry.get('provider')!r}, which is not known to serve them"
                 )
+
+
+class TestWhoWinsWhenTwoThingsNameTheLevel:
+    """The manifest used to seed its default level straight into
+    ``parameters``, which put a caller's own ``parameters`` override above the
+    default and below an explicit request. The mapper writes what that seed
+    held, so it has to keep the same two rungs.
+    """
+
+    def test_an_override_beats_the_manifest_default(self):
+        client = LLM("gpt-5.5", reasoning={"effort": "high"})
+        assert client.parameters["reasoning"]["effort"] == "high"
+
+    def test_a_requested_level_beats_an_override(self):
+        client = LLM("gpt-5.5", reasoning_effort="low", reasoning={"effort": "high"})
+        assert client.parameters["reasoning"]["effort"] == "low"
+        assert client.resolved_reasoning_effort == "low"
+
+    def test_the_default_is_still_written_when_nothing_overrides_it(self):
+        """The level is no longer sitting in `parameters` waiting to be sent, so
+        skipping the mapper here reports a level the request never carried."""
+        client = LLM("gpt-5.5")
+        assert client.parameters["reasoning"]["effort"] == client.resolved_reasoning_effort

--- a/tests/unit/llms/test_system_provider_and_tiers.py
+++ b/tests/unit/llms/test_system_provider_and_tiers.py
@@ -375,15 +375,10 @@ class TestPlatformVariantFiltering:
 # ---------------------------------------------------------------------------
 
 
-_EMBEDDING_KEYS = {"embedding-small", "embedding-large", "embedding-cn"}
-_CHAT_MODELS = {k: v for k, v in _MODELS.items() if k not in _EMBEDDING_KEYS}
-
 
 class TestModelsManifestIntegrity:
-    """Every model in models.json must have a valid provider and model_id.
-
-    Non-embedding models must also declare input_modalities.
-    """
+    """Every model in models.json must have a valid provider, model_id, and
+    input_modalities."""
 
     @pytest.mark.parametrize("model_key", list(_MODELS.keys()))
     def test_model_has_model_id(self, model_key):
@@ -402,9 +397,9 @@ class TestModelsManifestIntegrity:
             f"which is not defined in providers.json"
         )
 
-    @pytest.mark.parametrize("model_key", list(_CHAT_MODELS.keys()))
+    @pytest.mark.parametrize("model_key", list(_MODELS.keys()))
     def test_chat_model_has_input_modalities(self, model_key):
-        entry = _CHAT_MODELS[model_key]
+        entry = _MODELS[model_key]
         modalities = entry.get("input_modalities")
         assert modalities and isinstance(modalities, list), (
             f"Chat model '{model_key}' is missing input_modalities"

--- a/tests/unit/server/app/test_preferences_validation.py
+++ b/tests/unit/server/app/test_preferences_validation.py
@@ -151,6 +151,31 @@ class TestValidateCustomModels:
             {"name": "my-gpt", "model_id": "gpt-4o", "provider": "openai"},
         ])
 
+    def test_a_block_carrying_only_a_surface_is_still_checked(self):
+        """The save-time check used to run only when the block declared levels,
+        so a block that named nothing but a path was stored unread. Nothing
+        writes it today, which is exactly why a typo in it would sit there."""
+        with pytest.raises(HTTPException):
+            self._validate([{
+                "name": "my-gpt", "model_id": "gpt-4o", "provider": "openai",
+                "reasoning": {"write": "parmeters.reasoning.effort"},
+            }])
+
+    def test_a_wrongly_typed_block_is_a_400_not_a_500(self):
+        """`on` as a list survives the path check -- iterating it yields the
+        same strings a dict would -- then raises AttributeError in the mapper,
+        once per turn, for every turn."""
+        with pytest.raises(HTTPException):
+            self._validate([{
+                "name": "my-gpt", "model_id": "gpt-4o", "provider": "openai",
+                "reasoning": {
+                    "efforts": ["none", "high"],
+                    "write": "parameters.output_config.effort",
+                    "on": ["parameters.thinking.type"],
+                    "off": {"parameters.thinking.type": "disabled"},
+                },
+            }])
+
     def test_text_auto_prepended(self):
         """If input_modalities is provided without 'text', it should be auto-added."""
         models = [{"name": "my-llava", "model_id": "llava", "provider": "openai", "input_modalities": ["image"]}]

--- a/tests/unit/server/app/test_preferences_validation.py
+++ b/tests/unit/server/app/test_preferences_validation.py
@@ -176,6 +176,22 @@ class TestValidateCustomModels:
                 },
             }])
 
+    def test_an_empty_block_does_not_strand_the_flat_ladder(self):
+        """Accepted as declaring a ladder, then read as declaring none: the
+        level the user had already picked was cleared on the next save."""
+        from src.server.app.users import _clear_unhonored_efforts
+
+        entry = {
+            "name": "my-gpt", "model_id": "gpt-4o", "provider": "openai",
+            "reasoning": {}, "reasoning_efforts": ["low", "high"],
+        }
+        self._validate([dict(entry)])
+        written = {}
+        _clear_unhonored_efforts(
+            written, {"custom_models": [entry]}, {"my-gpt": {"reasoning_effort": "high"}}
+        )
+        assert written == {}
+
     def test_text_auto_prepended(self):
         """If input_modalities is provided without 'text', it should be auto-added."""
         models = [{"name": "my-llava", "model_id": "llava", "provider": "openai", "input_modalities": ["image"]}]

--- a/web/src/hooks/__tests__/useFilteredModels.test.ts
+++ b/web/src/hooks/__tests__/useFilteredModels.test.ts
@@ -409,6 +409,29 @@ describe('buildVisibleModels', () => {
     expect(result.rawModels.anthropic?.models).toEqual(['claude-sonnet']);
   });
 
+  it('an empty reasoning block does not strand the entry\'s flat ladder', () => {
+    // `{}` is truthy, so this side read the block as the whole declaration and
+    // showed no effort selector for a model whose flat keys declare one. The
+    // server reads the same entry through `reasoning_block`; the two have to
+    // agree on what an empty block means or the UI offers a different ladder
+    // than the turn runs.
+    const customModels = [
+      {
+        name: 'my-gpt',
+        model_id: 'gpt-4o',
+        provider: 'openai',
+        reasoning: {},
+        reasoning_efforts: ['low', 'high'],
+        reasoning_effort_default: 'high',
+      },
+    ];
+
+    const result = buildVisibleModels({}, {}, customModels, {}, null, []);
+
+    expect(result.metadata['my-gpt']?.reasoning_efforts).toEqual(['low', 'high']);
+    expect(result.metadata['my-gpt']?.reasoning_effort_default).toBe('high');
+  });
+
   it('variant bypass: parent-catalog model starred under variant shows under variant group', () => {
     // User has ``z-ai-coding`` configured (access_type=coding_plan). They
     // starred ``glm-5.1`` (a parent-catalog model, provider=z-ai) under the

--- a/web/src/hooks/useFilteredModels.ts
+++ b/web/src/hooks/useFilteredModels.ts
@@ -232,12 +232,18 @@ interface CustomModelEntry {
 // The ladder an entry declares, from either shape it may be stored in. Mirrors
 // `reasoning_block` on the server, precedence included: a `reasoning` object
 // answers for the whole declaration, so an entry carrying both does not get
-// its flat keys read as a fallback for the block's missing ones.
+// its flat keys read as a fallback for the block's missing ones. An empty
+// object is not such an answer, and `{}` being truthy here is what would have
+// made this side read one anyway.
 function declaredLadder(cm: CustomModelEntry): {
   efforts?: string[];
   effortDefault?: string;
 } {
-  if (cm.reasoning && typeof cm.reasoning === 'object') {
+  if (
+    cm.reasoning &&
+    typeof cm.reasoning === 'object' &&
+    Object.keys(cm.reasoning).length > 0
+  ) {
     return {
       ...('efforts' in cm.reasoning ? { efforts: cm.reasoning.efforts } : {}),
       ...('default' in cm.reasoning ? { effortDefault: cm.reasoning.default } : {}),

--- a/web/src/hooks/useFilteredModels.ts
+++ b/web/src/hooks/useFilteredModels.ts
@@ -222,10 +222,31 @@ interface CustomModelEntry {
   name: string;
   model_id: string;
   provider: string;
+  reasoning?: { efforts?: string[]; default?: string };
   reasoning_efforts?: string[];
   reasoning_effort_default?: string;
   prompt_guidance?: string;
   compaction_profile?: string;
+}
+
+// The ladder an entry declares, from either shape it may be stored in. Mirrors
+// `reasoning_block` on the server, precedence included: a `reasoning` object
+// answers for the whole declaration, so an entry carrying both does not get
+// its flat keys read as a fallback for the block's missing ones.
+function declaredLadder(cm: CustomModelEntry): {
+  efforts?: string[];
+  effortDefault?: string;
+} {
+  if (cm.reasoning && typeof cm.reasoning === 'object') {
+    return {
+      ...('efforts' in cm.reasoning ? { efforts: cm.reasoning.efforts } : {}),
+      ...('default' in cm.reasoning ? { effortDefault: cm.reasoning.default } : {}),
+    };
+  }
+  return {
+    ...('reasoning_efforts' in cm ? { efforts: cm.reasoning_efforts } : {}),
+    ...('reasoning_effort_default' in cm ? { effortDefault: cm.reasoning_effort_default } : {}),
+  };
 }
 
 interface ProviderCatalogEntry {
@@ -302,11 +323,12 @@ export function buildVisibleModels(
     // server resolves it identically (`with_inherited_declarations`). Presence,
     // not truthiness -- an entry declaring an empty ladder is saying the model
     // honors no levels, which the built-in's must not overwrite.
+    const ladder = declaredLadder(cm);
     metadata[cm.name] = {
       ...metadata[cm.name],
-      ...('reasoning_efforts' in cm ? { reasoning_efforts: cm.reasoning_efforts } : {}),
-      ...('reasoning_effort_default' in cm
-        ? { reasoning_effort_default: cm.reasoning_effort_default }
+      ...('efforts' in ladder ? { reasoning_efforts: ladder.efforts } : {}),
+      ...('effortDefault' in ladder
+        ? { reasoning_effort_default: ladder.effortDefault }
         : {}),
       ...('prompt_guidance' in cm ? { prompt_guidance: cm.prompt_guidance } : {}),
       ...('compaction_profile' in cm ? { compaction_profile: cm.compaction_profile } : {}),


### PR DESCRIPTION
## Summary

Each model now **declares** where its reasoning level is written, in a `reasoning` block on its
manifest entry. The mapper reads that declaration instead of guessing a vendor from whichever
keys an entry happened to carry, and a path outside two closed allowlists is refused where it
is authored rather than accepted by the vendor and ignored.

Before, `apply_reasoning_effort` was a nine-branch if/elif chain that sniffed an entry's
`parameters` and `extra_body` for a seed and inferred the surface from it. That inference was
wrong in ways nothing could catch: three of four buttons on a binary model emitted an identical
request, and a model declaring a ladder with no seed to sniff reported a level and sent nothing.

## Overview

| Category | Files | +LOC | −LOC |
|---|---:|---:|---:|
| Modified | 15 | 1378 | 1129 |
| New | 0 | 0 | 0 |
| Tests (excluded below) | 6 | 503 | 349 |
| **Net (excl. tests)** | **9** | **875** | **780** |

**`src/llms/` (net +212/−178)**
- `reasoning.py` (+151/−128): the mapper, rewritten around a declared surface. `WRITE_PATHS`
  (6 graded dials, ordered) and `PATCH_PATHS` (3 mode switches) are closed and disjoint;
  `validate_surface` refuses a block that cannot do what its ladder advertises; `infer_surface`
  is the narrow fallback for entries stored before the block existed.
- `model_spec.py` (+96/−55): `reasoning_block` reads either shape, `_checked_surface` validates
  at spec build, and `with_inherited_declarations` fills a shadow in key by key.
- `llm.py` (+27/−11): the resolved level goes through the mapper on both paths, since the seeds
  it used to ride on are gone. Ordering is the seed's old one, so a caller's `parameters`
  override still beats the manifest default and an explicitly requested level still beats both.
- `manifest/models.json` (+538/−523): every entry converted; vendor seeds removed from
  `parameters`/`extra_body`.
- `manifest/providers.json` (−39): the unused `embedding_models` block.

**`src/server/` (net +37/−13)**
- `app/users.py`: the preferences endpoint validates both shapes and calls `validate_surface`
  on save, so an unusable declaration is a 400 naming the model rather than a 500 at turn start.

**`web/` (net +25/−3)**
- `hooks/useFilteredModels.ts`: the custom-model merge reads a nested `reasoning` block as well
  as the flat keys, mirroring `reasoning_block` precedence.

**Config (net +1/−8)**: `agent_config.yaml` and `src/config/core.py`, dropping the dead
`embedding:` block and the comment naming it.

**What this introduces:** a model's effort ladder and the place its level is written are now one
declaration, checked where it is authored. A manifest typo fails the suite; a user's bad custom
entry is a 400 on save. The class of failure this removes is the silent one, where the UI offers
levels and the request carries something else.

## What an entry looks like

`deepseek-v4-flash`, which needs both a switch and a dial.

Before:

```json
"parameters": {
  "max_tokens": 384000,
  "thinking": { "type": "enabled" },
  "output_config": { "effort": "high" }
},
"reasoning_efforts": ["none", "low", "high", "max"],
"reasoning_effort_default": "high"
```

After:

```json
"parameters": {
  "max_tokens": 384000
},
"reasoning": {
  "efforts": ["none", "low", "high", "max"],
  "default": "high",
  "write": "parameters.output_config.effort",
  "on":  { "parameters.thinking.type": "enabled" },
  "off": { "parameters.thinking.type": "disabled" }
}
```

The ladder used to be two sibling keys and the surface was not written down at all: the mapper
recovered it by finding `output_config` in `parameters` and inferring DeepSeek's shape. Now the
block names both, and the seeds leave `parameters`. What stays there is transport config the
mapper does not own. Each rung emits:

```
none  ->  {"thinking": {"type": "disabled"}}
low   ->  {"thinking": {"type": "enabled"}, "output_config": {"effort": "low"}}
high  ->  {"thinking": {"type": "enabled"}, "output_config": {"effort": "high"}}
max   ->  {"thinking": {"type": "enabled"}, "output_config": {"effort": "max"}}
```

`off` replaces the write rather than layering over it, because on a surface carrying both a
switch and a dial only the switch reliably means off, and emitting both puts a live effort
beside the instruction not to think.

Three shapes cover the catalog:

| Shape | Block | Example |
|---|---|---|
| Graded dial | `write` only | `gpt-5.5` writes `parameters.reasoning.effort` |
| Dial behind a switch | `write` + `on` + `off` | `deepseek-v4-*`, `glm-5.2` |
| Bare switch, no dial | `on` + `off` only | `minimax-m3`: `none` sends `type: disabled`, `high` sends `type: adaptive` |

The third is where the vendor's name used to live in the mapper. `minimax-m3` sends a bare
switch, and the old chain knew that by testing the seed for the literal `"adaptive"`, in a
branch commented with MiniMax's name. Its wire is unchanged; what moved is who knows. The
entry now says `on` writes `adaptive` and `off` writes `disabled`, and the mapper knows
nothing about the vendor.

## The two allowlists

They are disjoint on purpose.

- **`WRITE_PATHS`**: graded dials that take a level name verbatim. Ordered, not a set, because
  `infer_surface` takes the first seed it finds, so an entry seeded in both lanes resolves to
  `parameters`, where a typed SDK field lives.
- **`PATCH_PATHS`**: mode switches, which take a vendor literal. If an `off` could name a dial,
  an off block would restate the entry's own graded write and contradict the switch beside it.

A dotted string makes a typo look like structurally valid JSON, which is why both are closed.

## Risk

- **The off-rung payload changed shape** for `deepseek-v4-*` and `glm-5.2`/`-cn`: the graded key
  is now omitted rather than kept at its declared value. Verified live, one turn per rung.
  DeepSeek at `none` takes `thinking.type: disabled` with no `output_config` and returns no
  thinking block; GLM at `none` takes the disabled switch with no `reasoning_effort` and returns
  no reasoning. Both graded rungs still work, and GLM reads 234 characters of reasoning back, so
  the `clear_thinking: false` gate survives being carried per request instead of seeded.
- **`claude-haiku-4-5` loses its effort selector.** Its ladder was written against a token-budget
  dial that no longer exists. Its default-turn payload is unchanged: `main` never ran the mapper
  on a turn nobody requested a level for, so bare `thinking: {type: enabled}` is what that model
  has always sent. The API-key entry carrying no `budget_tokens` while its OAuth twin carries
  8000 is a pre-existing asymmetry, not this branch's.
- **Two legacy BYOK seed shapes still send a stale level**: a `parameters.thinking` token budget
  and an `extra_body.thinking` mode switch. Neither is a graded dial, so neither is inferable,
  and the honest fix is a product call (drop the ladder loudly, or rebuild those two branches).
  Filed as item 7 of `todo/own-model-config-byok.md`. Not reachable from the UI, which has no
  field for a ladder at all.
- `create_llm_from_custom` has no try/except around it, so a stored block invalidated by some
  future narrowing of the allowlists would raise at turn start rather than degrade. Nothing
  stored is in the block shape yet, so there is nothing to narrow against today.

## Verification

- Backend unit suite: 9578 passed, 1 xfailed.
- Frontend: 310 files / 3347 tests; `tsc --noEmit` clean.
- Ruff clean on every file this branch touches.
- Live turns against DeepSeek and Z.ai covering both rungs of both changed surfaces.
- Every regression found in review was reproduced first, then pinned by a test that fails when
  the fix is ablated and passes with it in.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790970813&installation_model_id=432753&pr_number=388&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F388&signature=2693dfdcfdb617988774c9e95d48bb2bb432b5e212cacc8c43f03dca15d73dd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured reasoning controls with supported effort levels, defaults, and activation behavior.
  - Custom models can define reasoning settings using the new configuration format while retaining legacy compatibility.
  - Explicitly selected reasoning levels now take precedence over model defaults.

- **Changes**
  - Reasoning settings are validated before use.
  - Model listings recognize both structured and legacy reasoning configurations.
  - Empty structured reasoning settings fall back to legacy values.

- **Removals**
  - Removed built-in embedding model and provider configuration entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->