### PR TITLE
fix(web): keep a field unringed after a trip out of the window

### DIFF
--- a/web/e2e/focus-ring.spec.js
+++ b/web/e2e/focus-ring.spec.js
@@ -376,3 +376,86 @@ test.describe('a field whose container is the indicator', () => {
     expect(await outlineOn(page, field)).toMatchObject({ focused: true, style: 'none' });
   });
 });
+
+/**
+ * The half that survives leaving the browser.
+ *
+ * Switching to another app does not release element focus, it parks it:
+ * `document.activeElement` is unchanged across the whole trip, and the browser
+ * fires a `focusout`/`focusin` pair around it as bookkeeping. That restoring
+ * `focusin` is indistinguishable from any other, and by the time it arrives the
+ * recorded device has been flipped to keyboard by the user's own typing -- so
+ * the composer someone clicked, typed into, and left for the length of an agent
+ * turn came back wearing the ring. It is the shape of bug that reads as "it
+ * still happens sometimes": the trip out and back is what triggers it, and
+ * nothing about the app does.
+ *
+ * The trip is synthesized because Playwright cannot make one. It pins every
+ * page it drives to `Emulation.setFocusEmulationEnabled`, so a backgrounded tab
+ * still believes it has focus and fires nothing -- verified by driving a real
+ * Chrome with `osascript` instead, which is also where the sequence replayed
+ * below was measured. Everything else here is real: the app, the stylesheet,
+ * the click, the typing, and the paint that gets read back.
+ */
+const PARKED = [
+  { field: 'the chat composer', sel: COMPOSER },
+  { field: 'the dashboard search box', sel: SEARCH },
+];
+
+/** What the browser fires around a trip out of the window and back. */
+async function leaveWindowAndReturn(page) {
+  await page.evaluate(() => {
+    const el = document.activeElement;
+    const pair = { bubbles: true, composed: true, relatedTarget: null };
+    el.dispatchEvent(new FocusEvent('focusout', pair));
+    window.dispatchEvent(new FocusEvent('blur'));
+    window.dispatchEvent(new FocusEvent('focus'));
+    el.dispatchEvent(new FocusEvent('focusin', pair));
+  });
+}
+
+test.describe('a field left focused while the user is in another app', () => {
+  for (const { field, sel } of PARKED) {
+    test(`comes back unringed on ${field}`, async ({ page }) => {
+      await expect(page.locator(sel)).toBeVisible();
+      const resting = await outlineOn(page, sel);
+      await page.click(sel);
+      // Typing is what makes this reachable: it flips the recorded device to
+      // keyboard while focus sits still, so the restore has stale evidence to
+      // read. Without it the trip is harmless and this passes unfixed.
+      await page.keyboard.type('AAPL');
+      await leaveWindowAndReturn(page);
+
+      const returned = await outlineOn(page, sel);
+      expect(returned.focused).toBe(true);
+      expect(unpainted(returned.style, returned.color)).toBe(true);
+      expect(returned.shadow).toBe(resting.shadow);
+    });
+  }
+
+  test('comes back still ringed for someone who tabbed to it', async ({ page }) => {
+    // The over-eager fix passes every assertion above by never re-deciding at
+    // all. A keyboard user has to leave and return to their own indicator.
+    await expect(page.locator(SEARCH)).toBeVisible();
+    await keyboardFocus(page, SEARCH);
+    expect(await outlineOn(page, SEARCH)).toMatchObject({ style: 'solid' });
+
+    await leaveWindowAndReturn(page);
+    expect(await outlineOn(page, SEARCH)).toMatchObject({ focused: true, style: 'solid' });
+  });
+
+  test('leaves the next real focus move free to decide for itself', async ({ page }) => {
+    // Passing over the restore must consume exactly one focusin. If the flag
+    // outlives it, the first control the user reaches after coming back
+    // inherits the verdict of the one they left.
+    await expect(page.locator(SEARCH)).toBeVisible();
+    await page.click(SEARCH);
+    await page.keyboard.type('AAPL');
+    await leaveWindowAndReturn(page);
+
+    await tabTo(page, ROW);
+    expect(await outlineOn(page, ROW)).toMatchObject({ focused: true });
+    const ring = await outlineOn(page, ROW);
+    expect(ring.style === 'solid' || ring.shadow !== 'none').toBe(true);
+  });
+});

--- a/web/src/lib/inputModality.ts
+++ b/web/src/lib/inputModality.ts
@@ -24,24 +24,51 @@ const POINTER_FOCUS = 'data-pointer-focus';
 
 let pointer = false;
 
+/**
+ * What held focus when the browser window last lost it.
+ *
+ * Leaving the window does not release element focus, it parks it:
+ * `document.activeElement` is unchanged throughout, and the browser fires a
+ * `focusout`/`focusin` pair around the trip purely as bookkeeping. Nobody moved
+ * focus, so nothing about how it was reached has changed -- but the restoring
+ * `focusin` looks like every other one, and by then the flag below has been
+ * flipped to keyboard by the user's own typing. Re-reading it there re-decides
+ * a settled question with the wrong evidence and rings a field the mouse
+ * focused, which is the bug: click the composer, type, switch to another app,
+ * come back, ring. Remembering the parked element is what lets the restore be
+ * recognised and passed over.
+ */
+let parked: EventTarget | null = null;
+
 if (typeof window !== 'undefined') {
   // Capture phase: a handler that stops propagation must not be able to hide
   // the interaction from this.
-  window.addEventListener('pointerdown', () => { pointer = true; }, true);
+  window.addEventListener('pointerdown', () => { pointer = true; parked = null; }, true);
   window.addEventListener(
     'keydown',
     (event) => {
       if (!MODIFIERS.has(event.key)) pointer = false;
+      parked = null;
     },
     true,
   );
+  // Not capture phase, and on `window` rather than `document`: element blur does
+  // not bubble, so a listener reached only at its own target hears window
+  // deactivation and nothing else -- which is the one case where focus is parked
+  // rather than moved.
+  window.addEventListener('blur', () => { parked = document.activeElement; });
   // Written when focus moves rather than read at paint: typing into a field is
   // a keydown, so a rule consulting the live flag would light a ring under the
   // user mid-sentence. Freezing it here answers what the ring actually asks,
   // which is how the control holding focus was reached.
   window.addEventListener(
     'focusin',
-    () => { document.documentElement.toggleAttribute(POINTER_FOCUS, pointer); },
+    (event) => {
+      const restored = event.target === parked;
+      parked = null;
+      if (restored) return;
+      document.documentElement.toggleAttribute(POINTER_FOCUS, pointer);
+    },
     true,
   );
 }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -448,7 +448,9 @@ html {
      pointer, because focus never moved and no focusin fired. Written as
      `input` those controls go dark under the user's own first keystroke.
      Anything left off this list keeps a ring on a click, which is the mild
-     half of the trade.
+     half of the trade. `contenteditable` is qualified for the same reason the
+     inputs are: the bare attribute selector also matches
+     `contenteditable="false"`, which is not a field and does not take typing.
 
      Transparent rather than `none`, which is not a stylistic choice: forced
      colors repaints every outline in the system palette but cannot paint one
@@ -460,7 +462,7 @@ html {
      `outline-none` compiles to this and not to `outline: none`. */
   :root[data-pointer-focus] :is(
     textarea,
-    [contenteditable],
+    [contenteditable]:not([contenteditable="false"]),
     input:not([type]),
     input[type="text"],
     input[type="email"],


### PR DESCRIPTION
## Overview

A field the mouse focused now stays unringed when the user leaves the browser and comes back. Before this, clicking the composer, typing, switching to another app for the length of an agent turn and returning lit a focus ring on the composer, and left it lit until the next focus move. That is the stray ring that kept getting reported as intermittent.

| | Files | +/− |
|---|---|---|
| Modified | 3 | +116 / −4 |
| New | 0 | — |
| **Net (excl. tests)** | **2** | **+33 / −4** |

**By module**

| File | | What changed |
|---|---|---|
| `web/src/lib/inputModality.ts` | modified | Remembers what held focus at window `blur`, and skips the `focusin` that hands focus straight back to it. |
| `web/src/styles/tokens.css` | modified | Qualifies the `contenteditable` selector in the pointer-focus suppression list so it no longer matches `contenteditable="false"`. |
| `web/e2e/focus-ring.spec.js` | modified | Four tests replaying a trip out of the window and back, on the composer and the dashboard search box. |

## Why this way

Browsers always match `:focus-visible` on text-entry controls, on a click as well as on a Tab. That is a deliberate spec heuristic, and it means no CSS selector can separate the two on a `textarea`. The existing design answers that by recording how focus arrived: a capture-phase `focusin` listener stamps `data-pointer-focus` on the document element, and `tokens.css` reads it back to keep the ring off a mouse-focused field.

The flaw was in re-deriving that record on *every* `focusin`. Leaving the browser window does not release element focus, it parks it. `document.activeElement` never changes, and Chrome fires a `focusout`/`blur`/`focus`/`focusin` quartet around the trip purely as bookkeeping. The restoring `focusin` looks like any other one, but by the time it arrives the live modality flag has been flipped to keyboard by the user's own typing. So the browser handed back focus nobody had moved, and the listener re-decided a settled question with the wrong evidence.

The alternative considered was a timing latch: suppress any re-derivation for a short window after the page regains focus. It was rejected because it is not scoped to the element. If focus lands on a *different* control while the window is in the background, that is a genuine focus move and re-deciding is correct: Selectors Level 4 explicitly recommends indicating focus on an element that newly receives it. A time-based latch would carry field A's "pointer" verdict onto field B and hide B's ring from a mixed keyboard user, and it has no natural expiry. Identity of the parked element is the precise thing to key on, so that is what this keys on.

## How it works

`inputModality.ts` gains one piece of state, `parked`. A non-capture listener on `window` records `document.activeElement` when the window itself loses focus. That listener placement is the load-bearing detail: element `blur` does not bubble, so a listener reached only at its own target hears window deactivation and nothing else, which is exactly the case where focus is parked rather than moved.

The `focusin` listener then compares its target against `parked`. On a match it clears the record and returns without touching `data-pointer-focus`, so the attribute survives the round trip unchanged. Any real focus move clears `parked` first (a `pointerdown` or a non-modifier `keydown` both reset it), so the guard cannot leak into the next interaction.

`tokens.css` carries one unrelated tightening in the same suppression rule: the bare `[contenteditable]` attribute selector also matches `contenteditable="false"`, which is not a field and takes no typing. It has no reachable effect today (the app renders no `contenteditable` elements) and is a correctness guard for whenever one appears.

## Risk

- **Measured in Chrome only.** The event quartet was recorded by driving a real Chrome and reading its own trace. Firefox and Safari were not measured. If either orders the events differently the guard simply does not fire, and the behavior falls back to what ships today, so the failure direction is the current bug rather than a new one.
- **The regression test replays a recorded sequence, it does not integrate.** Playwright pins every page with focus emulation, so a backgrounded tab still believes it has focus and no amount of `bringToFront`, second contexts, headed mode, or disabling focus emulation over CDP produces a real window blur. The test therefore dispatches the recorded quartet. It pins the contract, and it went red under ablation, but it is not proof against a browser that changes the sequence.
- **Focus moving to a *different* element while the window is backgrounded still re-derives, by design.** That is a real focus move, and per the reasoning above it should ring.
- **Iframes remain a pre-existing hole**, unchanged by this branch: focus inside a child document does not update the parent's record.

## Test plan

- [x] `pnpm typecheck` clean
- [x] 38 focus e2e pass across `focus-ring.spec.js`, `model-menu.focus.spec.js`, `auth-surface.focus.spec.js`
- [x] Ablation: forcing the guard off failed exactly the two new mouse tests and left the two keyboard guards green
- [x] Verified by hand in real Chrome across three app-switch round trips, with the live modality flag reading keyboard each time and the field staying unringed

Tests added: 4 regression tests for the parked-focus restore.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791030862&installation_model_id=432753&pr_number=390&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F390&signature=293f36da25feeea556e4a53ee3ad913a63e5db555ca676ac01b536a8940af501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Focus rings now restore correctly when returning to the app after switching windows.
  - Mouse-focused fields remain without a ring, while keyboard-focused fields retain their ring.
  - Subsequent focus changes independently recalculate focus-ring behavior.
  - Elements marked `contenteditable="false"` now retain the standard focus ring.

- **Tests**
  - Added coverage for focus-ring behavior when the browser window is temporarily inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->