### PR TITLE
fix(web): smooth streaming end to end: one-pass reconnect, per-block markdown, spinner in the pauses

### DIFF
--- a/src/server/STREAM_CONTRACT_V2.md
+++ b/src/server/STREAM_CONTRACT_V2.md
@@ -133,8 +133,10 @@ sampled transactionally, the snapshot algorithm is a revalidation loop:
 - **Socket control frames** (mux-level, cursorless — distinct from in-stream frames):
   `chan_open{chan, lane, mode, started}` when the mux admits a channel (mode `replay`
   for a live run, `drain` for a settled backlog; `started` = ledger started_at epoch
-  ms, the client orders per-task outcome votes by it), and `chan_close{chan, reason}`
-  when it releases one. `chan_close{reason: terminal, outcome}` carries the ledger
+  ms, the client orders per-task outcome votes by it), `chan_caught_up{chan}` once the
+  channel's cursor reaches the stream head recorded at open (the frames before it are
+  backlog the client presents as already rendered; the ones after arrived live), and
+  `chan_close{chan, reason}` when it releases one. `chan_close{reason: terminal, outcome}` carries the ledger
   row's outcome — it is how a channel closes from row truth when the worker died
   between the terminal CAS and the `run_end` append. Other reasons:
   `resync_required` (cursor gap / aged-out stream) and `transport_error`.

--- a/src/server/handlers/chat/run_stream_reader.py
+++ b/src/server/handlers/chat/run_stream_reader.py
@@ -26,8 +26,15 @@ from src.server.handlers.chat.xread_tuning import (
 )
 from src.server.services.runs.executor import LocalRunExecutor
 from src.server.services.runs.stream_writer import RUN_END_EVENT_TYPE
+
 from src.utils.cache.redis_cache import get_cache_client, is_pool_exhaustion
 from src.utils.cache import stream_pool
+
+# Emitted once by the main-workflow consumer where the replayed backlog ends
+# and the live tail begins. The client batches everything before it. The
+# ``_EVENT_TYPE`` suffix is what the event-ledger scan keys on, so the type
+# stays visible even though the frame around it is built from the parameter.
+CAUGHT_UP_EVENT_TYPE = "caught_up"
 
 # Same hard-coded logger name request_prep uses — existing log routing keys off it.
 logger = logging.getLogger("src.server.handlers.chat_handler")
@@ -58,6 +65,21 @@ def _is_stream_end_sentinel(raw: str, sentinel_event: str) -> bool:
         and record.get("event") == sentinel_event
         and "seq" not in record
     )
+
+
+def _entry_id_key(entry_id: bytes | str) -> tuple[int, int]:
+    """Order key for a Redis stream ID (``ms-seq``).
+
+    Explicit ``seq-0`` ids and auto ids (epoch ms) share one stream, and the
+    tuple order is the order Redis itself uses, so a cursor compares against
+    the head without caring which kind either one is.
+    """
+    text = entry_id.decode("utf-8") if isinstance(entry_id, bytes) else entry_id
+    ms, _, seq = text.partition("-")
+    try:
+        return (int(ms), int(seq or 0))
+    except ValueError:
+        return (0, 0)
 
 
 def _first_available_seq(entries: list) -> Optional[int]:
@@ -92,6 +114,7 @@ async def _stream_from_redis_log(
     on_detach: Optional[Callable[[], Awaitable[None]]] = None,
     sentinel_event: Optional[str] = None,
     close_event: Optional[str] = None,
+    caught_up_event: Optional[str] = None,
 ) -> AsyncGenerator[str, None]:
     """Generic XREAD BLOCK loop yielding SSE strings stored in a Redis Stream.
 
@@ -125,6 +148,15 @@ async def _stream_from_redis_log(
     starting ``event: <name>\\n``) that is YIELDED to the client and then
     ends the stream — the visible ``run_end`` frame, vs the swallowed
     legacy sentinel above.
+
+    ``caught_up_event`` (optional) names a marker frame yielded exactly once,
+    where the cursor first reaches the stream head sampled at attach: what
+    precedes it is backlog the client may apply in one pass, what follows is
+    live. An empty stream marks the boundary at once (nothing to batch); an
+    unreadable head sends no marker at all, and the client's quiet-window and
+    cap timers close the backlog instead. An early marker would have the
+    client present the whole retained backlog live, which is the retype the
+    marker exists to prevent.
     """
     cache = get_cache_client()
     if not cache.enabled or not cache.client:
@@ -177,6 +209,29 @@ async def _stream_from_redis_log(
                 "[stream_from_log] gap probe failed on %s: %s", stream_key, exc
             )
 
+    # Backlog/live boundary: the head at attach time. Read once, up front, so
+    # a producer that keeps writing during the replay cannot push the marker
+    # out indefinitely. An empty stream leaves the zero key, which the first
+    # boundary check below clears; a failed probe drops the marker instead.
+    caught_up_pending = caught_up_event is not None
+    head_key: tuple[int, int] = (0, 0)
+    if caught_up_event is not None:
+        try:
+            tail = await asyncio.wait_for(
+                cache.client.xrevrange(stream_key_bytes, count=1),
+                timeout=xread_wait_timeout_s(),
+            )
+            if tail:
+                head_key = _entry_id_key(tail[0][0])
+        except Exception as exc:
+            caught_up_pending = False
+            logger.warning(
+                "[stream_from_log] head probe failed on %s, no boundary marker: %s",
+                stream_key,
+                exc,
+            )
+    caught_up_frame = f"event: {caught_up_event}\ndata: {{}}\n\n"
+
     attached = False
     try:
         if on_attach is not None:
@@ -184,6 +239,12 @@ async def _stream_from_redis_log(
             attached = True
         terminal_seen = False
         while True:
+            # The boundary, checked once per round before the read: covers
+            # the fresh attach and a batch that ends exactly on the head. A
+            # batch that runs past it emits the marker mid-batch below.
+            if caught_up_pending and _entry_id_key(cursor) >= head_key:
+                caught_up_pending = False
+                yield caught_up_frame
             try:
                 # asyncio.wait_for guards against the underlying redis-py
                 # XREAD hanging past BLOCK if the connection is poisoned.
@@ -233,6 +294,12 @@ async def _stream_from_redis_log(
                 continue
 
             if not result:
+                # Fallback for a head that raced ahead of what is readable:
+                # settle the boundary rather than hold the client's backlog
+                # open until the producer catches up to its own head.
+                if caught_up_pending:
+                    caught_up_pending = False
+                    yield caught_up_frame
                 # BLOCK timed out — emit keepalive comment so proxies and
                 # the browser see liveness, then re-check terminal.
                 yield ":keepalive\n\n"
@@ -245,6 +312,12 @@ async def _stream_from_redis_log(
             # result format: [(stream_key, [(entry_id, {field: value}), ...])]
             for _stream_name, entries in result:
                 for entry_id, fields in entries:
+                    # The boundary inside a batch: the first entry past the
+                    # recorded head is live, so the marker goes ahead of it
+                    # rather than after the whole batch.
+                    if caught_up_pending and _entry_id_key(entry_id) > head_key:
+                        caught_up_pending = False
+                        yield caught_up_frame
                     # Advance the cursor unconditionally before any skip path.
                     # If the *last* entry in a batch hits a continue (missing
                     # ``event`` field, non-UTF8 payload), leaving the cursor
@@ -366,5 +439,6 @@ async def stream_from_log(
         on_detach=on_detach,
         sentinel_event=WORKFLOW_STREAM_END_EVENT,
         close_event=RUN_END_EVENT_TYPE,
+        caught_up_event=CAUGHT_UP_EVENT_TYPE,
     ):
         yield event

--- a/src/server/handlers/chat/thread_stream_mux_v2.py
+++ b/src/server/handlers/chat/thread_stream_mux_v2.py
@@ -12,8 +12,10 @@ Wire shape:
 - Cursors: ``?cursors=run:<run_id>#<entry_id>,…`` — resume is exclusive.
 - Frames: ``id: run:<run_id>#<entry_id>`` + the contract envelope
   ``{run_id, seq, lane, type, payload}`` as data. Control frames
-  (``chan_open``, ``chan_close``, ``resync_required``, ``transport_error``,
-  ``timeout``) carry no cursor.
+  (``chan_open``, ``chan_caught_up``, ``chan_close``, ``resync_required``,
+  ``transport_error``, ``timeout``) carry no cursor. ``chan_caught_up``
+  marks where a channel's backlog ends: everything before it existed when
+  the channel opened, everything after arrived live.
 - Close: the ``run_end`` frame, or — for a worker that died between the
   terminal CAS and the append — a rate-limited ledger-row probe emitting
   ``chan_close{reason: terminal}`` from row truth. 'unknown' never closes.
@@ -178,6 +180,13 @@ class _RunChan:
     # Ledger started_at (epoch ms), declared on chan_open: the client
     # orders per-task outcome votes by run start, never by close order.
     started_ms: Optional[float] = None
+    # Stream head when the channel opened, probed once by the pump. The
+    # entries up to it are backlog the client presents as already rendered;
+    # ``chan_caught_up`` is emitted once the cursor reaches it, or on the
+    # first read that returns nothing for the channel. A failed probe sends
+    # no marker and leaves the client to its bounded fallback.
+    head_at_open: Optional[bytes] = None
+    caught_up: bool = False
 
     @property
     def name(self) -> str:
@@ -226,6 +235,47 @@ def _parse_task_entry(fields: dict) -> Optional[tuple[str, str]]:
     if not ftype:
         return None
     return ftype, payload or ""
+
+
+async def _probe_backlog_head(cache, chan: _RunChan) -> Optional[str]:
+    """Record the channel's backlog head; the marker frame when there is none."""
+    try:
+        tail = await cache.client.xrevrange(chan.stream_key, count=1)
+    except Exception:
+        chan.caught_up = True  # no marker: the client's fallback bounds the wait
+        logger.warning(
+            "[mux2] backlog head probe failed for %s, no boundary marker",
+            chan.name,
+            exc_info=True,
+        )
+        return None
+    if not tail:
+        chan.caught_up = True
+        return _control("chan_caught_up", {"chan": chan.name})
+    chan.head_at_open = tail[0][0]
+    return None
+
+
+def _marker_before(chan: _RunChan, entry_id: bytes) -> Optional[str]:
+    """The marker ahead of the first entry past the recorded head, so a batch
+    that straddles the boundary never sends live entries as backlog."""
+    if chan.caught_up or chan.closed or chan.head_at_open is None:
+        return None
+    if not _entry_after(entry_id, chan.head_at_open.decode()):
+        return None
+    chan.caught_up = True
+    return _control("chan_caught_up", {"chan": chan.name})
+
+
+def _caught_up_frame(chan: _RunChan, got_entries: bool) -> Optional[str]:
+    """The marker once the cursor reaches the recorded head, or a read came
+    back empty for the channel (its backlog was shorter than the head said)."""
+    if chan.caught_up or chan.closed or chan.head_at_open is None:
+        return None
+    if got_entries and _entry_after(chan.head_at_open, chan.cursor.decode()):
+        return None
+    chan.caught_up = True
+    return _control("chan_caught_up", {"chan": chan.name})
 
 
 async def _run_row(run_id: str, lane: str) -> Optional[dict]:
@@ -668,6 +718,30 @@ async def stream_thread_mux_v2(
         xread_failures = 0
         while True:
             open_chans = [c for c in channels.values() if not c.closed]
+            unprobed = [
+                c for c in open_chans if not c.caught_up and c.head_at_open is None
+            ]
+            if unprobed:
+                # One bound for the whole pass: probed together, so a slow
+                # pool costs one timeout, not one per channel, and the read
+                # loop keeps its keepalive cadence.
+                try:
+                    markers = await asyncio.wait_for(
+                        asyncio.gather(*(_probe_backlog_head(cache, c) for c in unprobed)),
+                        timeout=xread_wait_timeout_s(),
+                    )
+                except asyncio.TimeoutError:
+                    markers = []
+                    for c in unprobed:
+                        if c.head_at_open is None:
+                            c.caught_up = True
+                    logger.warning(
+                        "[mux2] backlog head probes timed out for %d channels, no boundary marker",
+                        len(unprobed),
+                    )
+                for marker in markers:
+                    if marker is not None:
+                        await out_q.put(("frame", marker))
             streams: dict[bytes, bytes] = {control_key: control_cursor}
             for c in open_chans:
                 streams[c.stream_key] = c.cursor
@@ -739,6 +813,9 @@ async def stream_thread_mux_v2(
                 got.add(chan.run_id)
                 chan.empty_rounds = 0
                 for entry_id, fields in entries:
+                    marker = _marker_before(chan, entry_id)
+                    if marker is not None:
+                        await out_q.put(("frame", marker))
                     chan.cursor = entry_id
                     parsed = (
                         _parse_main_entry(fields)
@@ -759,6 +836,9 @@ async def stream_thread_mux_v2(
                     if ftype == "run_end":
                         await _close(chan, "terminal")
                         break
+                marker = _caught_up_frame(chan, got_entries=True)
+                if marker is not None:
+                    await out_q.put(("frame", marker))
 
             # Crash-window backstop: a terminal ledger row whose stream
             # never got its run_end closes the channel from row truth.
@@ -766,6 +846,9 @@ async def stream_thread_mux_v2(
             for chan in open_chans:
                 if chan.run_id in got or chan.closed:
                     continue
+                marker = _caught_up_frame(chan, got_entries=False)
+                if marker is not None:
+                    await out_q.put(("frame", marker))
                 chan.empty_rounds += 1
                 if chan.empty_rounds < _QUIESCE_EMPTY_ROUNDS:
                     continue

--- a/tests/unit/server/handlers/chat/test_stream_readers.py
+++ b/tests/unit/server/handlers/chat/test_stream_readers.py
@@ -28,12 +28,19 @@ from src.server.handlers.chat.run_stream_reader import (
 
 
 def _make_cache(xread_returns: list[Any]) -> MagicMock:
-    """A cache mock whose client.xread iterates through the given sequence."""
+    """A cache mock whose client.xread iterates through the given sequence.
+
+    ``xrevrange`` answers empty by default: the head probe is awaited on every
+    ``caught_up``-carrying attach, and a bare MagicMock attribute there fails
+    the await and silently exercises the probe's error path instead of the
+    empty-stream one every non-caught_up test means to be on.
+    """
     cache = MagicMock()
     cache.enabled = True
     redis = MagicMock()
     cache.client = redis
     redis.xread = AsyncMock(side_effect=xread_returns)
+    redis.xrevrange = AsyncMock(return_value=[])
     return cache
 
 
@@ -797,7 +804,12 @@ async def test_stream_from_log_main_path_closes_on_sentinel(monkeypatch):
 
     out = [ev async for ev in stream_from_log("t-sent", last_event_id=None)]
 
-    assert out == [real_bytes.decode("utf-8")]
+    # Empty head probe → the boundary is already reached at attach, so the
+    # marker leads and the backlog behind it is empty.
+    assert out == [
+        "event: caught_up\ndata: {}\n\n",
+        real_bytes.decode("utf-8"),
+    ]
     assert cache.client.xread.await_count == 1
     fake_manager.decrement_connection.assert_awaited_once_with("t-sent", "r-1")
 
@@ -862,3 +874,214 @@ async def test_disabled_cache_returns_empty_immediately():
             )
         ]
     assert out == []
+
+
+# ---------------------------------------------------------------------------
+# caught_up marker (backlog / live boundary)
+# ---------------------------------------------------------------------------
+
+
+def _entries(*seqs: int) -> list:
+    return [
+        (
+            b"workflow:stream:t1",
+            [(f"{s}-0".encode(), {b"event": f"id: {s}\nevent: x\ndata: {s}\n\n".encode()}) for s in seqs],
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_caught_up_marks_the_head_at_attach_then_live_events_follow():
+    cache = _make_cache([_entries(1, 2), _entries(3), [], []])
+    cache.client.xrevrange = AsyncMock(return_value=[(b"2-0", {b"event": b"..."})])
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.run_stream_reader.get_cache_client",
+        return_value=cache,
+    ):
+        out = [
+            ev
+            async for ev in _stream_from_redis_log(
+                stream_key="workflow:stream:t1",
+                terminal_check=terminal,
+                last_event_id=None,
+                caught_up_event="caught_up",
+            )
+        ]
+
+    frames = [ev for ev in out if ev != ":keepalive\n\n"]
+    assert [f.split("\n")[0] for f in frames] == ["id: 1", "id: 2", "event: caught_up", "id: 3"]
+    assert frames.count("event: caught_up\ndata: {}\n\n") == 1
+
+
+@pytest.mark.asyncio
+async def test_caught_up_lands_inside_a_batch_that_straddles_the_head():
+    # The producer appended entry 3 between the head probe and the read, so
+    # one batch carries backlog and live entries: the marker goes ahead of
+    # the first live one, never after the batch.
+    cache = _make_cache([_entries(1, 2, 3), [], []])
+    cache.client.xrevrange = AsyncMock(return_value=[(b"2-0", {b"event": b"..."})])
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.run_stream_reader.get_cache_client",
+        return_value=cache,
+    ):
+        out = [
+            ev
+            async for ev in _stream_from_redis_log(
+                stream_key="workflow:stream:t1",
+                terminal_check=terminal,
+                last_event_id=None,
+                caught_up_event="caught_up",
+            )
+        ]
+
+    frames = [ev for ev in out if ev != ":keepalive\n\n"]
+    assert [f.split("\n")[0] for f in frames] == ["id: 1", "id: 2", "event: caught_up", "id: 3"]
+    assert frames.count("event: caught_up\ndata: {}\n\n") == 1
+
+
+@pytest.mark.asyncio
+async def test_caught_up_is_immediate_on_an_empty_stream():
+    cache = _make_cache([[], []])
+    cache.client.xrevrange = AsyncMock(return_value=[])
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.run_stream_reader.get_cache_client",
+        return_value=cache,
+    ):
+        out = [
+            ev
+            async for ev in _stream_from_redis_log(
+                stream_key="workflow:stream:t1",
+                terminal_check=terminal,
+                caught_up_event="caught_up",
+            )
+        ]
+
+    assert out[0] == "event: caught_up\ndata: {}\n\n"
+
+
+@pytest.mark.asyncio
+async def test_caught_up_after_an_empty_round_when_head_raced_ahead():
+    # Head says 3 but the producer's entry 3 is not readable yet: the first
+    # empty round settles it rather than holding the client's backlog open.
+    cache = _make_cache([_entries(1, 2), [], _entries(3), [], []])
+    cache.client.xrevrange = AsyncMock(return_value=[(b"3-0", {b"event": b"..."})])
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.run_stream_reader.get_cache_client",
+        return_value=cache,
+    ):
+        out = [
+            ev
+            async for ev in _stream_from_redis_log(
+                stream_key="workflow:stream:t1",
+                terminal_check=terminal,
+                caught_up_event="caught_up",
+            )
+        ]
+
+    frames = [ev for ev in out if ev != ":keepalive\n\n"]
+    assert [f.split("\n")[0] for f in frames] == ["id: 1", "id: 2", "event: caught_up", "id: 3"]
+
+
+@pytest.mark.asyncio
+async def test_no_marker_without_a_caught_up_event():
+    cache = _make_cache([_entries(1), [], []])
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.run_stream_reader.get_cache_client",
+        return_value=cache,
+    ):
+        out = [
+            ev
+            async for ev in _stream_from_redis_log(
+                stream_key="workflow:stream:t1",
+                terminal_check=terminal,
+            )
+        ]
+
+    assert not any("caught_up" in ev for ev in out)
+
+
+@pytest.mark.asyncio
+async def test_head_probe_failure_sends_no_marker():
+    """With no head to compare against there is no boundary to announce: the
+    client's quiet-window and cap timers close the backlog on their own, and
+    an early marker would have it present the whole backlog live instead."""
+    cache = _make_cache([_entries(1), [], []])
+    cache.client.xrevrange = AsyncMock(side_effect=RuntimeError("down"))
+
+    async def terminal() -> bool:
+        return True
+
+    with patch(
+        "src.server.handlers.chat.run_stream_reader.get_cache_client",
+        return_value=cache,
+    ):
+        out = [
+            ev
+            async for ev in _stream_from_redis_log(
+                stream_key="workflow:stream:t1",
+                terminal_check=terminal,
+                caught_up_event="caught_up",
+            )
+        ]
+
+    frames = [ev for ev in out if ev != ":keepalive\n\n"]
+    assert [f.split("\n")[0] for f in frames] == ["id: 1"]
+    assert not any("caught_up" in ev for ev in out)
+
+
+@pytest.mark.asyncio
+async def test_stream_from_log_marks_the_boundary_after_the_backlog(monkeypatch):
+    """The main consumer wires ``caught_up`` through with a real head: the
+    marker lands between the replayed backlog and the first live batch."""
+    from src.server.handlers.chat import run_stream_reader as rsr_mod
+    from src.server.services.runs.executor import (
+        LocalRunExecutor,
+        LocalRunStatus,
+    )
+
+    cache = _make_cache([_entries(1, 2), _entries(3), [], []])
+    cache.client.xrevrange = AsyncMock(return_value=[(b"2-0", {b"event": b"..."})])
+    monkeypatch.setattr(rsr_mod, "get_cache_client", lambda: cache)
+
+    fake_task = MagicMock()
+    fake_task.run_id = "r-1"
+    fake_task.status = LocalRunStatus.COMPLETED
+
+    fake_manager = MagicMock()
+    fake_manager.executions = {("t-head", "r-1"): fake_task}
+    fake_manager._find_latest_for_thread = MagicMock(return_value=fake_task)
+    fake_manager.increment_connection = AsyncMock(return_value=True)
+    fake_manager.decrement_connection = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        LocalRunExecutor, "get_instance", classmethod(lambda cls: fake_manager)
+    )
+
+    out = [ev async for ev in stream_from_log("t-head", last_event_id=None)]
+
+    frames = [ev for ev in out if ev != ":keepalive\n\n"]
+    assert [f.split("\n")[0] for f in frames] == [
+        "id: 1",
+        "id: 2",
+        f"event: {rsr_mod.CAUGHT_UP_EVENT_TYPE}",
+        "id: 3",
+    ]

--- a/tests/unit/server/handlers/chat/test_thread_stream_mux_v2_boundary.py
+++ b/tests/unit/server/handlers/chat/test_thread_stream_mux_v2_boundary.py
@@ -1,0 +1,102 @@
+"""Locks the per-channel backlog boundary of the v2 mux.
+
+A channel replays from 0 (or from a stale cursor) before it goes live, and the
+client presents that backlog as already rendered. ``chan_caught_up`` is the
+marker between the two: emitted at once for an empty stream, once the cursor
+reaches the head recorded at open, or on the first empty read for the channel.
+A failed head probe sends no marker, so the client's bounded fallback decides,
+and a channel closed by its run_end never trails one behind the close.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.server.handlers.chat.thread_stream_mux_v2 import (
+    _RunChan,
+    _caught_up_frame,
+    _probe_backlog_head,
+)
+
+
+def _chan(cursor: bytes = b"0") -> _RunChan:
+    return _RunChan(run_id="r1", lane="task:t1", stream_key=b"k", cursor=cursor)
+
+
+def _cache(tail=None, error=None):
+    cache = MagicMock()
+    cache.client.xrevrange = AsyncMock(return_value=tail)
+    if error is not None:
+        cache.client.xrevrange.side_effect = error
+    return cache
+
+
+def _payload(frame: str) -> dict:
+    assert frame.startswith("event: chan_caught_up\n")
+    return json.loads(frame.split("data: ", 1)[1])
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_is_caught_up_at_once():
+    chan = _chan()
+    frame = await _probe_backlog_head(_cache(tail=[]), chan)
+    assert _payload(frame) == {"chan": "run:r1"}
+    assert chan.caught_up is True
+    assert _caught_up_frame(chan, got_entries=False) is None
+
+
+@pytest.mark.asyncio
+async def test_marker_follows_the_cursor_to_the_recorded_head():
+    chan = _chan()
+    assert await _probe_backlog_head(_cache(tail=[(b"5-0", {})]), chan) is None
+    assert chan.head_at_open == b"5-0"
+    chan.cursor = b"3-0"
+    assert _caught_up_frame(chan, got_entries=True) is None
+    chan.cursor = b"5-0"
+    assert _payload(_caught_up_frame(chan, got_entries=True)) == {"chan": "run:r1"}
+    # Once only: later reads never repeat it.
+    chan.cursor = b"9-0"
+    assert _caught_up_frame(chan, got_entries=True) is None
+
+
+@pytest.mark.asyncio
+async def test_empty_read_marks_a_backlog_shorter_than_its_head():
+    chan = _chan()
+    await _probe_backlog_head(_cache(tail=[(b"5-0", {})]), chan)
+    chan.cursor = b"2-0"
+    assert _payload(_caught_up_frame(chan, got_entries=False)) == {"chan": "run:r1"}
+
+
+@pytest.mark.asyncio
+async def test_failed_probe_sends_no_marker_and_stops_probing():
+    chan = _chan()
+    assert await _probe_backlog_head(_cache(error=RuntimeError("down")), chan) is None
+    assert chan.caught_up is True
+    assert chan.head_at_open is None
+    assert _caught_up_frame(chan, got_entries=False) is None
+
+
+@pytest.mark.asyncio
+async def test_closed_channel_never_trails_a_marker_after_its_close():
+    # A run_end at the head closes the channel first; chan_close already ends
+    # the client's replay, so a marker behind it would be noise.
+    chan = _chan()
+    await _probe_backlog_head(_cache(tail=[(b"5-0", {})]), chan)
+    chan.cursor = b"5-0"
+    chan.closed = True
+    assert _caught_up_frame(chan, got_entries=True) is None
+
+
+@pytest.mark.asyncio
+async def test_marker_goes_ahead_of_the_first_entry_past_the_head():
+    # A batch that straddles the boundary: entries after the recorded head
+    # are live, so the marker is emitted before them, not after the batch.
+    from src.server.handlers.chat.thread_stream_mux_v2 import _marker_before
+
+    chan = _chan()
+    await _probe_backlog_head(_cache(tail=[(b"5-0", {})]), chan)
+    assert _marker_before(chan, b"5-0") is None
+    assert _payload(_marker_before(chan, b"6-0")) == {"chan": "run:r1"}
+    assert _marker_before(chan, b"7-0") is None
+    assert _caught_up_frame(chan, got_entries=True) is None

--- a/tests/unit/server/services/history/test_event_ledger.py
+++ b/tests/unit/server/services/history/test_event_ledger.py
@@ -82,6 +82,13 @@ LIVE_ONLY = {
     "chan_close",  # mux channel lifecycle (thread_stream_mux)
     "transport_error",  # mux whole-socket retryable close
     "timeout",  # watch/mux max-duration autoclose (predates mux; single-quoted emit sites evaded the scan)
+    "caught_up",  # backlog/live boundary marker on the run stream, emitted at
+    # the head sampled when a consumer attaches. Transient by construction: it
+    # marks where a batch of replayed events ends, so replaying it would be
+    # meaningless.
+    "chan_caught_up",  # the same boundary per mux channel (thread_stream_mux_v2)
+    "resync_required",  # mux: a channel's cursor fell off its stream, reload
+    # from history; a socket-level instruction, nothing to replay
 }
 
 # KNOWN GAP: survives replay only through persisted sse_events. Before
@@ -105,11 +112,16 @@ _EMIT_PATTERNS = (
     re.compile(r'_format_sse_event\(\s*"([a-z_]+)"'),
     # _sse("type", ...) — the per-module frame helpers
     re.compile(r'_sse\(\s*"([a-z_]+)"'),
+    # _control("type", ...) — the mux's socket-level control frames
+    re.compile(r'_control\(\s*"([a-z_]+)"'),
     # yield f"event: type\n..." and plain "event: type"
     re.compile(r'"(?:id: [^"]*?\\n)?event: ([a-z_]+)'),
     # replay item dicts: {"event": "type", ...}
     re.compile(r'\{"event": "([a-z_]+)"'),
     re.compile(r'"event": "([a-z_]+)",'),
+    # NAME_EVENT_TYPE = "type": a wire type named by a constant, where the
+    # frame around it is assembled somewhere the patterns above cannot see.
+    re.compile(r'^_?[A-Z][A-Z0-9_]*_EVENT_TYPE\s*=\s*"([a-z_]+)"', re.M),
 )
 
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -34,3 +34,7 @@ dist-ssr
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# streaming smoothness benchmark output (e2e/perf)
+/perf-results/
+/dist-perf/

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -14,6 +14,8 @@ pnpm test         # vitest run;  test:e2e = Playwright
 pnpm lint         # ESLint 9 flat config (advisory — NOT gated in CI)
 ```
 
+Streaming perf benchmarks live in `e2e/perf/`, are gated behind `PERF=1`, and their flags and canonical invocations are in [`e2e/perf/README.md`](e2e/perf/README.md).
+
 ## Landmines (non-obvious)
 
 - **Dual-mode auth** (`contexts/AuthContext.tsx`), switched by `VITE_HOST_MODE` (`config/hostMode.ts`, default `oss`): `platform` → `SupabaseAuthProvider` (real session; the axios interceptor reads its Bearer token from `lib/authToken.ts`); `oss` → static local-dev context, always logged in as `VITE_AUTH_USER_ID` (default `local-dev-user`). `VITE_SUPABASE_URL`/`_KEY` only gate Supabase-*client* construction, NOT the mode — check `isPlatformMode`, never `VITE_SUPABASE_URL`.

--- a/web/e2e/activity-live-zone.spec.js
+++ b/web/e2e/activity-live-zone.spec.js
@@ -1,0 +1,85 @@
+/**
+ * The activity live zone must size to its rows after a fold is interrupted.
+ *
+ * Three tool rows complete together, fold into the accordion, and a fourth
+ * call lands while the live zone is still collapsing. The zone must end up
+ * as tall as the one row it now holds, not the three it held before.
+ */
+import { configureSSE, resetMockServer, mockAPI, test, expect } from './fixtures.js';
+import { sseEvents } from './helpers/mockResponses.js';
+import { TH, chatViewOverrides } from './helpers/chatScenario.js';
+import { MIN_LIVE_EXPOSURE_MS } from '../src/pages/ChatAgent/components/messageList/liveZoneTiming.ts';
+
+// A completed row stays live for MIN_LIVE_EXPOSURE_MS after its call was
+// created, then folds; the zone's collapse runs about 180 ms more, so a call
+// landing 150 ms past the fold lands inside that collapse. The clock starts
+// at the first event, and the four events before the delay each cost a gap,
+// so the delay is measured from the first event, not from the last result.
+// The tool must not be an inline-artifact tool (those skip the exposure
+// window).
+const EVENT_GAP_MS = 30;
+const LAND_MID_COLLAPSE_MS = MIN_LIVE_EXPOSURE_MS + 150 - 4 * EVENT_GAP_MS;
+
+test.describe('activity live zone', () => {
+  test.beforeEach(async () => {
+    await resetMockServer();
+  });
+
+  test('sizes to its rows after a call lands mid-fold', async ({ page }) => {
+    await mockAPI(page, chatViewOverrides());
+    await configureSSE({
+      method: 'GET',
+      path: `/api/v1/threads/${TH}/messages/replay`,
+      events: [sseEvents.replayDone()],
+      delay: 10,
+    });
+
+    const batch = ['toolu_a1', 'toolu_a2', 'toolu_a3'];
+    await configureSSE({
+      method: 'POST',
+      path: `/api/v1/threads/${TH}/messages`,
+      events: [
+        sseEvents.toolCalls(batch.map((id, i) => ({ name: 'bash', args: { command: `echo ${i}` }, id }))),
+        sseEvents.finishToolCalls(),
+        sseEvents.toolCallResult('toolu_a1', '0'),
+        sseEvents.toolCallResult('toolu_a2', '1'),
+        { ...sseEvents.toolCallResult('toolu_a3', '2'), delayAfter: LAND_MID_COLLAPSE_MS },
+        sseEvents.toolCalls([{ name: 'bash', args: { command: 'echo 3' }, id: 'toolu_b' }]),
+        // Hold the fourth call in progress so it stays a live row while measured.
+        { ...sseEvents.finishToolCalls(), delayAfter: 3000 },
+        sseEvents.toolCallResult('toolu_b', '3'),
+        sseEvents.messageChunk('done'),
+        sseEvents.finishStop(),
+        sseEvents.creditUsage(),
+      ],
+      delay: EVENT_GAP_MS,
+    });
+
+    await page.goto(`/chat/t/${TH}`);
+    await page.waitForSelector('textarea', { timeout: 10000 });
+    await page.locator('textarea').fill('run four commands');
+    await page.locator('button[aria-label="Send message"]').click();
+
+    // The precondition, read in one pass so it can actually fail: the three
+    // rows must already be folded behind the accordion summary when the fourth
+    // call goes live. If the fourth arrived first there is no interrupted fold
+    // and the height below would be measured on a case that never regressed.
+    const atFold = await page.waitForFunction(() => {
+      if (!document.querySelector('[id^="activity-summary-"]')) return null;
+      return { active: document.querySelectorAll('[data-testid="activity-live-zone"] .nrow.state-active').length };
+    }, null, { timeout: 15000 }).then((h) => h.jsonValue());
+    expect(atFold.active, 'the fourth call went live before the first three folded').toBe(0);
+
+    const zone = page.getByTestId('activity-live-zone');
+    await expect(zone.locator('.nrow.state-active')).toHaveCount(1, { timeout: 15000 });
+    // Let the zone's own animations settle before measuring.
+    await page.waitForTimeout(1000);
+
+    const { zoneHeight, rowsHeight } = await zone.evaluate((el) => ({
+      zoneHeight: el.getBoundingClientRect().height,
+      rowsHeight: Array.from(el.children).reduce((sum, c) => sum + c.getBoundingClientRect().height, 0),
+    }));
+    expect(rowsHeight).toBeGreaterThan(0);
+    expect(zoneHeight).toBeLessThanOrEqual(rowsHeight + 2);
+  });
+});

--- a/web/e2e/chat.spec.js
+++ b/web/e2e/chat.spec.js
@@ -17,6 +17,7 @@ import {
   sseEvents,
 } from './helpers/mockResponses.js';
 import { loadFixture } from './helpers/loadFixture.js';
+import { chatViewOverrides as sharedChatViewOverrides } from './helpers/chatScenario.js';
 
 // -- Shared helpers --
 
@@ -51,23 +52,7 @@ function threadOverrides() {
 
 /** Overrides for the chat view with a specific thread. */
 function chatViewOverrides() {
-  return {
-    ...threadOverrides(),
-    'GET /threads/b0000001-0000-4000-8000-000000000001': th1,
-    'GET /threads/b0000001-0000-4000-8000-000000000001/status': { can_reconnect: false, status: 'idle' },
-    'GET /threads/b0000001-0000-4000-8000-000000000001/turns': {
-      thread_id: 'b0000001-0000-4000-8000-000000000001',
-      turns: [
-        {
-          turn_index: 0,
-          edit_checkpoint_id: 'cp-edit-0',
-          regenerate_checkpoint_id: 'cp-regen-0',
-        },
-      ],
-      retry_checkpoint_id: 'cp-retry-0',
-    },
-    'GET /workspaces/a0000001-0000-4000-8000-000000000001/files': { files: [] },
-  };
+  return sharedChatViewOverrides({ workspaces: [ws1, ws2], threads: [th1, th2] });
 }
 
 /**

--- a/web/e2e/helpers/chatScenario.js
+++ b/web/e2e/helpers/chatScenario.js
@@ -1,0 +1,32 @@
+/**
+ * The one chat scenario every streaming spec mocks: workspace WS holding
+ * thread TH, with one completed turn behind it.
+ */
+import { sampleWorkspace, sampleThread } from './mockResponses.js';
+
+export const WS = 'a0000001-0000-4000-8000-000000000001';
+export const TH = 'b0000001-0000-4000-8000-000000000001';
+
+/**
+ * REST overrides for the chat view on TH. `workspaces` and `threads` default
+ * to one of each and their first entry answers the by-id routes; a function
+ * passed as `threadStatus` is used as a route handler, which is how a spec
+ * makes the thread reconnectable partway through.
+ */
+export function chatViewOverrides({ workspaces, threads, threadStatus } = {}) {
+  const ws = workspaces ?? [sampleWorkspace()];
+  const th = threads ?? [sampleThread()];
+  return {
+    'GET /workspaces': { workspaces: ws, total: ws.length, limit: 20, offset: 0 },
+    [`GET /workspaces/${WS}`]: ws[0],
+    'GET /threads': { threads: th, total: th.length },
+    [`GET /threads/${TH}`]: th[0],
+    [`GET /threads/${TH}/status`]: threadStatus ?? { can_reconnect: false, status: 'idle' },
+    [`GET /threads/${TH}/turns`]: {
+      thread_id: TH,
+      turns: [{ turn_index: 0, edit_checkpoint_id: 'cp-edit-0', regenerate_checkpoint_id: 'cp-regen-0' }],
+      retry_checkpoint_id: 'cp-retry-0',
+    },
+    [`GET /workspaces/${WS}/files`]: { files: [] },
+  };
+}

--- a/web/e2e/helpers/mockResponses.js
+++ b/web/e2e/helpers/mockResponses.js
@@ -297,6 +297,9 @@ export const sseEvents = {
     },
   }),
 
+  /** Backlog/live boundary on a reconnect stream. */
+  caughtUp: () => ({ event: 'caught_up', data: {} }),
+
   replayDone: (threadId = 'b0000001-0000-4000-8000-000000000001') => ({
     event: 'replay_done',
     data: { thread_id: threadId },

--- a/web/e2e/mock-sse-server.js
+++ b/web/e2e/mock-sse-server.js
@@ -122,8 +122,11 @@ const server = http.createServer(async (req, res) => {
     lines.push('', '');
     res.write(lines.join('\n'));
 
-    if (i < scenario.events.length - 1 && scenario.delay > 0) {
-      await new Promise((r) => setTimeout(r, scenario.delay));
+    // An event may carry its own `delayAfter` (ms) to shape timing around
+    // a single gap without slowing the whole stream.
+    const wait = ev.delayAfter ?? scenario.delay;
+    if (i < scenario.events.length - 1 && wait > 0) {
+      await new Promise((r) => setTimeout(r, wait));
     }
   }
   res.end();

--- a/web/e2e/perf/README.md
+++ b/web/e2e/perf/README.md
@@ -1,0 +1,53 @@
+# Perf benchmarks
+
+Three benchmarks that measure how streaming *feels*, none of which run in the
+default e2e suite: they are all gated behind `PERF=1`.
+
+| Spec | Question it answers |
+|---|---|
+| `streaming-smoothness.spec.js` | Does a long reply at token cadence keep the frame rate up under CPU throttling? |
+| `typewriter.spec.js` | Does the reveal read as steady typing, and does it finish with the model? |
+| `return-glitch.spec.js` | When presentation falls behind state and then catches up, does the transcript jump, lose text or fling the view? |
+
+## The two canonical invocations
+
+```bash
+# Smoothness, against the shipped bundle, three runs, then the comparison.
+PERF=1 PERF_BUILD=1 PERF_LABEL=<label> pnpm exec playwright test e2e/perf/streaming-smoothness.spec.js --repeat-each=3
+node scripts/perf-summary.mjs <baseline-label> <label>
+
+# The catch-up repro, one scenario at a time, read from the console.
+PERF=1 pnpm exec playwright test e2e/perf/return-glitch.spec.js
+```
+
+`perf-summary.mjs` reads `perf-results/`, prints the median per label side by
+side, and refuses to show a delta when two labels were measured under different
+flags. `--kind typewriter` summarizes the typewriter runs instead, one table per
+arrival pattern.
+
+## Flags
+
+| Flag | Applies to | Effect |
+|---|---|---|
+| `PERF=1` | all three | Required. Without it every benchmark skips. |
+| `PERF_BUILD=1` | web server | Serves a production build instead of the dev server, so the numbers are the shipped bundle's. Adds a few minutes for the build; ignored unless `PERF` is set. |
+| `PERF_LABEL=<name>` | smoothness, typewriter | Column the run is filed under. Defaults to the git short sha. |
+| `PERF_HEADED=1` | all three | Runs on the real display. Headless rAF caps near 110 fps with no vsync, and a headless tab never goes hidden, so the hidden-tab scenario only measures a real background tab here. |
+| `PERF_CPU=<n>` | smoothness | CPU throttling rate (default 4). |
+| `PERF_CHUNK_MS=<n>` / `PERF_CHUNK_CHARS=<n>` | smoothness | Token cadence: chars per SSE event and the gap between them (defaults 8 and 8). |
+| `PERF_PROFILE=1` | smoothness | Records a V8 CPU profile and prints self time per module and per function: what to fix next. |
+| `PERF_TRACE=1` | smoothness | Records a Chrome trace and sums renderer time per event kind (Layout, Paint, ...), which is where the profiler's `(program)` time goes. |
+| `PERF_CAST=1` | return-glitch (reload) | Records compositor frames over the catch-up and counts the magenta band painted at the top of the transcript: the ground truth for whether a frame was ever shown away from the bottom. The band shifts layout and the encoder takes main-thread time, so a `PERF_CAST` run's layout and frame numbers are not comparable with a plain run's. |
+| `PERF_SHOT=<path>` | return-glitch (reload) | Screenshots the reconnecting state after the reload. |
+| `PERF_SCROLL_LOG=1` | return-glitch | Records every programmatic scroll with its caller, for finding which code moved the view. |
+| `PERF_NO_CAUGHT_UP=1` | return-glitch | Omits the `caught_up` marker, as a server without it would: the client falls back to a timer and the typewriter's catch-up rule. |
+| `PERF_BACKLOG_MS=<n>` | return-glitch | Gap between backlog events on reconnect (default 2). `0` lets Node coalesce the whole backlog into one socket read and one React render, which is a different test. |
+
+## Layout
+
+- `streamFixture.js` - the deterministic ~14 KB reply and the SSE event list built from it.
+- `metrics.js` - the smoothness probe (frame gaps, LoAF, DOM churn).
+- `probe.js` - the transcript sampler (text length, scroll position, layout shifts) plus its report, shared by the typewriter and catch-up specs.
+- `rafFreeze.js` - parks rAF callbacks, standing in for a hidden tab where there is no display.
+- `screencast.js` - compositor-frame capture and the magenta pixel count.
+- `run.js` - where a run is filed and under what label.

--- a/web/e2e/perf/metrics.js
+++ b/web/e2e/perf/metrics.js
@@ -7,11 +7,11 @@
  *  - Long Animation Frames from PerformanceObserver (why a frame was late)
  *  - DOM mutation churn on the transcript (how much the renderer touches)
  */
-export const PROBE_SOURCE = `(() => {
+export function installSmoothProbe() {
   const S = (window.__smooth = {
     running: false, t0: 0, t1: 0,
     frameGaps: [], loaf: [], longTasks: [],
-    mutations: 0, nodesAdded: 0, nodesRemoved: 0, charDataChanges: 0,
+    mutations: 0, nodesAdded: 0, nodesRemoved: 0, charDataChanges: 0, attrChanges: 0,
   });
   let last = 0;
   function loop(ts) {
@@ -35,24 +35,27 @@ export const PROBE_SOURCE = `(() => {
         S.loaf.push({ start: e.startTime, dur: e.duration, block: e.blockingDuration, styleLayout: (e.styleAndLayoutStart ? e.startTime + e.duration - e.styleAndLayoutStart : 0), scripts });
       }
     }).observe({ type: 'long-animation-frame', buffered: false });
-  } catch {}
+  } catch { /* entry type unsupported in this browser */ }
   try {
     new PerformanceObserver((list) => {
       if (!S.running) return;
       for (const e of list.getEntries()) S.longTasks.push(e.duration);
     }).observe({ type: 'longtask', buffered: false });
-  } catch {}
+  } catch { /* entry type unsupported in this browser */ }
 
   let mo = null;
   S.start = (root) => {
     S.frameGaps = []; S.loaf = []; S.longTasks = [];
-    S.mutations = 0; S.nodesAdded = 0; S.nodesRemoved = 0; S.charDataChanges = 0;
+    S.mutations = 0; S.nodesAdded = 0; S.nodesRemoved = 0; S.charDataChanges = 0; S.attrChanges = 0;
     mo = new MutationObserver((records) => {
       S.mutations += records.length;
       for (const r of records) {
         S.nodesAdded += r.addedNodes.length;
         S.nodesRemoved += r.removedNodes.length;
         if (r.type === 'characterData') S.charDataChanges += 1;
+        // Counted apart from the node churn: an attribute write is a class or
+        // style flip, which costs style recalc but no reconciliation.
+        if (r.type === 'attributes') S.attrChanges += 1;
       }
     });
     mo.observe(root || document.body, { childList: true, subtree: true, characterData: true, attributes: true });
@@ -81,7 +84,8 @@ export const PROBE_SOURCE = `(() => {
       loafTop: S.loaf.slice().sort((a, b) => b.dur - a.dur).slice(0, 5).map((e) => ({ at: Math.round(e.start - S.t0), dur: Math.round(e.dur), styleLayout: Math.round(e.styleLayout), scripts: e.scripts })),
       longTasks: S.longTasks.length,
       longTaskMaxMs: Math.round(S.longTasks.reduce((m, d) => Math.max(m, d), 0)),
-      mutations: S.mutations, nodesAdded: S.nodesAdded, nodesRemoved: S.nodesRemoved, charDataChanges: S.charDataChanges,
+      mutations: S.mutations, nodesAdded: S.nodesAdded, nodesRemoved: S.nodesRemoved,
+      charDataChanges: S.charDataChanges, attrChanges: S.attrChanges,
     };
   };
-})();`;
+}

--- a/web/e2e/perf/metrics.js
+++ b/web/e2e/perf/metrics.js
@@ -78,7 +78,7 @@ export const PROBE_SOURCE = `(() => {
       loafTotalMs: Math.round(S.loaf.reduce((s, e) => s + e.dur, 0)),
       loafBlockingMs: Math.round(S.loaf.reduce((s, e) => s + e.block, 0)),
       loafMaxMs: Math.round(S.loaf.reduce((m, e) => Math.max(m, e.dur), 0)),
-      loafTop: S.loaf.slice().sort((a, b) => b.dur - a.dur).slice(0, 5).map((e) => ({ dur: Math.round(e.dur), scripts: e.scripts })),
+      loafTop: S.loaf.slice().sort((a, b) => b.dur - a.dur).slice(0, 5).map((e) => ({ at: Math.round(e.start - S.t0), dur: Math.round(e.dur), styleLayout: Math.round(e.styleLayout), scripts: e.scripts })),
       longTasks: S.longTasks.length,
       longTaskMaxMs: Math.round(S.longTasks.reduce((m, d) => Math.max(m, d), 0)),
       mutations: S.mutations, nodesAdded: S.nodesAdded, nodesRemoved: S.nodesRemoved, charDataChanges: S.charDataChanges,

--- a/web/e2e/perf/metrics.js
+++ b/web/e2e/perf/metrics.js
@@ -1,0 +1,87 @@
+/**
+ * In-page smoothness probe, injected before the app loads.
+ *
+ * Three independent signals, so a change that helps one cannot hide behind
+ * another:
+ *  - frame gaps from a requestAnimationFrame loop (what the eye sees)
+ *  - Long Animation Frames from PerformanceObserver (why a frame was late)
+ *  - DOM mutation churn on the transcript (how much the renderer touches)
+ */
+export const PROBE_SOURCE = `(() => {
+  const S = (window.__smooth = {
+    running: false, t0: 0, t1: 0,
+    frameGaps: [], loaf: [], longTasks: [],
+    mutations: 0, nodesAdded: 0, nodesRemoved: 0, charDataChanges: 0,
+  });
+  let last = 0;
+  function loop(ts) {
+    if (S.running) {
+      if (last) S.frameGaps.push(ts - last);
+      last = ts;
+    } else {
+      last = 0;
+    }
+    requestAnimationFrame(loop);
+  }
+  requestAnimationFrame(loop);
+
+  try {
+    new PerformanceObserver((list) => {
+      if (!S.running) return;
+      for (const e of list.getEntries()) {
+        const scripts = (e.scripts || []).map((s) => ({
+          src: s.sourceURL || s.invoker || '', fn: s.sourceFunctionName || '', dur: Math.round(s.duration),
+        })).sort((a, b) => b.dur - a.dur).slice(0, 3);
+        S.loaf.push({ start: e.startTime, dur: e.duration, block: e.blockingDuration, styleLayout: (e.styleAndLayoutStart ? e.startTime + e.duration - e.styleAndLayoutStart : 0), scripts });
+      }
+    }).observe({ type: 'long-animation-frame', buffered: false });
+  } catch {}
+  try {
+    new PerformanceObserver((list) => {
+      if (!S.running) return;
+      for (const e of list.getEntries()) S.longTasks.push(e.duration);
+    }).observe({ type: 'longtask', buffered: false });
+  } catch {}
+
+  let mo = null;
+  S.start = (root) => {
+    S.frameGaps = []; S.loaf = []; S.longTasks = [];
+    S.mutations = 0; S.nodesAdded = 0; S.nodesRemoved = 0; S.charDataChanges = 0;
+    mo = new MutationObserver((records) => {
+      S.mutations += records.length;
+      for (const r of records) {
+        S.nodesAdded += r.addedNodes.length;
+        S.nodesRemoved += r.removedNodes.length;
+        if (r.type === 'characterData') S.charDataChanges += 1;
+      }
+    });
+    mo.observe(root || document.body, { childList: true, subtree: true, characterData: true, attributes: true });
+    S.t0 = performance.now(); S.running = true;
+  };
+  S.stop = () => {
+    S.running = false; S.t1 = performance.now();
+    if (mo) mo.disconnect();
+    const gaps = S.frameGaps.slice().sort((a, b) => a - b);
+    const q = (p) => (gaps.length ? gaps[Math.min(gaps.length - 1, Math.floor(p * gaps.length))] : 0);
+    const durationMs = S.t1 - S.t0;
+    const over = (ms) => S.frameGaps.filter((g) => g > ms).length;
+    return {
+      durationMs: Math.round(durationMs),
+      frames: gaps.length,
+      fps: +(gaps.length / (durationMs / 1000)).toFixed(1),
+      gapP50: +q(0.5).toFixed(1), gapP95: +q(0.95).toFixed(1), gapP99: +q(0.99).toFixed(1),
+      gapMax: +(gaps[gaps.length - 1] || 0).toFixed(1),
+      framesOver33: over(33), framesOver50: over(50), framesOver100: over(100),
+      // Time the user spent looking at a frozen frame: sum of gap beyond 16.7ms.
+      frozenMs: Math.round(S.frameGaps.reduce((s, g) => s + Math.max(0, g - 16.7), 0)),
+      loafCount: S.loaf.length,
+      loafTotalMs: Math.round(S.loaf.reduce((s, e) => s + e.dur, 0)),
+      loafBlockingMs: Math.round(S.loaf.reduce((s, e) => s + e.block, 0)),
+      loafMaxMs: Math.round(S.loaf.reduce((m, e) => Math.max(m, e.dur), 0)),
+      loafTop: S.loaf.slice().sort((a, b) => b.dur - a.dur).slice(0, 5).map((e) => ({ dur: Math.round(e.dur), scripts: e.scripts })),
+      longTasks: S.longTasks.length,
+      longTaskMaxMs: Math.round(S.longTasks.reduce((m, d) => Math.max(m, d), 0)),
+      mutations: S.mutations, nodesAdded: S.nodesAdded, nodesRemoved: S.nodesRemoved, charDataChanges: S.charDataChanges,
+    };
+  };
+})();`;

--- a/web/e2e/perf/probe.js
+++ b/web/e2e/perf/probe.js
@@ -1,0 +1,191 @@
+/**
+ * In-page transcript sampler, injected before the app loads.
+ *
+ * Per frame it records the transcript's text length and the scroller's
+ * position, which is enough to name what the eye would have caught: a "burst
+ * frame" gains far more text than the cadence or the typewriter can produce, a
+ * "drop frame" loses text (content replaced, or duplicated and collapsed), a
+ * "scroll jump" moves more than 300 px at once.
+ *
+ * Options, all off by default because each costs per-frame work the benchmark
+ * would otherwise be measuring:
+ *  - `live`: whether the composer still shows the stop control, which stamps
+ *    when the model finished without asking the client.
+ *  - `painted`: a second read from a task queued off the frame, so a layout or
+ *    resize-observer scroll that lands after the commit is included.
+ *  - `scrollLog`: every programmatic scroll with its caller.
+ *  - `reply`: the text length of the message bubbles alone, so a drop can be
+ *    told apart from page chrome (a route unmounting, a status label) that
+ *    shares the transcript's container.
+ */
+export function installProbe(options) {
+  const opts = options || {};
+  const P = (window.__probe = {
+    painted: [], samples: [], shifts: [], marks: {}, scrolls: [],
+    // An epoch time base, not a performance.now() mark: the screencast frames
+    // it is compared against are timestamped on the same clock.
+    catchUpWall: 0,
+  });
+  const nativeRaf = (window.__raf && window.__raf.native) || window.requestAnimationFrame.bind(window);
+  const ids = new WeakMap(); let nid = 0;
+  const idOf = (el) => { if (!ids.has(el)) ids.set(el, ++nid); return ids.get(el); };
+  P.idOf = idOf;
+
+  if (opts.scrollLog) try {
+    const caller = () => String(new Error().stack).split('\n').slice(2, 12).map((l) => l.trim().slice(-48));
+    const d = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollTop');
+    Object.defineProperty(Element.prototype, 'scrollTop', {
+      get: d.get,
+      set(v) { P.scrolls.push({ t: performance.now(), el: idOf(this), top: v, via: 'set', st: caller() }); d.set.call(this, v); },
+      configurable: true,
+    });
+    const orig = Element.prototype.scrollTo;
+    Element.prototype.scrollTo = function (...a) {
+      const o = a[0];
+      P.scrolls.push({ t: performance.now(), el: idOf(this), top: o && typeof o === 'object' ? o.top : a[1], beh: o && typeof o === 'object' ? o.behavior : 'auto', via: 'scrollTo', st: caller() });
+      return orig.apply(this, a);
+    };
+  } catch { /* entry type unsupported in this browser */ }
+
+  let scroller = null;
+  function findScroller() {
+    if (scroller && scroller.isConnected) return scroller;
+    const main = document.querySelector('main') || document.body;
+    for (const el of main.querySelectorAll('*')) {
+      const oy = getComputedStyle(el).overflowY;
+      if ((oy === 'auto' || oy === 'scroll') && el.scrollHeight > el.clientHeight + 50) { scroller = el; return el; }
+    }
+    return null;
+  }
+
+  /** Elements holding an implausible amount of text, to name a block that appeared or vanished. */
+  function bigTextNodes() {
+    const main = document.querySelector('main') || document.body;
+    const big = [];
+    for (const el of main.querySelectorAll('*')) {
+      if (el.children.length === 0 && el.textContent.length > 5000) {
+        big.push(el.tagName + '.' + String(el.className).slice(0, 60) + ':' + el.textContent.length + ':' + el.textContent.slice(0, 80));
+      }
+    }
+    return big.slice(0, 5).join(' | ');
+  }
+
+  function sample(ts) {
+    const main = document.querySelector('main') || document.body;
+    const s = findScroller();
+    const len = main.textContent.length;
+    const prev = P.samples[P.samples.length - 1];
+    if (prev && len < 50000 && prev.len < 50000 && len - prev.len > 1000 && !P.catchUpWall) P.catchUpWall = Date.now();
+    const rec = { t: ts, len, top: s ? s.scrollTop : -1, h: s ? s.scrollHeight - s.clientHeight : -1 };
+    if (opts.live) rec.live = !!document.querySelector('button[aria-label="Stop"]');
+    if (opts.reply) { let n = 0; for (const b of document.querySelectorAll('[data-message-id]')) n += b.textContent.length; rec.reply = n; }
+    const jumped = !!prev && Math.abs(len - prev.len) > 5000;
+    P.samples.push(rec);
+    if (opts.painted || jumped) {
+      // A task queued from rAF runs after this frame is painted, and a layout or
+      // resize-observer scroll lands between the two, so this is what the screen
+      // showed. The whole-DOM scan for a jump rides the same task: in the frame
+      // callback it would be work the frame gaps then blame on the app.
+      setTimeout(() => {
+        if (jumped) rec.note = bigTextNodes();
+        if (!opts.painted) return;
+        const sc = findScroller();
+        const m = document.querySelector('main') || document.body;
+        P.painted.push({ t: performance.now(), len: m.textContent.length, el: sc ? idOf(sc) : 0, cr: sc ? idOf(sc.querySelector('.max-w-3xl') || sc.firstElementChild || sc) : 0, top: sc ? sc.scrollTop : -1, h: sc ? sc.scrollHeight - sc.clientHeight : -1 });
+      }, 0);
+    }
+    nativeRaf(sample);
+  }
+  nativeRaf(sample);
+
+  try {
+    new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) if (!e.hadRecentInput) P.shifts.push({ t: e.startTime, v: e.value, src: (e.sources || []).slice(0, 4).map((s) => {
+        const n = s.node; const tag = n ? (n.tagName || '').toLowerCase() + (n.className && typeof n.className === 'string' ? '.' + n.className.split(' ').slice(0, 3).join('.') : '') : '?';
+        const r = (q) => q ? [Math.round(q.x), Math.round(q.y), Math.round(q.width), Math.round(q.height)].join(',') : '-';
+        return tag.slice(0, 60) + ' ' + r(s.previousRect) + ' -> ' + r(s.currentRect);
+      }) });
+    }).observe({ type: 'layout-shift', buffered: true });
+  } catch { /* entry type unsupported in this browser */ }
+
+  P.mark = (name) => { P.marks[name] = performance.now(); };
+  /** Frames since a mark, as the tuples the typewriter analysis reads. */
+  P.framesSince = (since) => {
+    const t0 = P.marks[since] ?? 0;
+    return P.samples.filter((x) => x.t >= t0).map((x) => [x.t, x.len, x.live ? 1 : 0, x.top, x.h, x.reply === undefined ? -1 : x.reply]);
+  };
+  // Poll the transcript's visible text and keep the snapshot around the
+  // largest drop, so a vanished block can be named rather than sized.
+  P.watchDrops = (ms) => {
+    const main = document.querySelector('main') || document.body;
+    let prev = main.innerText; let worst = 0; P.drop = null;
+    const iv = setInterval(() => {
+      const cur = main.innerText;
+      if (prev.length - cur.length > worst) {
+        worst = prev.length - cur.length;
+        const before = new Set(cur.split('\n'));
+        P.drop = { t: Math.round(performance.now()), size: worst, removed: prev.split('\n').filter((l) => l.trim() && !before.has(l)).slice(0, 12) };
+      }
+      prev = cur;
+    }, 100);
+    setTimeout(() => clearInterval(iv), ms);
+  };
+  P.report = (since) => {
+    const t0 = P.marks[since] ?? 0;
+    const xs = P.samples.filter((x) => x.t >= t0);
+    let bursts = 0, burstChars = 0, maxGain = 0, drops = 0, maxDrop = 0, replyDrops = 0, maxReplyDrop = 0, jumps = 0, maxJump = 0, lastBurstAt = t0, awayFromBottomFrames = 0;
+    for (let i = 1; i < xs.length; i++) {
+      const d = xs[i].len - xs[i - 1].len;
+      if (d > 20) { bursts++; burstChars += d; lastBurstAt = xs[i].t; }
+      if (d > maxGain) maxGain = d;
+      if (d < 0) { drops++; if (-d > maxDrop) maxDrop = -d; }
+      const rd = xs[i].reply === undefined ? 0 : xs[i].reply - xs[i - 1].reply;
+      if (rd < 0) { replyDrops++; if (-rd > maxReplyDrop) maxReplyDrop = -rd; }
+      const j = Math.abs(xs[i].top - xs[i - 1].top);
+      if (xs[i].top >= 0 && j > 300) { jumps++; if (j > maxJump) maxJump = j; }
+      if (xs[i].h > 0 && xs[i].h - xs[i].top > 400) awayFromBottomFrames++;
+    }
+    const cls = P.shifts.filter((s) => s.t >= t0).reduce((a, s) => a + s.v, 0);
+    const first = xs[0];
+    const gapAtResume = first && first.h > 0 ? Math.round(first.h - first.top) : -1;
+    let settleAt = -1, scrollFrames = 0;
+    for (let i = 1; i < xs.length; i++) {
+      if (xs[i].top !== xs[i - 1].top) scrollFrames++;
+      if (settleAt < 0 && xs[i].h > 0 && xs[i].h - xs[i].top < 50) settleAt = xs[i].t;
+    }
+    // Text growth per 500 ms bucket for the first 12 s: the cadence delivers
+    // ~100 chars per bucket, so a bucket far above that is catch-up.
+    const series = [];
+    for (let b = 0; b < 24; b++) {
+      const a = xs.filter((x) => x.t >= t0 + b * 500 && x.t < t0 + (b + 1) * 500);
+      series.push(a.length ? a[a.length - 1].len - a[0].len : 0);
+    }
+    const notable = [];
+    for (let i = 1; i < xs.length; i++) {
+      const d = xs[i].len - xs[i - 1].len; const j = xs[i].top - xs[i - 1].top;
+      if (Math.abs(d) > 60 || Math.abs(j) > 300 || xs[i].note) notable.push({ t: Math.round(xs[i].t - t0), d, top: xs[i].top, j: Math.round(j), note: xs[i].note });
+    }
+    const bigShifts = P.shifts.filter((s) => s.t >= t0 && s.v > 0.02).map((s) => ({ t: Math.round(s.t - t0), v: +s.v.toFixed(3), src: s.src }));
+    // Painted frames, after the transcript first appears, that showed the
+    // scroller more than 400 px short of the bottom: what the eye saw at the top.
+    const ps = P.painted.filter((x) => x.t >= t0);
+    const firstShown = ps.findIndex((x, i) => i > 0 && x.len - ps[i - 1].len > 500);
+    // A hint, not ground truth: the post-paint sample runs in a task, and a
+    // commit that lands between the paint and that task is read here as if it
+    // had been painted at scrollTop 0. PERF_CAST=1 records compositor frames
+    // and is what decides whether a frame was really shown away from the bottom.
+    const paintedAwayFrames = firstShown < 0 ? -1 : ps.slice(firstShown).filter((x) => x.h > 0 && x.h - x.top > 400).length;
+    return {
+      scrolls: P.scrolls.filter((x) => x.t >= t0).map((x) => ({ ...x, t: Math.round(x.t - t0) })).slice(0, 16), paintedPrev: (() => { const i = ps.findIndex((x) => x.h > 0 && x.h - x.top > 400); return i > 0 ? ps.slice(Math.max(0, i - 3), i + 2).map((x) => [Math.round(x.t - t0), x.len, x.el, x.cr, x.top, x.h]) : []; })(),
+      paintedAway: firstShown < 0 ? [] : ps.slice(firstShown).filter((x) => x.h > 0 && x.h - x.top > 400).slice(0, 5).map((x) => [Math.round(x.t - t0), x.len, x.el, x.cr, x.top, x.h]),
+      paintedAwayFrames, paintedFirstTop: firstShown < 0 ? -1 : ps[firstShown].top, paintedFirstGap: firstShown < 0 ? -1 : ps[firstShown].h - ps[firstShown].top,
+      frames: xs.length, burstFrames: bursts, burstChars, maxGainPerFrame: maxGain,
+      catchUpMs: Math.round(lastBurstAt - t0), dropFrames: drops, maxDrop, replyDropFrames: replyDrops, maxReplyDrop,
+      scrollJumps: jumps, maxScrollJumpPx: Math.round(maxJump), awayFromBottomFrames,
+      cls: +cls.toFixed(3), shifts: P.shifts.filter((s) => s.t >= t0).length,
+      textLen: xs.length ? xs[xs.length - 1].len : 0,
+      growthPer500ms: series, gapAtResumePx: gapAtResume, scrollSettleMs: settleAt < 0 ? -1 : Math.round(settleAt - t0), scrollFrames,
+      notable: notable.slice(0, 40), bigShifts: bigShifts.slice(0, 20),
+    };
+  };
+}

--- a/web/e2e/perf/rafFreeze.js
+++ b/web/e2e/perf/rafFreeze.js
@@ -1,0 +1,30 @@
+/**
+ * Stand-in for a hidden tab: park every rAF callback until thawed, then run
+ * the whole queue on one frame. A headless tab never goes hidden, so this is
+ * the only way to reproduce "state kept arriving while nothing painted"
+ * without a real display.
+ *
+ * Install it before any other init script that wants to keep ticking through
+ * the freeze: `window.__raf.native` is the unpatched requestAnimationFrame.
+ */
+export function installRafFreeze() {
+  const nativeRaf = window.requestAnimationFrame.bind(window);
+  const nativeCaf = window.cancelAnimationFrame.bind(window);
+  const R = (window.__raf = { frozen: false, queue: [], nextId: -1, native: nativeRaf });
+  window.requestAnimationFrame = (cb) => {
+    if (!R.frozen) return nativeRaf(cb);
+    const id = R.nextId--;
+    R.queue.push({ id, cb });
+    return id;
+  };
+  window.cancelAnimationFrame = (id) => {
+    if (id < 0) { R.queue = R.queue.filter((q) => q.id !== id); return; }
+    nativeCaf(id);
+  };
+  R.freeze = () => { R.frozen = true; };
+  R.thaw = () => {
+    R.frozen = false;
+    const q = R.queue; R.queue = [];
+    nativeRaf((ts) => { for (const { cb } of q) { try { cb(ts); } catch (e) { console.error(e); } } });
+  };
+}

--- a/web/e2e/perf/return-glitch.spec.js
+++ b/web/e2e/perf/return-glitch.spec.js
@@ -1,227 +1,57 @@
 /**
- * Catch-up glitch repro: what the transcript does when presentation falls
- * behind state and then catches up in a burst. Not part of the default run.
- *
- *   PERF=1 pnpm exec playwright test e2e/perf/return-glitch
- *
- * Two ways to fall behind:
- *  - reload mid-stream: the in-flight run is not in the history replay, so
- *    the reconnect stream re-delivers the whole run's buffer in one burst into
- *    a fresh bubble.
- *  - hidden tab: rAF stops (typewriter, framer, scroll follow) while SSE keeps
- *    landing in state; emulated here by parking every rAF callback for a while.
- *
- * Per frame the probe samples transcript text length and scrollTop, and
- * collects layout-shift entries. A "burst frame" gains far more text than the
- * cadence or the typewriter can produce; a "drop frame" loses text (content
- * replaced or duplicated and collapsed); a "scroll jump" moves more than
- * 300 px in one frame.
- *
- * PERF_CAST=1 (reload) records compositor frames around the catch-up and
- * counts, per frame, the pixels of a marker painted at the top of the
- * transcript: the ground truth for whether a frame was ever shown away from
- * the bottom. PERF_SCROLL_LOG=1 records every programmatic scroll with its
- * caller; PERF_SHOT=<path> screenshots the reconnecting state after reload.
+ * Catch-up glitch: what the transcript does when presentation falls behind
+ * state and then catches up in a burst. Four ways to fall behind - reload
+ * mid-stream, navigate to another thread and back, leave the chat route
+ * entirely and come back, and stop painting while SSE keeps landing.
+ * Off by default; flags and invocations are in e2e/perf/README.md.
  */
 import { configureSSE, resetMockServer, mockAPI, test, expect } from '../fixtures.js';
 import { sampleWorkspace, sampleThread, sseEvents } from '../helpers/mockResponses.js';
-import { buildReply, buildReasoning, chunk, END_MARKER } from './streamFixture.js';
+import { TH, chatViewOverrides } from '../helpers/chatScenario.js';
+import { buildEvents, END_MARKER } from './streamFixture.js';
+import { installRafFreeze } from './rafFreeze.js';
+import { installProbe } from './probe.js';
+import { recordUntil, countMagenta, MAGENTA_MARKER_CSS } from './screencast.js';
 
-const WS = 'a0000001-0000-4000-8000-000000000001';
-const TH = 'b0000001-0000-4000-8000-000000000001';
+const TH2 = 'b0000002-0000-4000-8000-000000000002';
 const CHUNK_MS = 40;
 const CHUNK_CHARS = 8;
 const PROMPT = 'Give me an earnings deep dive on NVDA';
 
-const PROBE = `(() => {
-  const nativeRaf = window.requestAnimationFrame.bind(window);
-  const nativeCaf = window.cancelAnimationFrame.bind(window);
-  const R = (window.__raf = { frozen: false, queue: [], nextId: -1 });
-  window.requestAnimationFrame = (cb) => {
-    if (!R.frozen) return nativeRaf(cb);
-    const id = R.nextId--;
-    R.queue.push({ id, cb });
-    return id;
-  };
-  window.cancelAnimationFrame = (id) => {
-    if (id < 0) { R.queue = R.queue.filter((q) => q.id !== id); return; }
-    nativeCaf(id);
-  };
-  R.freeze = () => { R.frozen = true; };
-  R.thaw = () => {
-    R.frozen = false;
-    const q = R.queue; R.queue = [];
-    nativeRaf((ts) => { for (const { cb } of q) { try { cb(ts); } catch (e) { console.error(e); } } });
-  };
+// What catching up must never do, whichever way the client fell behind.
+// The reply-text series is scoped to the message bubbles, because the page
+// around them legitimately loses text: a route unmounting on the way back, a
+// status label clearing. Within a bubble, streamed markdown still gives up a
+// few characters whenever a syntax run is consumed (a fence line, the stars
+// around a bold), so the bound is a lost block, not zero: the smallest block
+// in the fixture is several hundred characters and a duplicated-and-collapsed
+// bubble is thousands. The scroll bound is generous because the follow scroll
+// is allowed to travel - the fixture's transcript is ~14 KB and the whole
+// reply can land in one commit - but a fling that shows the top of the
+// transcript moves several thousand px, well clear of this.
+const MAX_REPLY_DROP_CHARS = 100;
+const MAX_SCROLL_JUMP_PX = 2000;
 
-  const P = (window.__probe = { painted: [], samples: [], shifts: [], marks: {}, scrolls: [] });
-  const ids = new WeakMap(); let nid = 0; const idOf = (el) => { if (!ids.has(el)) ids.set(el, ++nid); return ids.get(el); }; P.idOf = idOf;
-  // PERF_SCROLL_LOG=1: record every programmatic scroll with its caller.
-  if (${process.env.PERF_SCROLL_LOG ? 'true' : 'false'}) try {
-    const d = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollTop');
-    Object.defineProperty(Element.prototype, 'scrollTop', { get: d.get, set(v) { P.scrolls.push({ t: performance.now(), el: idOf(this), top: v, via: 'set', st: String(new Error().stack).split('\\n').slice(2, 12).map((l) => l.trim().slice(-48)) }); return d.set.call(this, v); }, configurable: true });
-    const orig = Element.prototype.scrollTo;
-    Element.prototype.scrollTo = function (...a) { const o = a[0]; P.scrolls.push({ t: performance.now(), el: idOf(this), top: o && typeof o === 'object' ? o.top : a[1], beh: o && typeof o === 'object' ? o.behavior : 'auto', via: 'scrollTo', st: String(new Error().stack).split('\\n').slice(2, 12).map((l) => l.trim().slice(-48)) }); return orig.apply(this, a); };
-  } catch {}
-  let scroller = null;
-  function findScroller() {
-    if (scroller && scroller.isConnected) return scroller;
-    const main = document.querySelector('main') || document.body;
-    for (const el of main.querySelectorAll('*')) {
-      const oy = getComputedStyle(el).overflowY;
-      if ((oy === 'auto' || oy === 'scroll') && el.scrollHeight > el.clientHeight + 50) { scroller = el; return el; }
-    }
-    return null;
-  }
-  function sample(ts) {
-    const main = document.querySelector('main') || document.body;
-    const s = findScroller();
-    const len = main.textContent.length;
-    const prev = P.samples[P.samples.length - 1];
-    if (prev && len < 50000 && prev.len < 50000 && len - prev.len > 1000 && !P.marks.catchUpWall) P.marks.catchUpWall = Date.now();
-    let note;
-    if (prev && Math.abs(len - prev.len) > 5000) {
-      const big = [];
-      for (const el of main.querySelectorAll('*')) {
-        if (el.children.length === 0 && el.textContent.length > 5000) big.push(el.tagName + '.' + String(el.className).slice(0, 60) + ':' + el.textContent.length + ':' + el.textContent.slice(0, 80));
-      }
-      note = big.slice(0, 5).join(' | ');
-    }
-    P.samples.push({ t: ts, len, top: s ? s.scrollTop : -1, h: s ? s.scrollHeight - s.clientHeight : -1, note });
-    // A task queued from rAF runs after this frame is painted, and a layout or
-    // resize-observer scroll lands between the two, so this is what the screen showed.
-    setTimeout(() => {
-      const sc = findScroller();
-      const m = document.querySelector('main') || document.body;
-      P.painted.push({ t: performance.now(), len: m.textContent.length, el: sc ? idOf(sc) : 0, cr: sc ? idOf(sc.querySelector('.max-w-3xl') || sc.firstElementChild || sc) : 0, top: sc ? sc.scrollTop : -1, h: sc ? sc.scrollHeight - sc.clientHeight : -1 });
-    }, 0);
-    nativeRaf(sample);
-  }
-  nativeRaf(sample);
-  try {
-    new PerformanceObserver((list) => {
-      for (const e of list.getEntries()) if (!e.hadRecentInput) P.shifts.push({ t: e.startTime, v: e.value, src: (e.sources || []).slice(0, 4).map((s) => {
-        const n = s.node; const tag = n ? (n.tagName || '').toLowerCase() + (n.className && typeof n.className === 'string' ? '.' + n.className.split(' ').slice(0, 3).join('.') : '') : '?';
-        const r = (q) => q ? [Math.round(q.x), Math.round(q.y), Math.round(q.width), Math.round(q.height)].join(',') : '-';
-        return tag.slice(0, 60) + ' ' + r(s.previousRect) + ' -> ' + r(s.currentRect);
-      }) });
-    }).observe({ type: 'layout-shift', buffered: true });
-  } catch {}
-  P.mark = (name) => { P.marks[name] = performance.now(); };
-  // Poll the transcript's visible text and keep the snapshot around the
-  // largest drop, so a vanished block can be named rather than sized.
-  P.watchDrops = (ms) => {
-    const main = document.querySelector('main') || document.body;
-    let prev = main.innerText; let worst = 0; P.drop = null;
-    const iv = setInterval(() => {
-      const cur = main.innerText;
-      if (prev.length - cur.length > worst) {
-        worst = prev.length - cur.length;
-        const before = new Set(cur.split(String.fromCharCode(10)));
-        P.drop = { t: Math.round(performance.now()), size: worst, removed: prev.split(String.fromCharCode(10)).filter((l) => l.trim() && !before.has(l)).slice(0, 12) };
-      }
-      prev = cur;
-    }, 100);
-    setTimeout(() => clearInterval(iv), ms);
-  };
-  P.report = (since) => {
-    const t0 = P.marks[since] ?? 0;
-    const xs = P.samples.filter((x) => x.t >= t0);
-    let bursts = 0, burstChars = 0, maxGain = 0, drops = 0, maxDrop = 0, jumps = 0, maxJump = 0, lastBurstAt = t0, awayFromBottomFrames = 0;
-    for (let i = 1; i < xs.length; i++) {
-      const d = xs[i].len - xs[i - 1].len;
-      if (d > 20) { bursts++; burstChars += d; lastBurstAt = xs[i].t; }
-      if (d > maxGain) maxGain = d;
-      if (d < 0) { drops++; if (-d > maxDrop) maxDrop = -d; }
-      const j = Math.abs(xs[i].top - xs[i - 1].top);
-      if (xs[i].top >= 0 && j > 300) { jumps++; if (j > maxJump) maxJump = j; }
-      if (xs[i].h > 0 && xs[i].h - xs[i].top > 400) awayFromBottomFrames++;
-    }
-    const cls = P.shifts.filter((s) => s.t >= t0).reduce((a, s) => a + s.v, 0);
-    const first = xs[0];
-    const gapAtResume = first && first.h > 0 ? Math.round(first.h - first.top) : -1;
-    let settleAt = -1, scrollFrames = 0;
-    for (let i = 1; i < xs.length; i++) {
-      if (xs[i].top !== xs[i - 1].top) scrollFrames++;
-      if (settleAt < 0 && xs[i].h > 0 && xs[i].h - xs[i].top < 50) settleAt = xs[i].t;
-    }
-    // Text growth per 500 ms bucket for the first 12 s: the cadence delivers
-    // ~100 chars per bucket, so a bucket far above that is catch-up.
-    const series = [];
-    for (let b = 0; b < 24; b++) {
-      const a = xs.filter((x) => x.t >= t0 + b * 500 && x.t < t0 + (b + 1) * 500);
-      series.push(a.length ? a[a.length - 1].len - a[0].len : 0);
-    }
-    const notable = [];
-    for (let i = 1; i < xs.length; i++) {
-      const d = xs[i].len - xs[i - 1].len; const j = xs[i].top - xs[i - 1].top;
-      if (Math.abs(d) > 60 || Math.abs(j) > 300 || xs[i].note) notable.push({ t: Math.round(xs[i].t - t0), d, top: xs[i].top, j: Math.round(j), note: xs[i].note });
-    }
-    const bigShifts = P.shifts.filter((s) => s.t >= t0 && s.v > 0.02).map((s) => ({ t: Math.round(s.t - t0), v: +s.v.toFixed(3), src: s.src }));
-    // Painted frames, after the transcript first appears, that showed the
-    // scroller more than 400 px short of the bottom: what the eye saw at the top.
-    const ps = P.painted.filter((x) => x.t >= t0);
-    const firstShown = ps.findIndex((x, i) => i > 0 && x.len - ps[i - 1].len > 500);
-    // A hint, not ground truth: the post-paint sample runs in a task, and a
-    // commit that lands between the paint and that task is read here as if it
-    // had been painted at scrollTop 0. PERF_CAST=1 records compositor frames
-    // and is what decides whether a frame was really shown away from the bottom.
-    const paintedAwayFrames = firstShown < 0 ? -1 : ps.slice(firstShown).filter((x) => x.h > 0 && x.h - x.top > 400).length;
-    return {
-      scrolls: P.scrolls.filter((x) => x.t >= t0).map((x) => ({ ...x, t: Math.round(x.t - t0) })).slice(0, 16), paintedPrev: (() => { const i = ps.findIndex((x) => x.h > 0 && x.h - x.top > 400); return i > 0 ? ps.slice(Math.max(0, i - 3), i + 2).map((x) => [Math.round(x.t - t0), x.len, x.el, x.cr, x.top, x.h]) : []; })(),
-      paintedAway: firstShown < 0 ? [] : ps.slice(firstShown).filter((x) => x.h > 0 && x.h - x.top > 400).slice(0, 5).map((x) => [Math.round(x.t - t0), x.len, x.el, x.cr, x.top, x.h]),
-      paintedAwayFrames, paintedFirstTop: firstShown < 0 ? -1 : ps[firstShown].top, paintedFirstGap: firstShown < 0 ? -1 : ps[firstShown].h - ps[firstShown].top,
-      frames: xs.length, burstFrames: bursts, burstChars, maxGainPerFrame: maxGain,
-      catchUpMs: Math.round(lastBurstAt - t0), dropFrames: drops, maxDrop,
-      scrollJumps: jumps, maxScrollJumpPx: Math.round(maxJump), awayFromBottomFrames,
-      cls: +cls.toFixed(3), shifts: P.shifts.filter((s) => s.t >= t0).length,
-      textLen: xs.length ? xs[xs.length - 1].len : 0,
-      growthPer500ms: series, gapAtResumePx: gapAtResume, scrollSettleMs: settleAt < 0 ? -1 : Math.round(settleAt - t0), scrollFrames,
-      notable: notable.slice(0, 40), bigShifts: bigShifts.slice(0, 20),
-    };
-  };
-})();`;
-
-const TH2 = 'b0000002-0000-4000-8000-000000000002';
+function assertCaughtUpCleanly(r) {
+  expect(r.maxReplyDrop, 'catching up must not remove reply text that was on screen').toBeLessThan(MAX_REPLY_DROP_CHARS);
+  expect(r.maxScrollJumpPx, 'catching up must not fling the view').toBeLessThan(MAX_SCROLL_JUMP_PX);
+}
 
 function overrides(state) {
-  const ws = sampleWorkspace();
-  const th = sampleThread();
   const th2 = { ...sampleThread(), id: TH2, thread_id: TH2, title: 'Other thread' };
   return {
+    ...chatViewOverrides({
+      workspaces: [sampleWorkspace()],
+      threads: [sampleThread(), th2],
+      threadStatus: (route) => route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify(state.reconnectable ? { can_reconnect: true, status: 'streaming', run_id: 'run-1' } : { can_reconnect: false, status: 'idle' }),
+      }),
+    }),
     [`GET /threads/${TH2}`]: th2,
     [`GET /threads/${TH2}/status`]: { can_reconnect: false, status: 'idle' },
     [`GET /threads/${TH2}/turns`]: { thread_id: TH2, turns: [], retry_checkpoint_id: null },
-    'GET /workspaces': { workspaces: [ws], total: 1, limit: 20, offset: 0 },
-    [`GET /workspaces/${WS}`]: ws,
-    'GET /threads': { threads: [th, th2], total: 2 },
-    [`GET /threads/${TH}`]: th,
-    [`GET /threads/${TH}/status`]: (route) => route.fulfill({
-      status: 200, contentType: 'application/json',
-      body: JSON.stringify(state.reconnectable ? { can_reconnect: true, status: 'streaming', run_id: 'run-1' } : { can_reconnect: false, status: 'idle' }),
-    }),
-    [`GET /threads/${TH}/turns`]: {
-      thread_id: TH,
-      turns: [{ turn_index: 0, edit_checkpoint_id: 'cp-edit-0', regenerate_checkpoint_id: 'cp-regen-0' }],
-      retry_checkpoint_id: 'cp-retry-0',
-    },
-    [`GET /workspaces/${WS}/files`]: { files: [] },
   };
-}
-
-function buildEvents() {
-  const events = [];
-  events.push(sseEvents.messageChunk('start', 'reasoning_signal'));
-  for (const c of chunk(buildReasoning(), CHUNK_CHARS)) events.push(sseEvents.messageChunk(c, 'reasoning'));
-  events.push(sseEvents.messageChunk('complete', 'reasoning_signal'));
-  const calls = ['toolu_p1', 'toolu_p2', 'toolu_p3', 'toolu_p4'];
-  events.push(sseEvents.toolCalls(calls.map((id, i) => ({ name: 'bash', args: { command: `echo ${i}` }, id }))));
-  events.push(sseEvents.finishToolCalls());
-  for (const id of calls) events.push({ ...sseEvents.toolCallResult(id, 'ok'), delayAfter: 150 });
-  for (const c of chunk(buildReply(), CHUNK_CHARS)) events.push(sseEvents.messageChunk(c));
-  events.push(sseEvents.finishStop());
-  events.push(sseEvents.creditUsage());
-  return events;
 }
 
 /** Index of the first event whose text carries `marker`. */
@@ -237,8 +67,27 @@ function indexOfMarker(events, marker) {
   return -1;
 }
 
+/**
+ * Serve the run's first `k` events as a reconnect backlog, the rest live.
+ * 2 ms apart so each event is its own socket read, as through a proxy; 0 lets
+ * Node coalesce the whole backlog into one read and one React render.
+ */
+async function serveAsReconnect(state, events, k) {
+  const backlog = events.slice(0, k).map((e) => ({ ...e, delayAfter: Number(process.env.PERF_BACKLOG_MS ?? 2) }));
+  state.reconnectable = true;
+  await configureSSE({
+    method: 'GET', path: `/api/v1/threads/${TH}/messages/replay`,
+    events: [sseEvents.userMessage(PROMPT), sseEvents.replayDone()], delay: 10,
+  });
+  // PERF_NO_CAUGHT_UP=1 omits the marker (a server without it): the client
+  // falls back to a timer and the typewriter's catch-up rule.
+  const boundary = process.env.PERF_NO_CAUGHT_UP ? [] : [{ ...sseEvents.caughtUp(), delayAfter: 0 }];
+  await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH}/messages/stream`, events: [...backlog, ...boundary, ...events.slice(k)], delay: CHUNK_MS });
+}
+
 async function startStream(page, state, events) {
-  await page.addInitScript(PROBE);
+  await page.addInitScript(installRafFreeze);
+  await page.addInitScript(installProbe, { painted: true, reply: true, scrollLog: !!process.env.PERF_SCROLL_LOG });
   await mockAPI(page, overrides(state));
   await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH}/messages/replay`, events: [sseEvents.replayDone()], delay: 10 });
   await configureSSE({ method: 'POST', path: `/api/v1/threads/${TH}/messages`, events, delay: CHUNK_MS });
@@ -248,6 +97,33 @@ async function startStream(page, state, events) {
   await page.locator('button[aria-label="Send message"]').click();
 }
 
+/**
+ * PERF_CAST=1: record compositor frames over the catch-up and count, per
+ * frame, the magenta band painted at the top of the transcript. This is the
+ * ground truth behind the probe's "painted away" frame, but the band shifts
+ * layout and the encoder takes main-thread time, so a PERF_CAST run's layout
+ * and frame numbers are not comparable with a plain run's.
+ */
+async function reportCastFrames(page, doneVisible) {
+  await page.addStyleTag({ content: MAGENTA_MARKER_CSS });
+  const frames = await recordUntil(page, () => page.waitForFunction(() => !!window.__probe.catchUpWall, null, { timeout: 30_000 }));
+  const wall = await page.evaluate(() => window.__probe.catchUpWall);
+  const markerStyle = await page.evaluate(() => {
+    const el = document.querySelector('main [data-message-id]');
+    return el ? [el.matches(':first-of-type'), getComputedStyle(el, '::before').height, getComputedStyle(el, '::before').backgroundColor] : null;
+  });
+  const span = (f) => Math.round(f.ts * 1000 - wall);
+  console.log(`[cast] total frames ${frames.length}, ts range ${frames.length ? span(frames[0]) : '-'}..${frames.length ? span(frames[frames.length - 1]) : '-'} ms vs catch-up; now-wall=${Date.now() - wall}; marker=${JSON.stringify(markerStyle)}`);
+  const around = frames.filter((f) => f.ts * 1000 > wall - 300);
+  await doneVisible();
+  const counts = await countMagenta(page, around.map((f) => f.data));
+  const rows = around.map((f, i) => [span(f), counts[i]]);
+  console.log('[cast] frames (ms since catch-up, magenta px):', JSON.stringify(rows.filter((r) => r[0] > -400 && r[0] < 600)));
+}
+
+// A real background tab needs a real display; everything else is headless.
+test.use({ headless: !process.env.PERF_HEADED });
+
 test.describe('catch-up glitch', () => {
   test.skip(!process.env.PERF, 'set PERF=1 to run the catch-up repro');
   test.setTimeout(180_000);
@@ -255,24 +131,12 @@ test.describe('catch-up glitch', () => {
 
   test('reload mid-stream', async ({ page }) => {
     const state = { reconnectable: false };
-    const events = buildEvents();
+    const events = buildEvents(CHUNK_CHARS);
     await startStream(page, state, events);
-    const marker = 'Section 3';
-    await expect(page.getByText(marker, { exact: false }).first()).toBeVisible({ timeout: 60_000 });
-    const k = indexOfMarker(events, marker) + 40;
-    // 2 ms apart so each event is its own socket read, as through a proxy; 0 lets
-    // Node coalesce the whole backlog into one read and one React render.
-    const backlog = events.slice(0, k).map((e) => ({ ...e, delayAfter: Number(process.env.PERF_BACKLOG_MS ?? 2) }));
-    const tail = events.slice(k);
-    state.reconnectable = true;
-    await configureSSE({
-      method: 'GET', path: `/api/v1/threads/${TH}/messages/replay`,
-      events: [sseEvents.userMessage(PROMPT), sseEvents.replayDone()], delay: 10,
-    });
-    // PERF_NO_CAUGHT_UP=1 omits the marker (a server without it): the client
-    // falls back to a timer and the typewriter's catch-up rule.
-    const boundary = process.env.PERF_NO_CAUGHT_UP ? [] : [{ ...sseEvents.caughtUp(), delayAfter: 0 }];
-    await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH}/messages/stream`, events: [...backlog, ...boundary, ...tail], delay: CHUNK_MS });
+    await expect(page.getByText('Section 3', { exact: false }).first()).toBeVisible({ timeout: 60_000 });
+    // The in-flight run is not in the history replay, so the reconnect stream
+    // re-delivers the whole run's buffer in one burst into a fresh bubble.
+    await serveAsReconnect(state, events, indexOfMarker(events, 'Section 3') + 40);
 
     await page.reload();
 
@@ -284,47 +148,10 @@ test.describe('catch-up glitch', () => {
     await page.waitForSelector('textarea', { timeout: 10000 });
     await page.waitForFunction(() => !!window.__probe, null, { timeout: 10000 });
     await page.evaluate(() => window.__probe.watchDrops(8000));
-    // PERF_CAST=1: record compositor frames over the catch-up and look for one
-    // that shows the top of the transcript (magenta marker) after the backlog
-    // landed, the ground truth behind the sampled "painted away" frame.
-    let castFrames = null; let castCdp = null;
-    if (process.env.PERF_CAST) {
-      await page.addStyleTag({ content: 'main [data-message-id]:first-of-type::before{content:"";display:block;height:30px;background:#ff00ff}' });
-      castFrames = [];
-      castCdp = await page.context().newCDPSession(page);
-      castCdp.on('Page.screencastFrame', (f) => { castFrames.push({ ts: f.metadata.timestamp, data: f.data }); castCdp.send('Page.screencastFrameAck', { sessionId: f.sessionId }).catch(() => {}); });
-      await castCdp.send('Page.startScreencast', { format: 'jpeg', quality: 60, everyNthFrame: 1, maxWidth: 480, maxHeight: 360 });
-      await page.waitForFunction(() => !!window.__probe.marks.catchUpWall, null, { timeout: 30_000 });
-      await page.waitForTimeout(600);
-      await castCdp.send('Page.stopScreencast');
-      const wall = await page.evaluate(() => window.__probe.marks.catchUpWall);
-      const marker = await page.evaluate(() => { const el = document.querySelector('main [data-message-id]'); return el ? [el.matches(':first-of-type'), getComputedStyle(el, '::before').height, getComputedStyle(el, '::before').backgroundColor] : null; });
-      console.log(`[cast] total frames ${castFrames.length}, ts range ${castFrames.length ? Math.round(castFrames[0].ts * 1000 - wall) : '-'}..${castFrames.length ? Math.round(castFrames[castFrames.length - 1].ts * 1000 - wall) : '-'} ms vs catch-up; now-wall=${Date.now() - wall}; marker=${JSON.stringify(marker)}`);
-      castFrames = castFrames.filter((f) => f.ts * 1000 > wall - 300);
-    }
-    await expect(page.getByText(END_MARKER)).toBeVisible({ timeout: 120_000 });
-    if (castCdp) {
-      const catchUpWall = await page.evaluate(() => window.__probe.marks.catchUpWall || 0);
-      const counts = await page.evaluate(async (datas) => {
-        const out = [];
-        const canvas = document.createElement('canvas');
-        const ctx = canvas.getContext('2d', { willReadFrequently: true });
-        for (const d of datas) {
-          const img = new Image();
-          img.src = 'data:image/jpeg;base64,' + d;
-          await img.decode();
-          canvas.width = img.width; canvas.height = img.height;
-          ctx.drawImage(img, 0, 0);
-          const px = ctx.getImageData(0, 0, img.width, img.height).data;
-          let magenta = 0;
-          for (let i = 0; i < px.length; i += 4) if (px[i] > 180 && px[i + 1] < 100 && px[i + 2] > 180) magenta++;
-          out.push(magenta);
-        }
-        return out;
-      }, castFrames.map((f) => f.data));
-      const rows = castFrames.map((f, i) => [Math.round(f.ts * 1000 - catchUpWall), counts[i]]);
-      console.log('[cast] frames (ms since catch-up, magenta px):', JSON.stringify(rows.filter((r) => r[0] > -400 && r[0] < 600)));
-    }
+    const done = () => expect(page.getByText(END_MARKER)).toBeVisible({ timeout: 120_000 });
+    if (process.env.PERF_CAST) await reportCastFrames(page, done);
+    else await done();
+
     await page.waitForTimeout(1500);
     const r = await page.evaluate(() => window.__probe.report());
     console.log('[reload] ' + JSON.stringify(r));
@@ -334,29 +161,20 @@ test.describe('catch-up glitch', () => {
       .sort((a, b) => a[1] - b[1]));
     console.log('[reload-waterfall] ' + JSON.stringify(waterfall));
     console.log('[reload-drop] ' + JSON.stringify(await page.evaluate(() => window.__probe.drop)));
+    assertCaughtUpCleanly(r);
   });
 
   for (const target of ['thread', 'dashboard']) {
     test(`in-app navigation to ${target} and back mid-stream`, async ({ page }) => {
       const state = { reconnectable: false };
-      const events = buildEvents();
+      const events = buildEvents(CHUNK_CHARS);
       await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH2}/messages/replay`, events: [sseEvents.replayDone()], delay: 10 });
       await startStream(page, state, events);
       await expect(page.getByText('Section 2', { exact: false }).first()).toBeVisible({ timeout: 60_000 });
       const dest = target === 'thread' ? `/chat/t/${TH2}` : '/dashboard';
-      if (target === 'dashboard') {
-        // Leaving the chat route unmounts it and drops the live stream; the
-        // return is a reconnect, served here the way the reload case is.
-        const k = indexOfMarker(events, 'Section 3') + 40;
-        const backlog = events.slice(0, k).map((e) => ({ ...e, delayAfter: Number(process.env.PERF_BACKLOG_MS ?? 2) }));
-        state.reconnectable = true;
-        await configureSSE({
-          method: 'GET', path: `/api/v1/threads/${TH}/messages/replay`,
-          events: [sseEvents.userMessage(PROMPT), sseEvents.replayDone()], delay: 10,
-        });
-        const boundary = process.env.PERF_NO_CAUGHT_UP ? [] : [{ ...sseEvents.caughtUp(), delayAfter: 0 }];
-        await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH}/messages/stream`, events: [...backlog, ...boundary, ...events.slice(k)], delay: CHUNK_MS });
-      }
+      // Leaving the chat route unmounts it and drops the live stream; the
+      // return is a reconnect, served here the way the reload case is.
+      if (target === 'dashboard') await serveAsReconnect(state, events, indexOfMarker(events, 'Section 3') + 40);
       // Router-level navigation without a document load: pushState + popstate.
       await page.evaluate((d) => { history.pushState({}, '', d); dispatchEvent(new PopStateEvent('popstate')); }, dest);
       await page.waitForTimeout(500);
@@ -364,30 +182,33 @@ test.describe('catch-up glitch', () => {
       await page.waitForTimeout(6000);
       await page.evaluate(() => { window.__probe.mark('resume'); history.back(); });
       await page.waitForTimeout(50);
+      await page.evaluate(() => window.__probe.watchDrops(8000));
       console.log(`[nav:${target}] back url=` + await page.evaluate(() => location.pathname));
       await expect(page.getByText(END_MARKER)).toBeVisible({ timeout: 120_000 });
       await page.waitForTimeout(1500);
       const r = await page.evaluate(() => window.__probe.report('resume'));
       console.log(`[nav:${target}] ` + JSON.stringify(r));
+      console.log(`[nav:${target}-drop] ` + JSON.stringify(await page.evaluate(() => window.__probe.drop)));
+      assertCaughtUpCleanly(r);
     });
   }
 
   test('hidden tab mid-stream', async ({ page }) => {
     const state = { reconnectable: false };
-    const events = buildEvents();
+    const events = buildEvents(CHUNK_CHARS);
     await startStream(page, state, events);
     await expect(page.getByText('Section 2', { exact: false }).first()).toBeVisible({ timeout: 60_000 });
     if (process.env.PERF_HEADED) {
       // A real background tab: rAF paused, timers throttled, no layout, no
-      // smooth-scroll ticks. Needs --headed; headless tabs never go hidden.
+      // smooth-scroll ticks. Needs a display; headless tabs never go hidden.
       const other = await page.context().newPage();
       await other.goto('about:blank');
       await other.bringToFront();
       await page.waitForTimeout(8000);
+      const away = await page.evaluate(() => document.visibilityState);
+      expect(away, 'the tab must really be hidden or this branch measures nothing').toBe('hidden');
       await page.evaluate(() => window.__probe.mark('resume'));
       await page.bringToFront();
-      const vis = await page.evaluate(() => document.visibilityState);
-      console.log('[hidden] visibility after return: ' + vis);
       await other.close();
     } else {
       const len = () => page.evaluate(() => (document.querySelector('main') || document.body).textContent.length);
@@ -405,5 +226,6 @@ test.describe('catch-up glitch', () => {
     await page.waitForTimeout(1500);
     const r = await page.evaluate(() => window.__probe.report('resume'));
     console.log('[hidden] ' + JSON.stringify(r));
+    assertCaughtUpCleanly(r);
   });
 });

--- a/web/e2e/perf/return-glitch.spec.js
+++ b/web/e2e/perf/return-glitch.spec.js
@@ -1,0 +1,333 @@
+/**
+ * Catch-up glitch repro: what the transcript does when presentation falls
+ * behind state and then catches up in a burst. Not part of the default run.
+ *
+ *   PERF=1 pnpm exec playwright test e2e/perf/return-glitch
+ *
+ * Two ways to fall behind:
+ *  - reload mid-stream: the in-flight run is not in the history replay, so
+ *    the reconnect stream re-delivers the whole run's buffer in one burst into
+ *    a fresh bubble.
+ *  - hidden tab: rAF stops (typewriter, framer, scroll follow) while SSE keeps
+ *    landing in state; emulated here by parking every rAF callback for a while.
+ *
+ * Per frame the probe samples transcript text length and scrollTop, and
+ * collects layout-shift entries. A "burst frame" gains far more text than the
+ * cadence or the typewriter can produce; a "drop frame" loses text (content
+ * replaced or duplicated and collapsed); a "scroll jump" moves more than
+ * 300 px in one frame.
+ */
+import { configureSSE, resetMockServer, mockAPI, test, expect } from '../fixtures.js';
+import { sampleWorkspace, sampleThread, sseEvents } from '../helpers/mockResponses.js';
+import { buildReply, buildReasoning, chunk, END_MARKER } from './streamFixture.js';
+
+const WS = 'a0000001-0000-4000-8000-000000000001';
+const TH = 'b0000001-0000-4000-8000-000000000001';
+const CHUNK_MS = 40;
+const CHUNK_CHARS = 8;
+const PROMPT = 'Give me an earnings deep dive on NVDA';
+
+const PROBE = `(() => {
+  const nativeRaf = window.requestAnimationFrame.bind(window);
+  const nativeCaf = window.cancelAnimationFrame.bind(window);
+  const R = (window.__raf = { frozen: false, queue: [], nextId: -1 });
+  window.requestAnimationFrame = (cb) => {
+    if (!R.frozen) return nativeRaf(cb);
+    const id = R.nextId--;
+    R.queue.push({ id, cb });
+    return id;
+  };
+  window.cancelAnimationFrame = (id) => {
+    if (id < 0) { R.queue = R.queue.filter((q) => q.id !== id); return; }
+    nativeCaf(id);
+  };
+  R.freeze = () => { R.frozen = true; };
+  R.thaw = () => {
+    R.frozen = false;
+    const q = R.queue; R.queue = [];
+    nativeRaf((ts) => { for (const { cb } of q) { try { cb(ts); } catch (e) { console.error(e); } } });
+  };
+
+  const P = (window.__probe = { painted: [], samples: [], shifts: [], marks: {} });
+  let scroller = null;
+  function findScroller() {
+    if (scroller && scroller.isConnected) return scroller;
+    const main = document.querySelector('main') || document.body;
+    for (const el of main.querySelectorAll('*')) {
+      const oy = getComputedStyle(el).overflowY;
+      if ((oy === 'auto' || oy === 'scroll') && el.scrollHeight > el.clientHeight + 50) { scroller = el; return el; }
+    }
+    return null;
+  }
+  function sample(ts) {
+    const main = document.querySelector('main') || document.body;
+    const s = findScroller();
+    const len = main.textContent.length;
+    const prev = P.samples[P.samples.length - 1];
+    let note;
+    if (prev && Math.abs(len - prev.len) > 5000) {
+      const big = [];
+      for (const el of main.querySelectorAll('*')) {
+        if (el.children.length === 0 && el.textContent.length > 5000) big.push(el.tagName + '.' + String(el.className).slice(0, 60) + ':' + el.textContent.length + ':' + el.textContent.slice(0, 80));
+      }
+      note = big.slice(0, 5).join(' | ');
+    }
+    P.samples.push({ t: ts, len, top: s ? s.scrollTop : -1, h: s ? s.scrollHeight - s.clientHeight : -1, note });
+    // A task queued from rAF runs after this frame is painted, and a layout or
+    // resize-observer scroll lands between the two, so this is what the screen showed.
+    setTimeout(() => {
+      const sc = findScroller();
+      const m = document.querySelector('main') || document.body;
+      P.painted.push({ t: performance.now(), len: m.textContent.length, top: sc ? sc.scrollTop : -1, h: sc ? sc.scrollHeight - sc.clientHeight : -1 });
+    }, 0);
+    nativeRaf(sample);
+  }
+  nativeRaf(sample);
+  try {
+    new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) if (!e.hadRecentInput) P.shifts.push({ t: e.startTime, v: e.value });
+    }).observe({ type: 'layout-shift', buffered: true });
+  } catch {}
+  P.mark = (name) => { P.marks[name] = performance.now(); };
+  // Poll the transcript's visible text and keep the snapshot around the
+  // largest drop, so a vanished block can be named rather than sized.
+  P.watchDrops = (ms) => {
+    const main = document.querySelector('main') || document.body;
+    let prev = main.innerText; let worst = 0; P.drop = null;
+    const iv = setInterval(() => {
+      const cur = main.innerText;
+      if (prev.length - cur.length > worst) {
+        worst = prev.length - cur.length;
+        const before = new Set(cur.split(String.fromCharCode(10)));
+        P.drop = { t: Math.round(performance.now()), size: worst, removed: prev.split(String.fromCharCode(10)).filter((l) => l.trim() && !before.has(l)).slice(0, 12) };
+      }
+      prev = cur;
+    }, 100);
+    setTimeout(() => clearInterval(iv), ms);
+  };
+  P.report = (since) => {
+    const t0 = P.marks[since] ?? 0;
+    const xs = P.samples.filter((x) => x.t >= t0);
+    let bursts = 0, burstChars = 0, maxGain = 0, drops = 0, maxDrop = 0, jumps = 0, maxJump = 0, lastBurstAt = t0, awayFromBottomFrames = 0;
+    for (let i = 1; i < xs.length; i++) {
+      const d = xs[i].len - xs[i - 1].len;
+      if (d > 20) { bursts++; burstChars += d; lastBurstAt = xs[i].t; }
+      if (d > maxGain) maxGain = d;
+      if (d < 0) { drops++; if (-d > maxDrop) maxDrop = -d; }
+      const j = Math.abs(xs[i].top - xs[i - 1].top);
+      if (xs[i].top >= 0 && j > 300) { jumps++; if (j > maxJump) maxJump = j; }
+      if (xs[i].h > 0 && xs[i].h - xs[i].top > 400) awayFromBottomFrames++;
+    }
+    const cls = P.shifts.filter((s) => s.t >= t0).reduce((a, s) => a + s.v, 0);
+    const first = xs[0];
+    const gapAtResume = first && first.h > 0 ? Math.round(first.h - first.top) : -1;
+    let settleAt = -1, scrollFrames = 0;
+    for (let i = 1; i < xs.length; i++) {
+      if (xs[i].top !== xs[i - 1].top) scrollFrames++;
+      if (settleAt < 0 && xs[i].h > 0 && xs[i].h - xs[i].top < 50) settleAt = xs[i].t;
+    }
+    // Text growth per 500 ms bucket for the first 12 s: the cadence delivers
+    // ~100 chars per bucket, so a bucket far above that is catch-up.
+    const series = [];
+    for (let b = 0; b < 24; b++) {
+      const a = xs.filter((x) => x.t >= t0 + b * 500 && x.t < t0 + (b + 1) * 500);
+      series.push(a.length ? a[a.length - 1].len - a[0].len : 0);
+    }
+    const notable = [];
+    for (let i = 1; i < xs.length; i++) {
+      const d = xs[i].len - xs[i - 1].len; const j = xs[i].top - xs[i - 1].top;
+      if (Math.abs(d) > 60 || Math.abs(j) > 300 || xs[i].note) notable.push({ t: Math.round(xs[i].t - t0), d, top: xs[i].top, j: Math.round(j), note: xs[i].note });
+    }
+    const bigShifts = P.shifts.filter((s) => s.t >= t0 && s.v > 0.02).map((s) => ({ t: Math.round(s.t - t0), v: +s.v.toFixed(3) }));
+    // Painted frames, after the transcript first appears, that showed the
+    // scroller more than 400 px short of the bottom: what the eye saw at the top.
+    const ps = P.painted.filter((x) => x.t >= t0);
+    const firstShown = ps.findIndex((x, i) => i > 0 && x.len - ps[i - 1].len > 500);
+    const paintedAwayFrames = firstShown < 0 ? -1 : ps.slice(firstShown).filter((x) => x.h > 0 && x.h - x.top > 400).length;
+    return {
+      paintedAwayFrames, paintedFirstTop: firstShown < 0 ? -1 : ps[firstShown].top, paintedFirstGap: firstShown < 0 ? -1 : ps[firstShown].h - ps[firstShown].top,
+      frames: xs.length, burstFrames: bursts, burstChars, maxGainPerFrame: maxGain,
+      catchUpMs: Math.round(lastBurstAt - t0), dropFrames: drops, maxDrop,
+      scrollJumps: jumps, maxScrollJumpPx: Math.round(maxJump), awayFromBottomFrames,
+      cls: +cls.toFixed(3), shifts: P.shifts.filter((s) => s.t >= t0).length,
+      textLen: xs.length ? xs[xs.length - 1].len : 0,
+      growthPer500ms: series, gapAtResumePx: gapAtResume, scrollSettleMs: settleAt < 0 ? -1 : Math.round(settleAt - t0), scrollFrames,
+      notable: notable.slice(0, 40), bigShifts: bigShifts.slice(0, 20),
+    };
+  };
+})();`;
+
+const TH2 = 'b0000002-0000-4000-8000-000000000002';
+
+function overrides(state) {
+  const ws = sampleWorkspace();
+  const th = sampleThread();
+  const th2 = { ...sampleThread(), id: TH2, thread_id: TH2, title: 'Other thread' };
+  return {
+    [`GET /threads/${TH2}`]: th2,
+    [`GET /threads/${TH2}/status`]: { can_reconnect: false, status: 'idle' },
+    [`GET /threads/${TH2}/turns`]: { thread_id: TH2, turns: [], retry_checkpoint_id: null },
+    'GET /workspaces': { workspaces: [ws], total: 1, limit: 20, offset: 0 },
+    [`GET /workspaces/${WS}`]: ws,
+    'GET /threads': { threads: [th, th2], total: 2 },
+    [`GET /threads/${TH}`]: th,
+    [`GET /threads/${TH}/status`]: (route) => route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify(state.reconnectable ? { can_reconnect: true, status: 'streaming', run_id: 'run-1' } : { can_reconnect: false, status: 'idle' }),
+    }),
+    [`GET /threads/${TH}/turns`]: {
+      thread_id: TH,
+      turns: [{ turn_index: 0, edit_checkpoint_id: 'cp-edit-0', regenerate_checkpoint_id: 'cp-regen-0' }],
+      retry_checkpoint_id: 'cp-retry-0',
+    },
+    [`GET /workspaces/${WS}/files`]: { files: [] },
+  };
+}
+
+function buildEvents() {
+  const events = [];
+  events.push(sseEvents.messageChunk('start', 'reasoning_signal'));
+  for (const c of chunk(buildReasoning(), CHUNK_CHARS)) events.push(sseEvents.messageChunk(c, 'reasoning'));
+  events.push(sseEvents.messageChunk('complete', 'reasoning_signal'));
+  const calls = ['toolu_p1', 'toolu_p2', 'toolu_p3', 'toolu_p4'];
+  events.push(sseEvents.toolCalls(calls.map((id, i) => ({ name: 'bash', args: { command: `echo ${i}` }, id }))));
+  events.push(sseEvents.finishToolCalls());
+  for (const id of calls) events.push({ ...sseEvents.toolCallResult(id, 'ok'), delayAfter: 150 });
+  for (const c of chunk(buildReply(), CHUNK_CHARS)) events.push(sseEvents.messageChunk(c));
+  events.push(sseEvents.finishStop());
+  events.push(sseEvents.creditUsage());
+  return events;
+}
+
+/** Index of the first event whose text carries `marker`. */
+function indexOfMarker(events, marker) {
+  let acc = '';
+  for (let i = 0; i < events.length; i++) {
+    const d = events[i]?.data;
+    const c = typeof d === 'string' ? (() => { try { return JSON.parse(d); } catch { return null; } })() : d;
+    const text = c?.content ?? c?.data?.content ?? '';
+    if (typeof text === 'string') acc += text;
+    if (acc.includes(marker)) return i;
+  }
+  return -1;
+}
+
+async function startStream(page, state, events) {
+  await page.addInitScript(PROBE);
+  await mockAPI(page, overrides(state));
+  await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH}/messages/replay`, events: [sseEvents.replayDone()], delay: 10 });
+  await configureSSE({ method: 'POST', path: `/api/v1/threads/${TH}/messages`, events, delay: CHUNK_MS });
+  await page.goto(`/chat/t/${TH}`);
+  await page.waitForSelector('textarea', { timeout: 10000 });
+  await page.locator('textarea').fill(PROMPT);
+  await page.locator('button[aria-label="Send message"]').click();
+}
+
+test.describe('catch-up glitch', () => {
+  test.skip(!process.env.PERF, 'set PERF=1 to run the catch-up repro');
+  test.setTimeout(180_000);
+  test.beforeEach(async () => { await resetMockServer(); });
+
+  test('reload mid-stream', async ({ page }) => {
+    const state = { reconnectable: false };
+    const events = buildEvents();
+    await startStream(page, state, events);
+    const marker = 'Section 3';
+    await expect(page.getByText(marker, { exact: false }).first()).toBeVisible({ timeout: 60_000 });
+    const k = indexOfMarker(events, marker) + 40;
+    // 2 ms apart so each event is its own socket read, as through a proxy; 0 lets
+    // Node coalesce the whole backlog into one read and one React render.
+    const backlog = events.slice(0, k).map((e) => ({ ...e, delayAfter: Number(process.env.PERF_BACKLOG_MS ?? 2) }));
+    const tail = events.slice(k);
+    state.reconnectable = true;
+    await configureSSE({
+      method: 'GET', path: `/api/v1/threads/${TH}/messages/replay`,
+      events: [sseEvents.userMessage(PROMPT), sseEvents.replayDone()], delay: 10,
+    });
+    // PERF_NO_CAUGHT_UP=1 omits the marker (a server without it): the client
+    // falls back to a timer and the typewriter's catch-up rule.
+    const boundary = process.env.PERF_NO_CAUGHT_UP ? [] : [{ ...sseEvents.caughtUp(), delayAfter: 0 }];
+    await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH}/messages/stream`, events: [...backlog, ...boundary, ...tail], delay: CHUNK_MS });
+
+    await page.reload();
+    await page.waitForSelector('textarea', { timeout: 10000 });
+    await page.waitForFunction(() => !!window.__probe, null, { timeout: 10000 });
+    await page.evaluate(() => window.__probe.watchDrops(8000));
+    await expect(page.getByText(END_MARKER)).toBeVisible({ timeout: 120_000 });
+    await page.waitForTimeout(1500);
+    const r = await page.evaluate(() => window.__probe.report());
+    console.log('[reload] ' + JSON.stringify(r));
+    console.log('[reload-drop] ' + JSON.stringify(await page.evaluate(() => window.__probe.drop)));
+  });
+
+  for (const target of ['thread', 'dashboard']) {
+    test(`in-app navigation to ${target} and back mid-stream`, async ({ page }) => {
+      const state = { reconnectable: false };
+      const events = buildEvents();
+      await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH2}/messages/replay`, events: [sseEvents.replayDone()], delay: 10 });
+      await startStream(page, state, events);
+      await expect(page.getByText('Section 2', { exact: false }).first()).toBeVisible({ timeout: 60_000 });
+      const dest = target === 'thread' ? `/chat/t/${TH2}` : '/dashboard';
+      if (target === 'dashboard') {
+        // Leaving the chat route unmounts it and drops the live stream; the
+        // return is a reconnect, served here the way the reload case is.
+        const k = indexOfMarker(events, 'Section 3') + 40;
+        const backlog = events.slice(0, k).map((e) => ({ ...e, delayAfter: Number(process.env.PERF_BACKLOG_MS ?? 2) }));
+        state.reconnectable = true;
+        await configureSSE({
+          method: 'GET', path: `/api/v1/threads/${TH}/messages/replay`,
+          events: [sseEvents.userMessage(PROMPT), sseEvents.replayDone()], delay: 10,
+        });
+        const boundary = process.env.PERF_NO_CAUGHT_UP ? [] : [{ ...sseEvents.caughtUp(), delayAfter: 0 }];
+        await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH}/messages/stream`, events: [...backlog, ...boundary, ...events.slice(k)], delay: CHUNK_MS });
+      }
+      // Router-level navigation without a document load: pushState + popstate.
+      await page.evaluate((d) => { history.pushState({}, '', d); dispatchEvent(new PopStateEvent('popstate')); }, dest);
+      await page.waitForTimeout(500);
+      console.log(`[nav:${target}] away url=` + await page.evaluate(() => location.pathname) + ' chatTextLen=' + await page.evaluate(() => (document.querySelector('main') || document.body).textContent.length));
+      await page.waitForTimeout(6000);
+      await page.evaluate(() => { window.__probe.mark('resume'); history.back(); });
+      await page.waitForTimeout(50);
+      console.log(`[nav:${target}] back url=` + await page.evaluate(() => location.pathname));
+      await expect(page.getByText(END_MARKER)).toBeVisible({ timeout: 120_000 });
+      await page.waitForTimeout(1500);
+      const r = await page.evaluate(() => window.__probe.report('resume'));
+      console.log(`[nav:${target}] ` + JSON.stringify(r));
+    });
+  }
+
+  test('hidden tab mid-stream', async ({ page }) => {
+    const state = { reconnectable: false };
+    const events = buildEvents();
+    await startStream(page, state, events);
+    await expect(page.getByText('Section 2', { exact: false }).first()).toBeVisible({ timeout: 60_000 });
+    if (process.env.PERF_HEADED) {
+      // A real background tab: rAF paused, timers throttled, no layout, no
+      // smooth-scroll ticks. Needs --headed; headless tabs never go hidden.
+      const other = await page.context().newPage();
+      await other.goto('about:blank');
+      await other.bringToFront();
+      await page.waitForTimeout(8000);
+      await page.evaluate(() => window.__probe.mark('resume'));
+      await page.bringToFront();
+      const vis = await page.evaluate(() => document.visibilityState);
+      console.log('[hidden] visibility after return: ' + vis);
+      await other.close();
+    } else {
+      const len = () => page.evaluate(() => (document.querySelector('main') || document.body).textContent.length);
+      await page.evaluate(() => window.__raf.freeze());
+      const atFreeze = await len();
+      await page.waitForTimeout(6000);
+      const atThaw = await len();
+      await page.evaluate(() => { window.__probe.mark('resume'); window.__raf.thaw(); });
+      await page.waitForTimeout(100); const after100 = await len();
+      await page.waitForTimeout(900); const after1000 = await len();
+      await page.waitForTimeout(2000); const after3000 = await len();
+      console.log(`[hidden] len freeze=${atFreeze} thaw=${atThaw} +100ms=${after100} +1s=${after1000} +3s=${after3000}`);
+    }
+    await expect(page.getByText(END_MARKER)).toBeVisible({ timeout: 120_000 });
+    await page.waitForTimeout(1500);
+    const r = await page.evaluate(() => window.__probe.report('resume'));
+    console.log('[hidden] ' + JSON.stringify(r));
+  });
+});

--- a/web/e2e/perf/return-glitch.spec.js
+++ b/web/e2e/perf/return-glitch.spec.js
@@ -16,6 +16,12 @@
  * cadence or the typewriter can produce; a "drop frame" loses text (content
  * replaced or duplicated and collapsed); a "scroll jump" moves more than
  * 300 px in one frame.
+ *
+ * PERF_CAST=1 (reload) records compositor frames around the catch-up and
+ * counts, per frame, the pixels of a marker painted at the top of the
+ * transcript: the ground truth for whether a frame was ever shown away from
+ * the bottom. PERF_SCROLL_LOG=1 records every programmatic scroll with its
+ * caller; PERF_SHOT=<path> screenshots the reconnecting state after reload.
  */
 import { configureSSE, resetMockServer, mockAPI, test, expect } from '../fixtures.js';
 import { sampleWorkspace, sampleThread, sseEvents } from '../helpers/mockResponses.js';
@@ -48,7 +54,15 @@ const PROBE = `(() => {
     nativeRaf((ts) => { for (const { cb } of q) { try { cb(ts); } catch (e) { console.error(e); } } });
   };
 
-  const P = (window.__probe = { painted: [], samples: [], shifts: [], marks: {} });
+  const P = (window.__probe = { painted: [], samples: [], shifts: [], marks: {}, scrolls: [] });
+  const ids = new WeakMap(); let nid = 0; const idOf = (el) => { if (!ids.has(el)) ids.set(el, ++nid); return ids.get(el); }; P.idOf = idOf;
+  // PERF_SCROLL_LOG=1: record every programmatic scroll with its caller.
+  if (${process.env.PERF_SCROLL_LOG ? 'true' : 'false'}) try {
+    const d = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollTop');
+    Object.defineProperty(Element.prototype, 'scrollTop', { get: d.get, set(v) { P.scrolls.push({ t: performance.now(), el: idOf(this), top: v, via: 'set', st: String(new Error().stack).split('\\n').slice(2, 12).map((l) => l.trim().slice(-48)) }); return d.set.call(this, v); }, configurable: true });
+    const orig = Element.prototype.scrollTo;
+    Element.prototype.scrollTo = function (...a) { const o = a[0]; P.scrolls.push({ t: performance.now(), el: idOf(this), top: o && typeof o === 'object' ? o.top : a[1], beh: o && typeof o === 'object' ? o.behavior : 'auto', via: 'scrollTo', st: String(new Error().stack).split('\\n').slice(2, 12).map((l) => l.trim().slice(-48)) }); return orig.apply(this, a); };
+  } catch {}
   let scroller = null;
   function findScroller() {
     if (scroller && scroller.isConnected) return scroller;
@@ -64,6 +78,7 @@ const PROBE = `(() => {
     const s = findScroller();
     const len = main.textContent.length;
     const prev = P.samples[P.samples.length - 1];
+    if (prev && len < 50000 && prev.len < 50000 && len - prev.len > 1000 && !P.marks.catchUpWall) P.marks.catchUpWall = Date.now();
     let note;
     if (prev && Math.abs(len - prev.len) > 5000) {
       const big = [];
@@ -78,14 +93,18 @@ const PROBE = `(() => {
     setTimeout(() => {
       const sc = findScroller();
       const m = document.querySelector('main') || document.body;
-      P.painted.push({ t: performance.now(), len: m.textContent.length, top: sc ? sc.scrollTop : -1, h: sc ? sc.scrollHeight - sc.clientHeight : -1 });
+      P.painted.push({ t: performance.now(), len: m.textContent.length, el: sc ? idOf(sc) : 0, cr: sc ? idOf(sc.querySelector('.max-w-3xl') || sc.firstElementChild || sc) : 0, top: sc ? sc.scrollTop : -1, h: sc ? sc.scrollHeight - sc.clientHeight : -1 });
     }, 0);
     nativeRaf(sample);
   }
   nativeRaf(sample);
   try {
     new PerformanceObserver((list) => {
-      for (const e of list.getEntries()) if (!e.hadRecentInput) P.shifts.push({ t: e.startTime, v: e.value });
+      for (const e of list.getEntries()) if (!e.hadRecentInput) P.shifts.push({ t: e.startTime, v: e.value, src: (e.sources || []).slice(0, 4).map((s) => {
+        const n = s.node; const tag = n ? (n.tagName || '').toLowerCase() + (n.className && typeof n.className === 'string' ? '.' + n.className.split(' ').slice(0, 3).join('.') : '') : '?';
+        const r = (q) => q ? [Math.round(q.x), Math.round(q.y), Math.round(q.width), Math.round(q.height)].join(',') : '-';
+        return tag.slice(0, 60) + ' ' + r(s.previousRect) + ' -> ' + r(s.currentRect);
+      }) });
     }).observe({ type: 'layout-shift', buffered: true });
   } catch {}
   P.mark = (name) => { P.marks[name] = performance.now(); };
@@ -138,13 +157,19 @@ const PROBE = `(() => {
       const d = xs[i].len - xs[i - 1].len; const j = xs[i].top - xs[i - 1].top;
       if (Math.abs(d) > 60 || Math.abs(j) > 300 || xs[i].note) notable.push({ t: Math.round(xs[i].t - t0), d, top: xs[i].top, j: Math.round(j), note: xs[i].note });
     }
-    const bigShifts = P.shifts.filter((s) => s.t >= t0 && s.v > 0.02).map((s) => ({ t: Math.round(s.t - t0), v: +s.v.toFixed(3) }));
+    const bigShifts = P.shifts.filter((s) => s.t >= t0 && s.v > 0.02).map((s) => ({ t: Math.round(s.t - t0), v: +s.v.toFixed(3), src: s.src }));
     // Painted frames, after the transcript first appears, that showed the
     // scroller more than 400 px short of the bottom: what the eye saw at the top.
     const ps = P.painted.filter((x) => x.t >= t0);
     const firstShown = ps.findIndex((x, i) => i > 0 && x.len - ps[i - 1].len > 500);
+    // A hint, not ground truth: the post-paint sample runs in a task, and a
+    // commit that lands between the paint and that task is read here as if it
+    // had been painted at scrollTop 0. PERF_CAST=1 records compositor frames
+    // and is what decides whether a frame was really shown away from the bottom.
     const paintedAwayFrames = firstShown < 0 ? -1 : ps.slice(firstShown).filter((x) => x.h > 0 && x.h - x.top > 400).length;
     return {
+      scrolls: P.scrolls.filter((x) => x.t >= t0).map((x) => ({ ...x, t: Math.round(x.t - t0) })).slice(0, 16), paintedPrev: (() => { const i = ps.findIndex((x) => x.h > 0 && x.h - x.top > 400); return i > 0 ? ps.slice(Math.max(0, i - 3), i + 2).map((x) => [Math.round(x.t - t0), x.len, x.el, x.cr, x.top, x.h]) : []; })(),
+      paintedAway: firstShown < 0 ? [] : ps.slice(firstShown).filter((x) => x.h > 0 && x.h - x.top > 400).slice(0, 5).map((x) => [Math.round(x.t - t0), x.len, x.el, x.cr, x.top, x.h]),
       paintedAwayFrames, paintedFirstTop: firstShown < 0 ? -1 : ps[firstShown].top, paintedFirstGap: firstShown < 0 ? -1 : ps[firstShown].h - ps[firstShown].top,
       frames: xs.length, burstFrames: bursts, burstChars, maxGainPerFrame: maxGain,
       catchUpMs: Math.round(lastBurstAt - t0), dropFrames: drops, maxDrop,
@@ -250,13 +275,64 @@ test.describe('catch-up glitch', () => {
     await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH}/messages/stream`, events: [...backlog, ...boundary, ...tail], delay: CHUNK_MS });
 
     await page.reload();
+
+    if (process.env.PERF_SHOT) {
+      await page.locator('.page-loading__wall').waitFor({ state: 'detached', timeout: 10000 }).catch(() => {});
+      await page.locator('[role="status"]').first().waitFor({ timeout: 5000 }).catch(() => {});
+      await page.screenshot({ path: process.env.PERF_SHOT });
+    }
     await page.waitForSelector('textarea', { timeout: 10000 });
     await page.waitForFunction(() => !!window.__probe, null, { timeout: 10000 });
     await page.evaluate(() => window.__probe.watchDrops(8000));
+    // PERF_CAST=1: record compositor frames over the catch-up and look for one
+    // that shows the top of the transcript (magenta marker) after the backlog
+    // landed, the ground truth behind the sampled "painted away" frame.
+    let castFrames = null; let castCdp = null;
+    if (process.env.PERF_CAST) {
+      await page.addStyleTag({ content: 'main [data-message-id]:first-of-type::before{content:"";display:block;height:30px;background:#ff00ff}' });
+      castFrames = [];
+      castCdp = await page.context().newCDPSession(page);
+      castCdp.on('Page.screencastFrame', (f) => { castFrames.push({ ts: f.metadata.timestamp, data: f.data }); castCdp.send('Page.screencastFrameAck', { sessionId: f.sessionId }).catch(() => {}); });
+      await castCdp.send('Page.startScreencast', { format: 'jpeg', quality: 60, everyNthFrame: 1, maxWidth: 480, maxHeight: 360 });
+      await page.waitForFunction(() => !!window.__probe.marks.catchUpWall, null, { timeout: 30_000 });
+      await page.waitForTimeout(600);
+      await castCdp.send('Page.stopScreencast');
+      const wall = await page.evaluate(() => window.__probe.marks.catchUpWall);
+      const marker = await page.evaluate(() => { const el = document.querySelector('main [data-message-id]'); return el ? [el.matches(':first-of-type'), getComputedStyle(el, '::before').height, getComputedStyle(el, '::before').backgroundColor] : null; });
+      console.log(`[cast] total frames ${castFrames.length}, ts range ${castFrames.length ? Math.round(castFrames[0].ts * 1000 - wall) : '-'}..${castFrames.length ? Math.round(castFrames[castFrames.length - 1].ts * 1000 - wall) : '-'} ms vs catch-up; now-wall=${Date.now() - wall}; marker=${JSON.stringify(marker)}`);
+      castFrames = castFrames.filter((f) => f.ts * 1000 > wall - 300);
+    }
     await expect(page.getByText(END_MARKER)).toBeVisible({ timeout: 120_000 });
+    if (castCdp) {
+      const catchUpWall = await page.evaluate(() => window.__probe.marks.catchUpWall || 0);
+      const counts = await page.evaluate(async (datas) => {
+        const out = [];
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
+        for (const d of datas) {
+          const img = new Image();
+          img.src = 'data:image/jpeg;base64,' + d;
+          await img.decode();
+          canvas.width = img.width; canvas.height = img.height;
+          ctx.drawImage(img, 0, 0);
+          const px = ctx.getImageData(0, 0, img.width, img.height).data;
+          let magenta = 0;
+          for (let i = 0; i < px.length; i += 4) if (px[i] > 180 && px[i + 1] < 100 && px[i + 2] > 180) magenta++;
+          out.push(magenta);
+        }
+        return out;
+      }, castFrames.map((f) => f.data));
+      const rows = castFrames.map((f, i) => [Math.round(f.ts * 1000 - catchUpWall), counts[i]]);
+      console.log('[cast] frames (ms since catch-up, magenta px):', JSON.stringify(rows.filter((r) => r[0] > -400 && r[0] < 600)));
+    }
     await page.waitForTimeout(1500);
     const r = await page.evaluate(() => window.__probe.report());
     console.log('[reload] ' + JSON.stringify(r));
+    const waterfall = await page.evaluate(() => performance.getEntriesByType('resource')
+      .filter((e) => e.name.includes('/api/v1/'))
+      .map((e) => [e.name.replace(/^.*\/api\/v1/, ''), Math.round(e.startTime), Math.round(e.duration)])
+      .sort((a, b) => a[1] - b[1]));
+    console.log('[reload-waterfall] ' + JSON.stringify(waterfall));
     console.log('[reload-drop] ' + JSON.stringify(await page.evaluate(() => window.__probe.drop)));
   });
 

--- a/web/e2e/perf/run.js
+++ b/web/e2e/perf/run.js
@@ -1,0 +1,33 @@
+/** Where a benchmark run is filed and under what name. */
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+/** PERF_LABEL, else the git short sha: the column a run lands in. */
+export function label() {
+  if (process.env.PERF_LABEL) return process.env.PERF_LABEL;
+  try { return execSync('git rev-parse --short HEAD').toString().trim(); } catch { return 'unlabeled'; }
+}
+
+/**
+ * The execution mode every benchmark shares: a production build, a real
+ * display, a profiler or tracer attached. Each one moves the numbers, so the
+ * summary fingerprints it alongside the benchmark's own config.
+ */
+export function mode() {
+  return {
+    build: process.env.PERF_BUILD ? 'production' : 'dev',
+    headed: !!process.env.PERF_HEADED,
+    profile: !!process.env.PERF_PROFILE,
+    trace: !!process.env.PERF_TRACE,
+  };
+}
+
+/** Write one run as perf-results/<kind>-<label>-<ts>-<repeat>.json, stamped with the mode. */
+export function writeRun(kind, run, testInfo) {
+  const dir = path.resolve('perf-results');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${kind}-${run.label}-${Date.now()}-${testInfo.repeatEachIndex}.json`);
+  fs.writeFileSync(file, JSON.stringify({ ...run, mode: mode() }, null, 2));
+  return file;
+}

--- a/web/e2e/perf/screencast.js
+++ b/web/e2e/perf/screencast.js
@@ -1,0 +1,58 @@
+/**
+ * Compositor-frame capture: the ground truth for "was this ever on screen".
+ *
+ * The in-page probe samples from a task queued off the frame, so a commit that
+ * lands between the paint and that task reads as if it had been painted. A
+ * screencast frame cannot lie about it. The transcript's first message wears a
+ * magenta band, so counting magenta pixels per frame says whether that frame
+ * showed the top of the transcript.
+ */
+
+/** Paints a band at the top of the transcript, above the fold only while scrolled up. */
+export const MAGENTA_MARKER_CSS = 'main [data-message-id]:first-of-type::before{content:"";display:block;height:30px;background:#ff00ff}';
+
+/**
+ * Record compositor frames until `until()` resolves, plus a tail. Always stops
+ * the screencast and detaches the session, so a failing `until` cannot leave
+ * the browser encoding JPEGs for the rest of the run.
+ */
+export async function recordUntil(page, until, { tailMs = 600, quality = 60, maxWidth = 480, maxHeight = 360 } = {}) {
+  const frames = [];
+  const cdp = await page.context().newCDPSession(page);
+  const onFrame = (f) => {
+    frames.push({ ts: f.metadata.timestamp, data: f.data });
+    cdp.send('Page.screencastFrameAck', { sessionId: f.sessionId }).catch(() => {});
+  };
+  cdp.on('Page.screencastFrame', onFrame);
+  try {
+    await cdp.send('Page.startScreencast', { format: 'jpeg', quality, everyNthFrame: 1, maxWidth, maxHeight });
+    await until();
+    await page.waitForTimeout(tailMs);
+  } finally {
+    await cdp.send('Page.stopScreencast').catch(() => {});
+    cdp.off('Page.screencastFrame', onFrame);
+    await cdp.detach().catch(() => {});
+  }
+  return frames;
+}
+
+/** Magenta pixel count per frame, decoded in the page (Node has no image decoder). */
+export async function countMagenta(page, datas) {
+  return page.evaluate(async (ds) => {
+    const out = [];
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    for (const d of ds) {
+      const img = new Image();
+      img.src = 'data:image/jpeg;base64,' + d;
+      await img.decode();
+      canvas.width = img.width; canvas.height = img.height;
+      ctx.drawImage(img, 0, 0);
+      const px = ctx.getImageData(0, 0, img.width, img.height).data;
+      let magenta = 0;
+      for (let i = 0; i < px.length; i += 4) if (px[i] > 180 && px[i + 1] < 100 && px[i + 2] > 180) magenta++;
+      out.push(magenta);
+    }
+    return out;
+  }, datas);
+}

--- a/web/e2e/perf/streamFixture.d.ts
+++ b/web/e2e/perf/streamFixture.d.ts
@@ -1,0 +1,8 @@
+// Kept for src/pages/ChatAgent/components/__tests__/Markdown.blocks.test.tsx,
+// which imports buildReply: tsc resolves this file for that import, and
+// dropping it fails `pnpm typecheck` even though e2e/ is excluded.
+export const END_MARKER: string;
+export function buildReply(): string;
+export function buildEvents(chunkChars?: number): Array<Record<string, unknown>>;
+export function buildReasoning(): string;
+export function chunk(text: string, size?: number): string[];

--- a/web/e2e/perf/streamFixture.js
+++ b/web/e2e/perf/streamFixture.js
@@ -1,0 +1,139 @@
+/**
+ * Deterministic long reply for the streaming smoothness benchmark.
+ *
+ * Mixed constructs on purpose: headings, emphasis, inline code, links, lists,
+ * fenced code in three languages, a table, math and a blockquote. Each one
+ * exercises a different remark/rehype path, so a renderer change that only
+ * helps paragraphs shows up as a smaller gain here, not as a false win.
+ */
+
+import { sseEvents } from '../helpers/mockResponses.js';
+
+export const END_MARKER = 'END-OF-REPLY';
+
+const PARA = [
+  'Revenue growth **accelerated to 18% year over year**, driven by the data-center segment, while gross margin expanded 140 bps on mix. Management guided *above* consensus for the next quarter and reiterated the capex envelope.',
+  'The balance sheet remains net cash positive at `$4.2B`, and free cash flow conversion improved to 92% of adjusted EBITDA. See the [10-Q filing](https://example.com/10q) for segment detail and the reconciliation tables.',
+  'Risks include customer concentration (top three customers are 41% of revenue), export-control exposure in two regions, and a lumpy services backlog that can move quarterly recognition by several points.',
+  'Valuation sits at 24x forward earnings against a five-year median of 19x; the premium is roughly explained by the growth differential versus peers, but it leaves little room for a guidance miss.',
+];
+
+function codePython(i) {
+  return `\`\`\`python
+import pandas as pd
+
+def load_prices_${i}(symbol: str) -> pd.DataFrame:
+    """Load daily closes and compute a ${20 + i}-day rolling mean."""
+    df = pd.read_parquet(f"data/{symbol}.parquet")
+    df["ma"] = df["close"].rolling(${20 + i}).mean()
+    return df.dropna()
+
+prices = load_prices_${i}("NVDA")
+print(prices.tail())
+\`\`\``;
+}
+
+const CODE_JSON = `\`\`\`json
+{
+  "symbol": "NVDA",
+  "quarter": "Q2 FY27",
+  "revenue_bn": 46.7,
+  "gross_margin": 0.751,
+  "segments": [{ "name": "Data Center", "share": 0.88 }, { "name": "Gaming", "share": 0.08 }]
+}
+\`\`\``;
+
+const CODE_BASH = `\`\`\`bash
+uv run python scripts/backtest.py --symbol NVDA --window 20 --start 2024-01-01
+\`\`\``;
+
+const TABLE = `| Metric | Q1 | Q2 | Q3 | Q4 |
+|---|---:|---:|---:|---:|
+| Revenue ($B) | 26.0 | 30.0 | 35.1 | 39.3 |
+| Gross margin | 78.4% | 75.1% | 74.6% | 73.0% |
+| Op. margin | 64.9% | 62.3% | 62.3% | 61.1% |
+| FCF ($B) | 14.9 | 13.5 | 16.8 | 15.5 |`;
+
+const MATH = 'The implied growth rate solves $g = \\frac{r \\cdot P - D}{P}$ where $P$ is price and $D$ the dividend, which gives $g \\approx 7.8\\%$ at the current quote.';
+
+const QUOTE = '> "We see demand visibility extending through next year and are supply constrained in two product lines.": CFO, Q2 call';
+
+function list(i) {
+  return `- **Thesis ${i}.1**: the installed base compounds services revenue at ~30% with minimal incremental capex.
+- **Thesis ${i}.2**: pricing power holds while the competitor roadmap slips by two quarters.
+  - Sub-point: channel checks in ${['Taiwan', 'Korea', 'Germany', 'Texas'][i % 4]} corroborate lead times.
+- **Thesis ${i}.3**: buybacks absorb dilution; the share count is flat since 2023.`;
+}
+
+function numbered(i) {
+  return `1. Pull the last ${8 + i} quarters of segment data.
+2. Normalize for the fiscal-year shift in ${2020 + i}.
+3. Regress margin on mix and utilization; report the residual.`;
+}
+
+/** The whole reply as one markdown string (about 14 KB). */
+export function buildReply() {
+  const parts = ['# NVDA earnings deep dive\n'];
+  for (let i = 0; i < 6; i++) {
+    parts.push(`## Section ${i + 1}: ${['Growth', 'Margins', 'Cash', 'Risks', 'Valuation', 'Setup'][i]}\n`);
+    parts.push(PARA[i % PARA.length]);
+    parts.push(list(i));
+    parts.push(PARA[(i + 1) % PARA.length]);
+    if (i % 2 === 0) parts.push(codePython(i));
+    if (i === 1) parts.push(TABLE);
+    if (i === 3) parts.push(CODE_JSON);
+    if (i === 4) parts.push(MATH);
+    if (i === 5) parts.push(CODE_BASH);
+    parts.push(numbered(i));
+    parts.push(QUOTE);
+  }
+  parts.push(`Summary: the setup is constructive into the print. ${END_MARKER}`);
+  return parts.join('\n\n');
+}
+
+/**
+ * The whole turn as SSE events: reasoning, four tool calls, then the reply,
+ * every text event split to `chunkChars` so the stream arrives at token cadence.
+ */
+export function buildEvents(chunkChars = 8) {
+  const events = [];
+  events.push(sseEvents.messageChunk('start', 'reasoning_signal'));
+  for (const c of chunk(buildReasoning(), chunkChars)) events.push(sseEvents.messageChunk(c, 'reasoning'));
+  events.push(sseEvents.messageChunk('complete', 'reasoning_signal'));
+  const calls = ['toolu_p1', 'toolu_p2', 'toolu_p3', 'toolu_p4'];
+  events.push(sseEvents.toolCalls(calls.map((id, i) => ({ name: 'bash', args: { command: `echo ${i}` }, id }))));
+  events.push(sseEvents.finishToolCalls());
+  for (const id of calls) events.push({ ...sseEvents.toolCallResult(id, 'ok'), delayAfter: 150 });
+  for (const c of chunk(buildReply(), chunkChars)) events.push(sseEvents.messageChunk(c));
+  events.push(sseEvents.finishStop());
+  events.push(sseEvents.creditUsage());
+  return events;
+}
+
+/** A reasoning block with enough prose to fill a live row several times over. */
+export function buildReasoning() {
+  return [
+    '**Framing the question**',
+    'The user wants an earnings deep dive. I should cover growth, margins, cash generation, the main risks and valuation, and close with a positioning summary.',
+    'I will pull the last eight quarters from the filings tool, compute margin trends, and cross-check the guidance commentary from the call transcript before writing.',
+    'Structure: six sections, each with a short thesis list, a code sample where a reader may want to reproduce the number, and one table for the quarterly view.',
+  ].join('\n\n');
+}
+
+/** Split text into token-sized chunks (about `size` chars, never inside a surrogate pair). */
+export function chunk(text, size = 8) {
+  // A zero or negative size never advances the loop; fail loudly rather than
+  // let PERF_CHUNK_CHARS=0 hang the benchmark until its timeout.
+  if (!Number.isSafeInteger(size) || size < 1) {
+    throw new RangeError(`chunk size must be a positive integer, got ${size}`);
+  }
+  const out = [];
+  let i = 0;
+  while (i < text.length) {
+    let end = Math.min(text.length, i + size);
+    if (end < text.length && /[\uD800-\uDBFF]/.test(text[end - 1])) end += 1;
+    out.push(text.slice(i, end));
+    i = end;
+  }
+  return out;
+}

--- a/web/e2e/perf/streaming-smoothness.spec.js
+++ b/web/e2e/perf/streaming-smoothness.spec.js
@@ -8,7 +8,11 @@
  * throttling and writes one JSON per run to perf-results/. PERF_BUILD serves a
  * production build (the number that matters); without it the dev server runs,
  * which is faster to iterate on but inflates React's share. PERF_PROFILE=1 adds
- * a V8 CPU profile summarized per module, for finding what to fix next.
+ * a V8 CPU profile summarized per module, for finding what to fix next;
+ * PERF_TRACE=1 adds a Chrome trace summed per event kind (Layout, Paint, ...),
+ * which is where the profiler's "(program)" time goes. Requests issued during
+ * the stream are tallied by path: a control that writes and refetches in a
+ * loop shows up there long before it shows up in the frame numbers.
  * PERF_CPU (default 4) is the CPU throttle; PERF_CHUNK_MS / PERF_CHUNK_CHARS set
  * the token cadence. The label defaults to the git short sha.
  */
@@ -27,6 +31,10 @@ const CHUNK_DELAY_MS = Number(process.env.PERF_CHUNK_MS || 8);
 const CHUNK_CHARS = Number(process.env.PERF_CHUNK_CHARS || 8);
 // PERF_PROFILE=1 also records a V8 CPU profile and writes self-time per module.
 const PROFILE = !!process.env.PERF_PROFILE;
+// PERF_TRACE=1 records a Chrome trace and sums renderer time per event kind
+// (Layout, UpdateLayoutTree, Paint, ...), which is where the JS profiler's
+// "(program)" bucket goes.
+const TRACE = !!process.env.PERF_TRACE;
 
 function label() {
   if (process.env.PERF_LABEL) return process.env.PERF_LABEL;
@@ -99,6 +107,30 @@ function summarizeProfile(p) {
   return { byModule: top(byModule), byFunction: top(byFunction) };
 }
 
+/** Wall time per trace event name, for the renderer main thread only. */
+function summarizeTrace(events) {
+  const byName = new Map();
+  const count = new Map();
+  const open = new Map();
+  for (const e of events) {
+    if (e.cat && !/devtools\.timeline/.test(e.cat)) continue;
+    if (e.ph === 'X' && typeof e.dur === 'number') {
+      byName.set(e.name, (byName.get(e.name) || 0) + e.dur);
+      count.set(e.name, (count.get(e.name) || 0) + 1);
+    } else if (e.ph === 'B') {
+      open.set(`${e.name}:${e.tid}`, e.ts);
+    } else if (e.ph === 'E') {
+      const k = `${e.name}:${e.tid}`;
+      if (open.has(k)) {
+        byName.set(e.name, (byName.get(e.name) || 0) + (e.ts - open.get(k)));
+        count.set(e.name, (count.get(e.name) || 0) + 1);
+        open.delete(k);
+      }
+    }
+  }
+  return [...byName].map(([k, us]) => [k, Math.round(us / 1000), count.get(k)]).sort((a, b) => b[1] - a[1]).slice(0, 25);
+}
+
 test.describe('streaming smoothness', () => {
   test.skip(!process.env.PERF, 'set PERF=1 to run the smoothness benchmark');
   test.setTimeout(180_000);
@@ -136,7 +168,17 @@ test.describe('streaming smoothness', () => {
     // Let the throttled page settle before the clock starts.
     await page.waitForTimeout(500);
     if (PROFILE) await cdp.send('Profiler.start');
+    const traceEvents = [];
+    if (TRACE) {
+      cdp.on('Tracing.dataCollected', (d) => traceEvents.push(...d.value));
+      await cdp.send('Tracing.start', {
+        traceConfig: { includedCategories: ['devtools.timeline', 'disabled-by-default-devtools.timeline'] },
+        transferMode: 'ReportEvents',
+      });
+    }
 
+    const reqs = new Map();
+    page.on('request', (r) => { const k = `${r.method()} ${new URL(r.url()).pathname}`; reqs.set(k, (reqs.get(k) || 0) + 1); });
     await page.locator('textarea').fill('Give me an earnings deep dive on NVDA');
     await page.evaluate(() => window.__smooth.start(document.querySelector('main') || document.body));
     await page.locator('button[aria-label="Send message"]').click();
@@ -150,6 +192,13 @@ test.describe('streaming smoothness', () => {
       const { profile: p } = await cdp.send('Profiler.stop');
       profile = summarizeProfile(p);
     }
+    let trace = null;
+    if (TRACE) {
+      const done = new Promise((resolve) => cdp.once('Tracing.tracingComplete', resolve));
+      await cdp.send('Tracing.end');
+      await done;
+      trace = summarizeTrace(traceEvents);
+    }
     if (CPU_RATE > 1) await cdp.send('Emulation.setCPUThrottlingRate', { rate: 1 });
 
     const run = {
@@ -158,6 +207,7 @@ test.describe('streaming smoothness', () => {
       config: { build: process.env.PERF_BUILD ? 'production' : 'dev', cpuRate: CPU_RATE, chunkDelayMs: CHUNK_DELAY_MS, chunkChars: CHUNK_CHARS, events: events.length, replyChars: buildReply().length },
       metrics: m,
       profile,
+      trace,
     };
     const dir = path.resolve('perf-results');
     fs.mkdirSync(dir, { recursive: true });
@@ -171,6 +221,12 @@ test.describe('streaming smoothness', () => {
       for (const [mod, ms] of profile.byModule.slice(0, 18)) console.log(`    ${String(ms).padStart(6)}  ${mod}`);
       console.log(`[perf ${run.label}] top functions (ms):`);
       for (const [fn, ms] of profile.byFunction.slice(0, 18)) console.log(`    ${String(ms).padStart(6)}  ${fn}`);
+    }
+    if (trace) {
+      console.log(`[perf ${run.label}] requests during the stream:`);
+      for (const [k, n] of [...reqs].sort((a, b) => b[1] - a[1]).slice(0, 12)) console.log(`    ${String(n).padStart(6)}  ${k}`);
+      console.log(`[perf ${run.label}] trace time by event (ms, count):`);
+      for (const [name, ms, n] of trace) console.log(`    ${String(ms).padStart(6)}  ${String(n).padStart(6)}  ${name}`);
     }
     expect(m.frames).toBeGreaterThan(0);
   });

--- a/web/e2e/perf/streaming-smoothness.spec.js
+++ b/web/e2e/perf/streaming-smoothness.spec.js
@@ -1,79 +1,22 @@
 /**
- * Streaming smoothness benchmark. Not part of the default e2e run.
- *
- *   PERF=1 PERF_BUILD=1 PERF_LABEL=<label> pnpm exec playwright test e2e/perf --repeat-each=3
- *   node scripts/perf-summary.mjs <baseline-label> <label>
- *
- * Streams a long reply through the mock SSE server at token cadence under CPU
- * throttling and writes one JSON per run to perf-results/. PERF_BUILD serves a
- * production build (the number that matters); without it the dev server runs,
- * which is faster to iterate on but inflates React's share. PERF_PROFILE=1 adds
- * a V8 CPU profile summarized per module, for finding what to fix next;
- * PERF_TRACE=1 adds a Chrome trace summed per event kind (Layout, Paint, ...),
- * which is where the profiler's "(program)" time goes. Requests issued during
- * the stream are tallied by path: a control that writes and refetches in a
- * loop shows up there long before it shows up in the frame numbers.
- * PERF_CPU (default 4) is the CPU throttle; PERF_CHUNK_MS / PERF_CHUNK_CHARS set
- * the token cadence. The label defaults to the git short sha.
+ * Streaming smoothness: a long reply arriving at token cadence under CPU
+ * throttling, measured as frame gaps, long animation frames and DOM churn.
+ * Off by default; flags and invocations are in e2e/perf/README.md.
  */
-import fs from 'node:fs';
-import path from 'node:path';
-import { execSync } from 'node:child_process';
 import { configureSSE, resetMockServer, mockAPI, test, expect } from '../fixtures.js';
-import { sampleWorkspace, sampleThread, sseEvents } from '../helpers/mockResponses.js';
-import { buildReply, buildReasoning, chunk, END_MARKER } from './streamFixture.js';
-import { PROBE_SOURCE } from './metrics.js';
+import { sseEvents } from '../helpers/mockResponses.js';
+import { TH, chatViewOverrides } from '../helpers/chatScenario.js';
+import { buildReply, buildEvents, END_MARKER } from './streamFixture.js';
+import { installSmoothProbe } from './metrics.js';
+import { label, writeRun } from './run.js';
 
-const WS = 'a0000001-0000-4000-8000-000000000001';
-const TH = 'b0000001-0000-4000-8000-000000000001';
 const CPU_RATE = Number(process.env.PERF_CPU || 4);
 const CHUNK_DELAY_MS = Number(process.env.PERF_CHUNK_MS || 8);
 const CHUNK_CHARS = Number(process.env.PERF_CHUNK_CHARS || 8);
-// PERF_PROFILE=1 also records a V8 CPU profile and writes self-time per module.
 const PROFILE = !!process.env.PERF_PROFILE;
-// PERF_TRACE=1 records a Chrome trace and sums renderer time per event kind
-// (Layout, UpdateLayoutTree, Paint, ...), which is where the JS profiler's
-// "(program)" bucket goes.
 const TRACE = !!process.env.PERF_TRACE;
-
-function label() {
-  if (process.env.PERF_LABEL) return process.env.PERF_LABEL;
-  try { return execSync('git rev-parse --short HEAD').toString().trim(); } catch { return 'unlabeled'; }
-}
-
-function overrides() {
-  const ws = sampleWorkspace();
-  const th = sampleThread();
-  return {
-    'GET /workspaces': { workspaces: [ws], total: 1, limit: 20, offset: 0 },
-    [`GET /workspaces/${WS}`]: ws,
-    'GET /threads': { threads: [th], total: 1 },
-    [`GET /threads/${TH}`]: th,
-    [`GET /threads/${TH}/status`]: { can_reconnect: false, status: 'idle' },
-    [`GET /threads/${TH}/turns`]: {
-      thread_id: TH,
-      turns: [{ turn_index: 0, edit_checkpoint_id: 'cp-edit-0', regenerate_checkpoint_id: 'cp-regen-0' }],
-      retry_checkpoint_id: 'cp-retry-0',
-    },
-    [`GET /workspaces/${WS}/files`]: { files: [] },
-  };
-}
-
-/** Reasoning, four tool calls, then the long reply, all at token cadence. */
-function buildEvents() {
-  const events = [];
-  events.push(sseEvents.messageChunk('start', 'reasoning_signal'));
-  for (const c of chunk(buildReasoning(), CHUNK_CHARS)) events.push(sseEvents.messageChunk(c, 'reasoning'));
-  events.push(sseEvents.messageChunk('complete', 'reasoning_signal'));
-  const calls = ['toolu_p1', 'toolu_p2', 'toolu_p3', 'toolu_p4'];
-  events.push(sseEvents.toolCalls(calls.map((id, i) => ({ name: 'bash', args: { command: `echo ${i}` }, id }))));
-  events.push(sseEvents.finishToolCalls());
-  for (const id of calls) events.push({ ...sseEvents.toolCallResult(id, 'ok'), delayAfter: 150 });
-  for (const c of chunk(buildReply(), CHUNK_CHARS)) events.push(sseEvents.messageChunk(c));
-  events.push(sseEvents.finishStop());
-  events.push(sseEvents.creditUsage());
-  return events;
-}
+// Paths worth naming in the log: the rest are the page-load fetches.
+const TOP_REQUEST_PATHS = 12;
 
 /** Self time per module and per function from a V8 CPU profile. */
 function summarizeProfile(p) {
@@ -107,29 +50,53 @@ function summarizeProfile(p) {
   return { byModule: top(byModule), byFunction: top(byFunction) };
 }
 
-/** Wall time per trace event name, for the renderer main thread only. */
+/**
+ * Wall time per trace event name, for the page's renderer main thread only.
+ * One trace carries every process (other renderers, the browser, the GPU)
+ * and every thread in them, and their durations overlap in time, so summing
+ * across them would count concurrent work as if it were serial.
+ */
 function summarizeTrace(events) {
+  const isTimeline = (e) => /devtools\.timeline/.test(e.cat || '');
+  // The page's main thread is the CrRendererMain that carried the most
+  // timeline events; an extension or about:blank renderer carries next to none.
+  const mains = new Set();
+  for (const e of events) {
+    if (e.ph === 'M' && e.name === 'thread_name' && e.args?.name === 'CrRendererMain') mains.add(`${e.pid}:${e.tid}`);
+  }
+  const load = new Map();
+  for (const e of events) {
+    const k = `${e.pid}:${e.tid}`;
+    if (mains.has(k) && isTimeline(e)) load.set(k, (load.get(k) || 0) + 1);
+  }
+  const main = [...load].sort((a, b) => b[1] - a[1])[0]?.[0];
+  if (!main) return [];
   const byName = new Map();
   const count = new Map();
+  // B/E pairs nest like a call stack, same name included, so each name keeps
+  // a stack of open starts and an E closes the innermost one.
   const open = new Map();
+  const add = (name, us) => {
+    byName.set(name, (byName.get(name) || 0) + us);
+    count.set(name, (count.get(name) || 0) + 1);
+  };
   for (const e of events) {
-    if (e.cat && !/devtools\.timeline/.test(e.cat)) continue;
+    if (`${e.pid}:${e.tid}` !== main || !isTimeline(e)) continue;
     if (e.ph === 'X' && typeof e.dur === 'number') {
-      byName.set(e.name, (byName.get(e.name) || 0) + e.dur);
-      count.set(e.name, (count.get(e.name) || 0) + 1);
+      add(e.name, e.dur);
     } else if (e.ph === 'B') {
-      open.set(`${e.name}:${e.tid}`, e.ts);
+      if (!open.has(e.name)) open.set(e.name, []);
+      open.get(e.name).push(e.ts);
     } else if (e.ph === 'E') {
-      const k = `${e.name}:${e.tid}`;
-      if (open.has(k)) {
-        byName.set(e.name, (byName.get(e.name) || 0) + (e.ts - open.get(k)));
-        count.set(e.name, (count.get(e.name) || 0) + 1);
-        open.delete(k);
-      }
+      const start = open.get(e.name)?.pop();
+      if (start !== undefined) add(e.name, e.ts - start);
     }
   }
   return [...byName].map(([k, us]) => [k, Math.round(us / 1000), count.get(k)]).sort((a, b) => b[1] - a[1]).slice(0, 25);
 }
+
+// PERF_HEADED=1 runs on the real display: headless rAF caps near 110 fps.
+test.use({ headless: !process.env.PERF_HEADED });
 
 test.describe('streaming smoothness', () => {
   test.skip(!process.env.PERF, 'set PERF=1 to run the smoothness benchmark');
@@ -140,15 +107,16 @@ test.describe('streaming smoothness', () => {
   });
 
   test('long reply at token cadence', async ({ page }, testInfo) => {
-    await page.addInitScript(PROBE_SOURCE);
-    await mockAPI(page, overrides());
+    await page.addInitScript(installSmoothProbe);
+    await mockAPI(page, chatViewOverrides());
     await configureSSE({
       method: 'GET',
       path: `/api/v1/threads/${TH}/messages/replay`,
       events: [sseEvents.replayDone()],
       delay: 10,
     });
-    const events = buildEvents();
+    const reply = buildReply();
+    const events = buildEvents(CHUNK_CHARS);
     await configureSSE({
       method: 'POST',
       path: `/api/v1/threads/${TH}/messages`,
@@ -201,21 +169,25 @@ test.describe('streaming smoothness', () => {
     }
     if (CPU_RATE > 1) await cdp.send('Emulation.setCPUThrottlingRate', { rate: 1 });
 
+    // Requests are part of every run, not a trace extra: a control that writes
+    // and refetches in a loop shows up here long before it shows up in the
+    // frame numbers, and the summary diffs the counts between labels.
+    const requests = [...reqs].sort((a, b) => b[1] - a[1]);
     const run = {
       label: label(),
       at: new Date().toISOString(),
-      config: { build: process.env.PERF_BUILD ? 'production' : 'dev', cpuRate: CPU_RATE, chunkDelayMs: CHUNK_DELAY_MS, chunkChars: CHUNK_CHARS, events: events.length, replyChars: buildReply().length },
+      config: { cpuRate: CPU_RATE, chunkDelayMs: CHUNK_DELAY_MS, chunkChars: CHUNK_CHARS, events: events.length, replyChars: reply.length },
       metrics: m,
+      requests,
       profile,
       trace,
     };
-    const dir = path.resolve('perf-results');
-    fs.mkdirSync(dir, { recursive: true });
-    const file = path.join(dir, `streaming-${run.label}-${Date.now()}-${testInfo.repeatEachIndex}.json`);
-    fs.writeFileSync(file, JSON.stringify(run, null, 2));
+    writeRun('streaming', run, testInfo);
 
     const { durationMs, fps, gapP95, gapMax, framesOver50, frozenMs, loafCount, loafMaxMs, mutations } = m;
     console.log(`[perf ${run.label}] ${durationMs}ms fps=${fps} p95=${gapP95}ms max=${gapMax}ms >50ms=${framesOver50} frozen=${frozenMs}ms loaf=${loafCount}/${loafMaxMs}ms mutations=${mutations}`);
+    console.log(`[perf ${run.label}] requests during the stream:`);
+    for (const [k, n] of requests.slice(0, TOP_REQUEST_PATHS)) console.log(`    ${String(n).padStart(6)}  ${k}`);
     if (profile) {
       console.log(`[perf ${run.label}] self time by module (ms):`);
       for (const [mod, ms] of profile.byModule.slice(0, 18)) console.log(`    ${String(ms).padStart(6)}  ${mod}`);
@@ -223,11 +195,11 @@ test.describe('streaming smoothness', () => {
       for (const [fn, ms] of profile.byFunction.slice(0, 18)) console.log(`    ${String(ms).padStart(6)}  ${fn}`);
     }
     if (trace) {
-      console.log(`[perf ${run.label}] requests during the stream:`);
-      for (const [k, n] of [...reqs].sort((a, b) => b[1] - a[1]).slice(0, 12)) console.log(`    ${String(n).padStart(6)}  ${k}`);
       console.log(`[perf ${run.label}] trace time by event (ms, count):`);
       for (const [name, ms, n] of trace) console.log(`    ${String(ms).padStart(6)}  ${String(n).padStart(6)}  ${name}`);
     }
-    expect(m.frames).toBeGreaterThan(0);
+    // The probe has to have sampled at a plausible rate for any of the gap
+    // percentiles to mean anything: under 10 fps average, they do not.
+    expect(m.frames).toBeGreaterThan(m.durationMs / 100);
   });
 });

--- a/web/e2e/perf/streaming-smoothness.spec.js
+++ b/web/e2e/perf/streaming-smoothness.spec.js
@@ -1,0 +1,177 @@
+/**
+ * Streaming smoothness benchmark. Not part of the default e2e run.
+ *
+ *   PERF=1 PERF_BUILD=1 PERF_LABEL=<label> pnpm exec playwright test e2e/perf --repeat-each=3
+ *   node scripts/perf-summary.mjs <baseline-label> <label>
+ *
+ * Streams a long reply through the mock SSE server at token cadence under CPU
+ * throttling and writes one JSON per run to perf-results/. PERF_BUILD serves a
+ * production build (the number that matters); without it the dev server runs,
+ * which is faster to iterate on but inflates React's share. PERF_PROFILE=1 adds
+ * a V8 CPU profile summarized per module, for finding what to fix next.
+ * PERF_CPU (default 4) is the CPU throttle; PERF_CHUNK_MS / PERF_CHUNK_CHARS set
+ * the token cadence. The label defaults to the git short sha.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { configureSSE, resetMockServer, mockAPI, test, expect } from '../fixtures.js';
+import { sampleWorkspace, sampleThread, sseEvents } from '../helpers/mockResponses.js';
+import { buildReply, buildReasoning, chunk, END_MARKER } from './streamFixture.js';
+import { PROBE_SOURCE } from './metrics.js';
+
+const WS = 'a0000001-0000-4000-8000-000000000001';
+const TH = 'b0000001-0000-4000-8000-000000000001';
+const CPU_RATE = Number(process.env.PERF_CPU || 4);
+const CHUNK_DELAY_MS = Number(process.env.PERF_CHUNK_MS || 8);
+const CHUNK_CHARS = Number(process.env.PERF_CHUNK_CHARS || 8);
+// PERF_PROFILE=1 also records a V8 CPU profile and writes self-time per module.
+const PROFILE = !!process.env.PERF_PROFILE;
+
+function label() {
+  if (process.env.PERF_LABEL) return process.env.PERF_LABEL;
+  try { return execSync('git rev-parse --short HEAD').toString().trim(); } catch { return 'unlabeled'; }
+}
+
+function overrides() {
+  const ws = sampleWorkspace();
+  const th = sampleThread();
+  return {
+    'GET /workspaces': { workspaces: [ws], total: 1, limit: 20, offset: 0 },
+    [`GET /workspaces/${WS}`]: ws,
+    'GET /threads': { threads: [th], total: 1 },
+    [`GET /threads/${TH}`]: th,
+    [`GET /threads/${TH}/status`]: { can_reconnect: false, status: 'idle' },
+    [`GET /threads/${TH}/turns`]: {
+      thread_id: TH,
+      turns: [{ turn_index: 0, edit_checkpoint_id: 'cp-edit-0', regenerate_checkpoint_id: 'cp-regen-0' }],
+      retry_checkpoint_id: 'cp-retry-0',
+    },
+    [`GET /workspaces/${WS}/files`]: { files: [] },
+  };
+}
+
+/** Reasoning, four tool calls, then the long reply, all at token cadence. */
+function buildEvents() {
+  const events = [];
+  events.push(sseEvents.messageChunk('start', 'reasoning_signal'));
+  for (const c of chunk(buildReasoning(), CHUNK_CHARS)) events.push(sseEvents.messageChunk(c, 'reasoning'));
+  events.push(sseEvents.messageChunk('complete', 'reasoning_signal'));
+  const calls = ['toolu_p1', 'toolu_p2', 'toolu_p3', 'toolu_p4'];
+  events.push(sseEvents.toolCalls(calls.map((id, i) => ({ name: 'bash', args: { command: `echo ${i}` }, id }))));
+  events.push(sseEvents.finishToolCalls());
+  for (const id of calls) events.push({ ...sseEvents.toolCallResult(id, 'ok'), delayAfter: 150 });
+  for (const c of chunk(buildReply(), CHUNK_CHARS)) events.push(sseEvents.messageChunk(c));
+  events.push(sseEvents.finishStop());
+  events.push(sseEvents.creditUsage());
+  return events;
+}
+
+/** Self time per module and per function from a V8 CPU profile. */
+function summarizeProfile(p) {
+  const nodes = new Map(p.nodes.map((n) => [n.id, n]));
+  const selfUs = new Map();
+  for (let i = 0; i < p.samples.length; i++) {
+    selfUs.set(p.samples[i], (selfUs.get(p.samples[i]) || 0) + (p.timeDeltas[i] || 0));
+  }
+  const moduleOf = (url) => {
+    if (!url) return '(native/anonymous)';
+    const dep = url.match(/\/node_modules\/\.vite\/deps\/([^?]+)/);
+    if (dep) return `dep:${dep[1].replace(/\.js$/, '')}`;
+    const nm = url.match(/\/node_modules\/(@[^/]+\/[^/]+|[^/]+)/);
+    if (nm) return `dep:${nm[1]}`;
+    const src = url.match(/\/src\/(.+?)(\?|$)/);
+    if (src) return `src/${src[1]}`;
+    return url.replace(/\?.*$/, '').split('/').slice(-2).join('/');
+  };
+  const byModule = new Map();
+  const byFunction = new Map();
+  for (const [id, us] of selfUs) {
+    const n = nodes.get(id);
+    if (!n) continue;
+    const { functionName, url, lineNumber } = n.callFrame;
+    const mod = moduleOf(url);
+    byModule.set(mod, (byModule.get(mod) || 0) + us);
+    const fn = `${functionName || '(anonymous)'} ${mod}:${lineNumber}`;
+    byFunction.set(fn, (byFunction.get(fn) || 0) + us);
+  }
+  const top = (m) => [...m].map(([k, us]) => [k, Math.round(us / 1000)]).sort((a, b) => b[1] - a[1]).slice(0, 40);
+  return { byModule: top(byModule), byFunction: top(byFunction) };
+}
+
+test.describe('streaming smoothness', () => {
+  test.skip(!process.env.PERF, 'set PERF=1 to run the smoothness benchmark');
+  test.setTimeout(180_000);
+
+  test.beforeEach(async () => {
+    await resetMockServer();
+  });
+
+  test('long reply at token cadence', async ({ page }, testInfo) => {
+    await page.addInitScript(PROBE_SOURCE);
+    await mockAPI(page, overrides());
+    await configureSSE({
+      method: 'GET',
+      path: `/api/v1/threads/${TH}/messages/replay`,
+      events: [sseEvents.replayDone()],
+      delay: 10,
+    });
+    const events = buildEvents();
+    await configureSSE({
+      method: 'POST',
+      path: `/api/v1/threads/${TH}/messages`,
+      events,
+      delay: CHUNK_DELAY_MS,
+    });
+
+    await page.goto(`/chat/t/${TH}`);
+    await page.waitForSelector('textarea', { timeout: 10000 });
+
+    const cdp = await page.context().newCDPSession(page);
+    if (CPU_RATE > 1) await cdp.send('Emulation.setCPUThrottlingRate', { rate: CPU_RATE });
+    if (PROFILE) {
+      await cdp.send('Profiler.enable');
+      await cdp.send('Profiler.setSamplingInterval', { interval: 500 });
+    }
+    // Let the throttled page settle before the clock starts.
+    await page.waitForTimeout(500);
+    if (PROFILE) await cdp.send('Profiler.start');
+
+    await page.locator('textarea').fill('Give me an earnings deep dive on NVDA');
+    await page.evaluate(() => window.__smooth.start(document.querySelector('main') || document.body));
+    await page.locator('button[aria-label="Send message"]').click();
+
+    await expect(page.getByText(END_MARKER)).toBeVisible({ timeout: 150_000 });
+    // The typewriter and the last fold animations run past the final chunk.
+    await page.waitForTimeout(1500);
+    const m = await page.evaluate(() => window.__smooth.stop());
+    let profile = null;
+    if (PROFILE) {
+      const { profile: p } = await cdp.send('Profiler.stop');
+      profile = summarizeProfile(p);
+    }
+    if (CPU_RATE > 1) await cdp.send('Emulation.setCPUThrottlingRate', { rate: 1 });
+
+    const run = {
+      label: label(),
+      at: new Date().toISOString(),
+      config: { build: process.env.PERF_BUILD ? 'production' : 'dev', cpuRate: CPU_RATE, chunkDelayMs: CHUNK_DELAY_MS, chunkChars: CHUNK_CHARS, events: events.length, replyChars: buildReply().length },
+      metrics: m,
+      profile,
+    };
+    const dir = path.resolve('perf-results');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `streaming-${run.label}-${Date.now()}-${testInfo.repeatEachIndex}.json`);
+    fs.writeFileSync(file, JSON.stringify(run, null, 2));
+
+    const { durationMs, fps, gapP95, gapMax, framesOver50, frozenMs, loafCount, loafMaxMs, mutations } = m;
+    console.log(`[perf ${run.label}] ${durationMs}ms fps=${fps} p95=${gapP95}ms max=${gapMax}ms >50ms=${framesOver50} frozen=${frozenMs}ms loaf=${loafCount}/${loafMaxMs}ms mutations=${mutations}`);
+    if (profile) {
+      console.log(`[perf ${run.label}] self time by module (ms):`);
+      for (const [mod, ms] of profile.byModule.slice(0, 18)) console.log(`    ${String(ms).padStart(6)}  ${mod}`);
+      console.log(`[perf ${run.label}] top functions (ms):`);
+      for (const [fn, ms] of profile.byFunction.slice(0, 18)) console.log(`    ${String(ms).padStart(6)}  ${fn}`);
+    }
+    expect(m.frames).toBeGreaterThan(0);
+  });
+});

--- a/web/e2e/perf/typewriter.spec.js
+++ b/web/e2e/perf/typewriter.spec.js
@@ -1,87 +1,35 @@
 /**
- * Typewriter feel benchmark. Not part of the default e2e run.
- *
- *   PERF=1 PERF_LABEL=<label> pnpm exec playwright test e2e/perf/typewriter.spec.js
- *
- * Streams the long reply at a fast model's pace twice: once as an even token
- * stream and once in lumps (what a proxy or a Redis batch delivers), and
- * records what the eye would notice in the reveal: how far the text trails
- * the model, how long it keeps typing after the model stopped, stalls, and
- * jumps. Writes one JSON per scenario to perf-results/.
+ * Typewriter feel: the long reply at a fast model's pace, once as an even
+ * token stream and once in lumps (what a proxy or a Redis batch delivers).
+ * Records what the eye notices in the reveal - how far the text trails the
+ * model, how long it keeps typing after the model stopped, stalls and jumps.
+ * Off by default; flags and invocations are in e2e/perf/README.md.
  */
-import fs from 'node:fs';
-import path from 'node:path';
-import { execSync } from 'node:child_process';
 import { configureSSE, resetMockServer, mockAPI, test, expect } from '../fixtures.js';
-import { sampleWorkspace, sampleThread, sseEvents } from '../helpers/mockResponses.js';
+import { sseEvents } from '../helpers/mockResponses.js';
+import { TH, chatViewOverrides } from '../helpers/chatScenario.js';
 import { buildReply, chunk, END_MARKER } from './streamFixture.js';
+import { installProbe } from './probe.js';
+import { label, writeRun } from './run.js';
 
-const WS = 'a0000001-0000-4000-8000-000000000001';
-const TH = 'b0000001-0000-4000-8000-000000000001';
 // ~500 chars/s, the pace of a fast model.
 const SCENARIOS = [
   { name: 'even', chars: 16, delayMs: 32 },
   { name: 'lumpy', chars: 160, delayMs: 320 },
 ];
 
-function label() {
-  if (process.env.PERF_LABEL) return process.env.PERF_LABEL;
-  try { return execSync('git rev-parse --short HEAD').toString().trim(); } catch { return 'unlabeled'; }
-}
-
-function overrides() {
-  const ws = sampleWorkspace();
-  const th = sampleThread();
-  return {
-    'GET /workspaces': { workspaces: [ws], total: 1, limit: 20, offset: 0 },
-    [`GET /workspaces/${WS}`]: ws,
-    'GET /threads': { threads: [th], total: 1 },
-    [`GET /threads/${TH}`]: th,
-    [`GET /threads/${TH}/status`]: { can_reconnect: false, status: 'idle' },
-    [`GET /threads/${TH}/turns`]: { thread_id: TH, turns: [{ turn_index: 0, edit_checkpoint_id: 'cp-edit-0', regenerate_checkpoint_id: 'cp-regen-0' }], retry_checkpoint_id: 'cp-retry-0' },
-    [`GET /workspaces/${WS}/files`]: { files: [] },
-  };
-}
-
-// Per frame: transcript text length and whether the composer still shows the
-// stop control (the stream is live). The stop control flips on the final
-// event, which stamps when the model finished without asking the client.
-const PROBE = `(() => {
-  const P = (window.__tw = { frames: [], running: false });
-  let scroller = null;
-  function findScroller() {
-    if (scroller && scroller.isConnected) return scroller;
-    const main = document.querySelector('main') || document.body;
-    for (const el of main.querySelectorAll('*')) {
-      const oy = getComputedStyle(el).overflowY;
-      if ((oy === 'auto' || oy === 'scroll') && el.scrollHeight > el.clientHeight + 50) { scroller = el; return el; }
-    }
-    return null;
-  }
-  function tick(ts) {
-    if (P.running) {
-      const main = document.querySelector('main') || document.body;
-      const live = !!document.querySelector('button[aria-label="Stop"]');
-      const sc = findScroller();
-      P.frames.push([ts, main.textContent.length, live ? 1 : 0, sc ? sc.scrollTop : -1, sc ? sc.scrollHeight - sc.clientHeight : -1]);
-    }
-    requestAnimationFrame(tick);
-  }
-  requestAnimationFrame(tick);
-  P.start = () => { P.frames = []; P.running = true; };
-  P.stop = () => { P.running = false; return P.frames; };
-})();`;
-
 function analyze(frames, replyChars) {
   // Resample to fixed 50 ms buckets so the numbers do not depend on the
   // machine's frame rate (headless Chromium runs rAF at ~110 fps, no vsync).
+  // The text measured is the message bubbles' alone (the probe's reply
+  // column), so composer, status and activity text never count as reveal.
   const STEP = 50;
   const t0 = frames[0][0], t1 = frames[frames.length - 1][0];
   const at = [];
   let j = 0;
   for (let t = t0; t <= t1; t += STEP) {
     while (j + 1 < frames.length && frames[j + 1][0] <= t) j++;
-    at.push([t, frames[j][1], frames[j][2]]);
+    at.push([t, frames[j][5], frames[j][2]]);
   }
   let first = -1, last = -1;
   for (let i = 1; i < at.length; i++) if (at[i][1] > at[i - 1][1]) { if (first < 0) first = i; last = i; }
@@ -126,13 +74,15 @@ function analyze(frames, replyChars) {
     // Buckets that showed more than three times the typical amount: a visible jump.
     jumps: gains.filter((g) => g > Math.max(3 * median, 60)).length,
     maxGainPer50ms: maxGain, maxGainAtMs: maxGainAt, medianGainPer50ms: median,
-    // Text still hidden when the model finished: what the final frame has to pop or type.
-    backlogAtModelDone: modelDoneAt === null ? at[last][1] - at[Math.max(first, last - 1)][1] : null,
+    // Text still hidden when the model finished, against what finally
+    // rendered rather than the Markdown source, whose syntax never shows:
+    // what the final frame has to pop or type (null: stop control never seen).
+    backlogAtModelDone: modelDoneAt === null ? null : at[last][1] - at[liveEnd][1],
     // Unevenness of the reveal, bucket to bucket (0 = perfectly steady).
     speedCv: +(sd / mean).toFixed(2),
     meanCharsPerSec: Math.round(mean * 1000 / STEP),
     frameGapP95: +fgaps[Math.floor(fgaps.length * 0.95)].toFixed(1),
-    liveFrames, replyChars, follow,
+    frames: frames.length, liveFrames, replyChars, follow,
   };
 }
 
@@ -146,8 +96,12 @@ test.describe('typewriter feel', () => {
 
   for (const sc of SCENARIOS) {
     test(`fast model, ${sc.name} arrival`, async ({ page }, testInfo) => {
-      await page.addInitScript(PROBE);
-      await mockAPI(page, overrides());
+      // `live` adds the stop-control read per frame, which is what stamps when
+      // the model finished, and `reply` the bubble-only text length the reveal
+      // is measured on; the painted and scroll-log passes stay off so the
+      // probe costs the reveal as little as possible.
+      await page.addInitScript(installProbe, { live: true, reply: true });
+      await mockAPI(page, chatViewOverrides());
       await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH}/messages/replay`, events: [sseEvents.replayDone()], delay: 10 });
       const reply = buildReply();
       const events = [];
@@ -160,18 +114,18 @@ test.describe('typewriter feel', () => {
       await page.waitForSelector('textarea', { timeout: 10000 });
       await page.waitForTimeout(500);
       await page.locator('textarea').fill('Give me an earnings deep dive on NVDA');
-      await page.evaluate(() => window.__tw.start());
+      await page.evaluate(() => window.__probe.mark('send'));
       await page.locator('button[aria-label="Send message"]').click();
       await expect(page.getByText(END_MARKER)).toBeVisible({ timeout: 150_000 });
       await page.waitForTimeout(1500);
-      const frames = await page.evaluate(() => window.__tw.stop());
+      const frames = await page.evaluate(() => window.__probe.framesSince('send'));
       const m = analyze(frames, reply.length);
       const run = { label: label(), scenario: sc, at: new Date().toISOString(), metrics: m };
-      const dir = path.resolve('perf-results');
-      fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(path.join(dir, `typewriter-${sc.name}-${run.label}-${Date.now()}-${testInfo.repeatEachIndex}.json`), JSON.stringify(run, null, 2));
+      writeRun(`typewriter-${sc.name}`, run, testInfo);
       console.log(`[typewriter ${sc.name} ${run.label}] ${JSON.stringify(m)}`);
-      expect(m).not.toBeNull();
+      // The sampler has to have run for the bucketed numbers to mean anything:
+      // under 10 fps across the reveal, they are noise.
+      expect(m.frames).toBeGreaterThan(m.revealMs / 100);
     });
   }
 });

--- a/web/e2e/perf/typewriter.spec.js
+++ b/web/e2e/perf/typewriter.spec.js
@@ -48,11 +48,22 @@ function overrides() {
 // event, which stamps when the model finished without asking the client.
 const PROBE = `(() => {
   const P = (window.__tw = { frames: [], running: false });
+  let scroller = null;
+  function findScroller() {
+    if (scroller && scroller.isConnected) return scroller;
+    const main = document.querySelector('main') || document.body;
+    for (const el of main.querySelectorAll('*')) {
+      const oy = getComputedStyle(el).overflowY;
+      if ((oy === 'auto' || oy === 'scroll') && el.scrollHeight > el.clientHeight + 50) { scroller = el; return el; }
+    }
+    return null;
+  }
   function tick(ts) {
     if (P.running) {
       const main = document.querySelector('main') || document.body;
       const live = !!document.querySelector('button[aria-label="Stop"]');
-      P.frames.push([ts, main.textContent.length, live ? 1 : 0]);
+      const sc = findScroller();
+      P.frames.push([ts, main.textContent.length, live ? 1 : 0, sc ? sc.scrollTop : -1, sc ? sc.scrollHeight - sc.clientHeight : -1]);
     }
     requestAnimationFrame(tick);
   }
@@ -92,6 +103,18 @@ function analyze(frames, replyChars) {
   const median = sorted[Math.floor(sorted.length / 2)];
   const mean = gains.reduce((a, b) => a + b, 0) / gains.length;
   const sd = Math.sqrt(gains.reduce((a, b) => a + (b - mean) ** 2, 0) / gains.length);
+  // Follow scroll while the model is talking: how far the view sits above the
+  // bottom, how often it moves backwards, and how uneven its motion is.
+  const live = frames.filter((f) => f[2] === 1 && f[3] >= 0);
+  const dist = live.map((f) => f[4] - f[3]).sort((a, b) => a - b);
+  let back = 0; const moves = [];
+  for (let i = 1; i < live.length; i++) { const d = live[i][3] - live[i - 1][3]; if (d < -1) back++; if (d > 0) moves.push(d); }
+  const mmean = moves.reduce((a, b) => a + b, 0) / (moves.length || 1);
+  const msd = Math.sqrt(moves.reduce((a, b) => a + (b - mmean) ** 2, 0) / (moves.length || 1));
+  const follow = live.length ? {
+    distP50: Math.round(dist[Math.floor(dist.length * 0.5)]), distP95: Math.round(dist[Math.floor(dist.length * 0.95)]), distMax: Math.round(dist[dist.length - 1]),
+    backwardFrames: back, movingFrames: moves.length, moveCv: +(msd / (mmean || 1)).toFixed(2), maxMovePx: Math.round(Math.max(...moves, 0)),
+  } : null;
   const fgaps = [];
   for (let i = 1; i < frames.length; i++) fgaps.push(frames[i][0] - frames[i - 1][0]);
   fgaps.sort((a, b) => a - b);
@@ -109,7 +132,7 @@ function analyze(frames, replyChars) {
     speedCv: +(sd / mean).toFixed(2),
     meanCharsPerSec: Math.round(mean * 1000 / STEP),
     frameGapP95: +fgaps[Math.floor(fgaps.length * 0.95)].toFixed(1),
-    liveFrames, replyChars,
+    liveFrames, replyChars, follow,
   };
 }
 

--- a/web/e2e/perf/typewriter.spec.js
+++ b/web/e2e/perf/typewriter.spec.js
@@ -1,0 +1,154 @@
+/**
+ * Typewriter feel benchmark. Not part of the default e2e run.
+ *
+ *   PERF=1 PERF_LABEL=<label> pnpm exec playwright test e2e/perf/typewriter.spec.js
+ *
+ * Streams the long reply at a fast model's pace twice: once as an even token
+ * stream and once in lumps (what a proxy or a Redis batch delivers), and
+ * records what the eye would notice in the reveal: how far the text trails
+ * the model, how long it keeps typing after the model stopped, stalls, and
+ * jumps. Writes one JSON per scenario to perf-results/.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { configureSSE, resetMockServer, mockAPI, test, expect } from '../fixtures.js';
+import { sampleWorkspace, sampleThread, sseEvents } from '../helpers/mockResponses.js';
+import { buildReply, chunk, END_MARKER } from './streamFixture.js';
+
+const WS = 'a0000001-0000-4000-8000-000000000001';
+const TH = 'b0000001-0000-4000-8000-000000000001';
+// ~500 chars/s, the pace of a fast model.
+const SCENARIOS = [
+  { name: 'even', chars: 16, delayMs: 32 },
+  { name: 'lumpy', chars: 160, delayMs: 320 },
+];
+
+function label() {
+  if (process.env.PERF_LABEL) return process.env.PERF_LABEL;
+  try { return execSync('git rev-parse --short HEAD').toString().trim(); } catch { return 'unlabeled'; }
+}
+
+function overrides() {
+  const ws = sampleWorkspace();
+  const th = sampleThread();
+  return {
+    'GET /workspaces': { workspaces: [ws], total: 1, limit: 20, offset: 0 },
+    [`GET /workspaces/${WS}`]: ws,
+    'GET /threads': { threads: [th], total: 1 },
+    [`GET /threads/${TH}`]: th,
+    [`GET /threads/${TH}/status`]: { can_reconnect: false, status: 'idle' },
+    [`GET /threads/${TH}/turns`]: { thread_id: TH, turns: [{ turn_index: 0, edit_checkpoint_id: 'cp-edit-0', regenerate_checkpoint_id: 'cp-regen-0' }], retry_checkpoint_id: 'cp-retry-0' },
+    [`GET /workspaces/${WS}/files`]: { files: [] },
+  };
+}
+
+// Per frame: transcript text length and whether the composer still shows the
+// stop control (the stream is live). The stop control flips on the final
+// event, which stamps when the model finished without asking the client.
+const PROBE = `(() => {
+  const P = (window.__tw = { frames: [], running: false });
+  function tick(ts) {
+    if (P.running) {
+      const main = document.querySelector('main') || document.body;
+      const live = !!document.querySelector('button[aria-label="Stop"]');
+      P.frames.push([ts, main.textContent.length, live ? 1 : 0]);
+    }
+    requestAnimationFrame(tick);
+  }
+  requestAnimationFrame(tick);
+  P.start = () => { P.frames = []; P.running = true; };
+  P.stop = () => { P.running = false; return P.frames; };
+})();`;
+
+function analyze(frames, replyChars) {
+  // Resample to fixed 50 ms buckets so the numbers do not depend on the
+  // machine's frame rate (headless Chromium runs rAF at ~110 fps, no vsync).
+  const STEP = 50;
+  const t0 = frames[0][0], t1 = frames[frames.length - 1][0];
+  const at = [];
+  let j = 0;
+  for (let t = t0; t <= t1; t += STEP) {
+    while (j + 1 < frames.length && frames[j + 1][0] <= t) j++;
+    at.push([t, frames[j][1], frames[j][2]]);
+  }
+  let first = -1, last = -1;
+  for (let i = 1; i < at.length; i++) if (at[i][1] > at[i - 1][1]) { if (first < 0) first = i; last = i; }
+  if (first < 0) return null;
+  const liveFrames = frames.filter((f) => f[2]).length;
+  let liveEnd = -1;
+  for (let i = first; i < at.length; i++) if (at[i][2] === 0 && at[i - 1][2] === 1) { liveEnd = i; break; }
+  const modelDoneAt = liveEnd > 0 ? at[liveEnd][0] : null;
+  const gains = [];
+  let stalls = 0, stallBuckets = 0, run = 0, maxGain = 0, maxGainAt = 0, firstStallAt = -1;
+  for (let i = first; i <= last; i++) {
+    const g = at[i][1] - at[i - 1][1];
+    gains.push(g);
+    if (g > maxGain) { maxGain = g; maxGainAt = Math.round(at[i][0] - at[first][0]); }
+    // A stall: no visible progress for 150 ms or more while the model is still talking.
+    if (g <= 0 && at[i][2] === 1) { run++; if (run === 3) { stalls++; if (firstStallAt < 0) firstStallAt = Math.round(at[i][0] - at[first][0]); } if (run >= 3) stallBuckets++; } else run = 0;
+  }
+  const sorted = gains.slice().sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)];
+  const mean = gains.reduce((a, b) => a + b, 0) / gains.length;
+  const sd = Math.sqrt(gains.reduce((a, b) => a + (b - mean) ** 2, 0) / gains.length);
+  const fgaps = [];
+  for (let i = 1; i < frames.length; i++) fgaps.push(frames[i][0] - frames[i - 1][0]);
+  fgaps.sort((a, b) => a - b);
+  return {
+    revealMs: Math.round(at[last][0] - at[first][0]),
+    // How long the text keeps typing after the model stopped (null: stop control never seen).
+    tailAfterModelMs: modelDoneAt === null ? null : Math.round(at[last][0] - modelDoneAt),
+    stalls, stallMs: stallBuckets * STEP, firstStallAtMs: firstStallAt,
+    // Buckets that showed more than three times the typical amount: a visible jump.
+    jumps: gains.filter((g) => g > Math.max(3 * median, 60)).length,
+    maxGainPer50ms: maxGain, maxGainAtMs: maxGainAt, medianGainPer50ms: median,
+    // Text still hidden when the model finished: what the final frame has to pop or type.
+    backlogAtModelDone: modelDoneAt === null ? at[last][1] - at[Math.max(first, last - 1)][1] : null,
+    // Unevenness of the reveal, bucket to bucket (0 = perfectly steady).
+    speedCv: +(sd / mean).toFixed(2),
+    meanCharsPerSec: Math.round(mean * 1000 / STEP),
+    frameGapP95: +fgaps[Math.floor(fgaps.length * 0.95)].toFixed(1),
+    liveFrames, replyChars,
+  };
+}
+
+// Headed gives real vsync; the reveal is judged at the screen's refresh rate.
+test.use({ headless: !process.env.PERF_HEADED });
+
+test.describe('typewriter feel', () => {
+  test.skip(!process.env.PERF, 'set PERF=1 to run the typewriter benchmark');
+  test.setTimeout(180_000);
+  test.beforeEach(async () => { await resetMockServer(); });
+
+  for (const sc of SCENARIOS) {
+    test(`fast model, ${sc.name} arrival`, async ({ page }, testInfo) => {
+      await page.addInitScript(PROBE);
+      await mockAPI(page, overrides());
+      await configureSSE({ method: 'GET', path: `/api/v1/threads/${TH}/messages/replay`, events: [sseEvents.replayDone()], delay: 10 });
+      const reply = buildReply();
+      const events = [];
+      for (const c of chunk(reply, sc.chars)) events.push(sseEvents.messageChunk(c));
+      events.push({ ...sseEvents.finishStop(), delayAfter: 0 });
+      events.push(sseEvents.creditUsage());
+      await configureSSE({ method: 'POST', path: `/api/v1/threads/${TH}/messages`, events, delay: sc.delayMs });
+
+      await page.goto(`/chat/t/${TH}`);
+      await page.waitForSelector('textarea', { timeout: 10000 });
+      await page.waitForTimeout(500);
+      await page.locator('textarea').fill('Give me an earnings deep dive on NVDA');
+      await page.evaluate(() => window.__tw.start());
+      await page.locator('button[aria-label="Send message"]').click();
+      await expect(page.getByText(END_MARKER)).toBeVisible({ timeout: 150_000 });
+      await page.waitForTimeout(1500);
+      const frames = await page.evaluate(() => window.__tw.stop());
+      const m = analyze(frames, reply.length);
+      const run = { label: label(), scenario: sc, at: new Date().toISOString(), metrics: m };
+      const dir = path.resolve('perf-results');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, `typewriter-${sc.name}-${run.label}-${Date.now()}-${testInfo.repeatEachIndex}.json`), JSON.stringify(run, null, 2));
+      console.log(`[typewriter ${sc.name} ${run.label}] ${JSON.stringify(m)}`);
+      expect(m).not.toBeNull();
+    });
+  }
+});

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -7,6 +7,10 @@ const E2E_PORT = 5176;
 // dev server boots, not per test. So it gets a server of its own rather than a
 // flag some spec could flip.
 const E2E_AUTH_PORT = 5177;
+// PERF_BUILD only means anything under PERF: the benchmarks are the one caller
+// that wants a production build, and a PERF_BUILD left in the shell must not
+// make an ordinary e2e run wait four minutes for a vite build first.
+const PERF_BUILD = !!process.env.PERF && !!process.env.PERF_BUILD;
 
 export default defineConfig({
   testDir: './e2e',
@@ -21,8 +25,14 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: `npm run dev -- --port ${E2E_PORT}`,
+      // PERF=1 PERF_BUILD=1 serves a production build instead of the dev server,
+      // so the smoothness benchmark (e2e/perf) measures shipped code rather than
+      // the dev JSX runtime and HMR client. Everything else is identical.
+      command: PERF_BUILD
+        ? `npx vite build --outDir dist-perf && npx vite preview --port ${E2E_PORT} --outDir dist-perf`
+        : `npm run dev -- --port ${E2E_PORT}`,
       port: E2E_PORT,
+      timeout: PERF_BUILD ? 240_000 : 60_000,
       // Always start fresh: the env block below is load-bearing (forces OSS mode
       // and clears Supabase vars). If we reused an existing server, a developer's
       // pre-running `pnpm dev` with personal .env would silently override these.

--- a/web/scripts/perf-summary.mjs
+++ b/web/scripts/perf-summary.mjs
@@ -72,6 +72,6 @@ for (const l of labels) {
   console.log(`\nworst long animation frames (${l}, first run):`);
   for (const e of top) {
     const s = e.scripts.map((x) => `${x.fn || '?'}@${(x.src || '').split('/').pop().slice(0, 40)} ${x.dur}ms`).join('; ');
-    console.log(`  ${String(e.dur).padStart(5)} ms  ${s}`);
+    console.log(`  ${String(e.dur).padStart(5)} ms  at ${String(e.at ?? '?').padStart(6)} ms  style+layout ${String(e.styleLayout ?? '?').padStart(3)} ms  ${s}`);
   }
 }

--- a/web/scripts/perf-summary.mjs
+++ b/web/scripts/perf-summary.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Summarize streaming benchmark runs: median per label, side by side.
+ *
+ *   node scripts/perf-summary.mjs            # every label in perf-results/
+ *   node scripts/perf-summary.mjs base opt1  # only these, in this order
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const dir = path.resolve('perf-results');
+const want = process.argv.slice(2);
+const runs = fs.existsSync(dir)
+  ? fs.readdirSync(dir).filter((f) => f.startsWith('streaming-') && f.endsWith('.json')).map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')))
+  : [];
+if (!runs.length) { console.log('no runs in perf-results/'); process.exit(0); }
+
+const byLabel = new Map();
+for (const r of runs) {
+  if (want.length && !want.includes(r.label)) continue;
+  if (!byLabel.has(r.label)) byLabel.set(r.label, []);
+  byLabel.get(r.label).push(r);
+}
+const labels = want.length ? want.filter((l) => byLabel.has(l)) : [...byLabel.keys()];
+
+const median = (xs) => { const s = xs.slice().sort((a, b) => a - b); return s.length ? s[Math.floor(s.length / 2)] : 0; };
+const ROWS = [
+  ['durationMs', 'stream duration (ms)', 'lower'],
+  ['fps', 'frames per second', 'higher'],
+  ['gapP50', 'frame gap p50 (ms)', 'lower'],
+  ['gapP95', 'frame gap p95 (ms)', 'lower'],
+  ['gapP99', 'frame gap p99 (ms)', 'lower'],
+  ['gapMax', 'worst frame gap (ms)', 'lower'],
+  ['framesOver33', 'frames over 33 ms', 'lower'],
+  ['framesOver50', 'frames over 50 ms', 'lower'],
+  ['framesOver100', 'frames over 100 ms', 'lower'],
+  ['frozenMs', 'time frozen (ms)', 'lower'],
+  ['loafCount', 'long animation frames', 'lower'],
+  ['loafTotalMs', 'LoAF total (ms)', 'lower'],
+  ['loafBlockingMs', 'LoAF blocking (ms)', 'lower'],
+  ['loafMaxMs', 'LoAF worst (ms)', 'lower'],
+  ['longTasks', 'long tasks', 'lower'],
+  ['mutations', 'DOM mutation records', 'lower'],
+  ['nodesAdded', 'DOM nodes added', 'lower'],
+  ['nodesRemoved', 'DOM nodes removed', 'lower'],
+  ['charDataChanges', 'text node edits', 'lower'],
+];
+
+const cfg = byLabel.get(labels[0])[0].config;
+console.log(`config: ${cfg.build || 'dev'} build, cpu x${cfg.cpuRate}, ${cfg.events} events, ${cfg.chunkChars} chars every ${cfg.chunkDelayMs} ms, reply ${cfg.replyChars} chars`);
+console.log('runs per label: ' + labels.map((l) => `${l}=${byLabel.get(l).length}`).join(', '));
+console.log('');
+const w = Math.max(...labels.map((l) => l.length), 10);
+console.log('metric'.padEnd(26) + labels.map((l) => l.padStart(w + 2)).join('') + (labels.length > 1 ? '   vs first' : ''));
+for (const [key, name, better] of ROWS) {
+  const vals = labels.map((l) => median(byLabel.get(l).map((r) => r.metrics[key] ?? 0)));
+  let delta = '';
+  if (labels.length > 1) {
+    const a = vals[0]; const b = vals[vals.length - 1];
+    if (a) {
+      const pct = ((b - a) / a) * 100;
+      const good = better === 'lower' ? pct < 0 : pct > 0;
+      delta = `   ${pct >= 0 ? '+' : ''}${pct.toFixed(0)}% ${Math.abs(pct) < 3 ? '' : good ? 'better' : 'worse'}`;
+    }
+  }
+  console.log(name.padEnd(26) + vals.map((v) => String(v).padStart(w + 2)).join('') + delta);
+}
+
+for (const l of labels) {
+  const top = byLabel.get(l)[0].metrics.loafTop || [];
+  if (!top.length) continue;
+  console.log(`\nworst long animation frames (${l}, first run):`);
+  for (const e of top) {
+    const s = e.scripts.map((x) => `${x.fn || '?'}@${(x.src || '').split('/').pop().slice(0, 40)} ${x.dur}ms`).join('; ');
+    console.log(`  ${String(e.dur).padStart(5)} ms  ${s}`);
+  }
+}

--- a/web/scripts/perf-summary.mjs
+++ b/web/scripts/perf-summary.mjs
@@ -1,30 +1,20 @@
 #!/usr/bin/env node
 /**
- * Summarize streaming benchmark runs: median per label, side by side.
+ * Summarize benchmark runs from perf-results/: median per label, side by side.
  *
- *   node scripts/perf-summary.mjs            # every label in perf-results/
- *   node scripts/perf-summary.mjs base opt1  # only these, in this order
+ *   node scripts/perf-summary.mjs                    # every label
+ *   node scripts/perf-summary.mjs base opt1          # only these, in this order
+ *   node scripts/perf-summary.mjs --kind typewriter  # the typewriter runs instead
+ *
+ * A delta only means something between runs of the same benchmark, so each
+ * run's config is fingerprinted per label: if two labels were measured under
+ * different flags the configs are printed and the exit code is non-zero,
+ * rather than a percentage that reads as a win.
  */
 import fs from 'node:fs';
 import path from 'node:path';
 
-const dir = path.resolve('perf-results');
-const want = process.argv.slice(2);
-const runs = fs.existsSync(dir)
-  ? fs.readdirSync(dir).filter((f) => f.startsWith('streaming-') && f.endsWith('.json')).map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')))
-  : [];
-if (!runs.length) { console.log('no runs in perf-results/'); process.exit(0); }
-
-const byLabel = new Map();
-for (const r of runs) {
-  if (want.length && !want.includes(r.label)) continue;
-  if (!byLabel.has(r.label)) byLabel.set(r.label, []);
-  byLabel.get(r.label).push(r);
-}
-const labels = want.length ? want.filter((l) => byLabel.has(l)) : [...byLabel.keys()];
-
-const median = (xs) => { const s = xs.slice().sort((a, b) => a - b); return s.length ? s[Math.floor(s.length / 2)] : 0; };
-const ROWS = [
+const STREAMING_ROWS = [
   ['durationMs', 'stream duration (ms)', 'lower'],
   ['fps', 'frames per second', 'higher'],
   ['gapP50', 'frame gap p50 (ms)', 'lower'],
@@ -44,34 +34,154 @@ const ROWS = [
   ['nodesAdded', 'DOM nodes added', 'lower'],
   ['nodesRemoved', 'DOM nodes removed', 'lower'],
   ['charDataChanges', 'text node edits', 'lower'],
+  ['attrChanges', 'attribute changes', 'lower'],
 ];
 
-const cfg = byLabel.get(labels[0])[0].config;
-console.log(`config: ${cfg.build || 'dev'} build, cpu x${cfg.cpuRate}, ${cfg.events} events, ${cfg.chunkChars} chars every ${cfg.chunkDelayMs} ms, reply ${cfg.replyChars} chars`);
-console.log('runs per label: ' + labels.map((l) => `${l}=${byLabel.get(l).length}`).join(', '));
-console.log('');
-const w = Math.max(...labels.map((l) => l.length), 10);
-console.log('metric'.padEnd(26) + labels.map((l) => l.padStart(w + 2)).join('') + (labels.length > 1 ? '   vs first' : ''));
-for (const [key, name, better] of ROWS) {
-  const vals = labels.map((l) => median(byLabel.get(l).map((r) => r.metrics[key] ?? 0)));
-  let delta = '';
-  if (labels.length > 1) {
-    const a = vals[0]; const b = vals[vals.length - 1];
-    if (a) {
-      const pct = ((b - a) / a) * 100;
-      const good = better === 'lower' ? pct < 0 : pct > 0;
-      delta = `   ${pct >= 0 ? '+' : ''}${pct.toFixed(0)}% ${Math.abs(pct) < 3 ? '' : good ? 'better' : 'worse'}`;
-    }
-  }
-  console.log(name.padEnd(26) + vals.map((v) => String(v).padStart(w + 2)).join('') + delta);
+const TYPEWRITER_ROWS = [
+  ['revealMs', 'reveal duration (ms)', 'lower'],
+  ['tailAfterModelMs', 'typing past model (ms)', 'lower'],
+  ['stalls', 'stalls', 'lower'],
+  ['stallMs', 'time stalled (ms)', 'lower'],
+  ['jumps', 'visible jumps', 'lower'],
+  ['maxGainPer50ms', 'worst gain per 50 ms', 'lower'],
+  ['medianGainPer50ms', 'median gain per 50 ms', 'higher'],
+  ['speedCv', 'reveal unevenness (cv)', 'lower'],
+  ['meanCharsPerSec', 'mean chars per second', 'higher'],
+  ['frameGapP95', 'frame gap p95 (ms)', 'lower'],
+  ['frames', 'frames sampled', 'higher'],
+  ['follow.distP50', 'follow gap p50 (px)', 'lower'],
+  ['follow.distP95', 'follow gap p95 (px)', 'lower'],
+  ['follow.backwardFrames', 'backward scroll frames', 'lower'],
+  ['follow.moveCv', 'scroll unevenness (cv)', 'lower'],
+  ['follow.maxMovePx', 'worst scroll step (px)', 'lower'],
+];
+
+// The run's execution mode (see run.js `mode`): part of the fingerprint, since a
+// production build, a real display, or an attached profiler each move the numbers.
+const modeText = (m) => (m ? `${m.build} build, ${m.headed ? 'headed' : 'headless'}${m.profile ? ', profiled' : ''}${m.trace ? ', traced' : ''}` : 'unknown mode');
+
+const KINDS = {
+  streaming: {
+    prefix: 'streaming-',
+    rows: STREAMING_ROWS,
+    // One table: every streaming run is the same scenario.
+    groupOf: () => '',
+    configOf: (r) => ({ ...r.config, mode: r.mode }),
+    describe: (c) => (c.cpuRate != null ? `${modeText(c.mode)}, cpu x${c.cpuRate}, ${c.events} events, ${c.chunkChars} chars every ${c.chunkDelayMs} ms, reply ${c.replyChars} chars` : '(no config recorded)'),
+  },
+  typewriter: {
+    prefix: 'typewriter-',
+    rows: TYPEWRITER_ROWS,
+    // One table per arrival pattern: the two scenarios are different benchmarks.
+    groupOf: (r) => r.scenario?.name ?? '(no scenario)',
+    configOf: (r) => ({ ...r.scenario, mode: r.mode }),
+    describe: (c) => (c.name ? `${modeText(c.mode)}, ${c.name} arrival, ${c.chars} chars every ${c.delayMs} ms` : '(no scenario recorded)'),
+  },
+};
+
+const argv = process.argv.slice(2);
+let kind = 'streaming';
+const want = [];
+for (let i = 0; i < argv.length; i++) {
+  if (argv[i] === '--kind') { kind = argv[++i]; continue; }
+  if (argv[i].startsWith('--kind=')) { kind = argv[i].slice('--kind='.length); continue; }
+  want.push(argv[i]);
+}
+const spec = KINDS[kind];
+if (!spec) {
+  console.error(`unknown --kind ${kind}; expected one of ${Object.keys(KINDS).join(', ')}`);
+  process.exit(2);
 }
 
-for (const l of labels) {
-  const top = byLabel.get(l)[0].metrics.loafTop || [];
-  if (!top.length) continue;
-  console.log(`\nworst long animation frames (${l}, first run):`);
-  for (const e of top) {
-    const s = e.scripts.map((x) => `${x.fn || '?'}@${(x.src || '').split('/').pop().slice(0, 40)} ${x.dur}ms`).join('; ');
-    console.log(`  ${String(e.dur).padStart(5)} ms  at ${String(e.at ?? '?').padStart(6)} ms  style+layout ${String(e.styleLayout ?? '?').padStart(3)} ms  ${s}`);
+const dir = path.resolve('perf-results');
+const runs = fs.existsSync(dir)
+  ? fs.readdirSync(dir).filter((f) => f.startsWith(spec.prefix) && f.endsWith('.json')).map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')))
+  : [];
+
+const groups = new Map();
+for (const r of runs) {
+  if (want.length && !want.includes(r.label)) continue;
+  const g = spec.groupOf(r);
+  if (!groups.has(g)) groups.set(g, new Map());
+  const byLabel = groups.get(g);
+  if (!byLabel.has(r.label)) byLabel.set(r.label, []);
+  byLabel.get(r.label).push(r);
+}
+if (!groups.size) {
+  if (!runs.length) console.log(`no ${kind} runs in perf-results/`);
+  else console.log(`no ${kind} runs for ${want.join(', ')}; available labels: ${[...new Set(runs.map((r) => r.label))].join(', ')}`);
+  process.exit(0);
+}
+
+// A null sample is a measurement the probe could not take (the typewriter
+// tail when the stop control never showed), not a zero: drop it, and report
+// n/a when nothing measurable is left rather than a median of zeros.
+const median = (xs) => {
+  const s = xs.filter((x) => typeof x === 'number').sort((a, b) => a - b);
+  return s.length ? s[Math.floor(s.length / 2)] : 'n/a';
+};
+const get = (o, key) => key.split('.').reduce((a, k) => (a == null ? a : a[k]), o);
+/** Key-order-independent JSON, so two configs written in a different order still match. */
+const stable = (v) => {
+  if (v === null || typeof v !== 'object') return JSON.stringify(v ?? null);
+  if (Array.isArray(v)) return `[${v.map(stable).join(',')}]`;
+  return `{${Object.keys(v).sort().map((k) => `${JSON.stringify(k)}:${stable(v[k])}`).join(',')}}`;
+};
+
+for (const [group, byLabel] of [...groups].sort((a, b) => String(a[0]).localeCompare(String(b[0])))) {
+  const labels = want.length ? want.filter((l) => byLabel.has(l)) : [...byLabel.keys()];
+  if (group) console.log(`\n=== ${group} ===`);
+  const fingerprints = new Set();
+  for (const l of labels) {
+    const fps = new Set(byLabel.get(l).map((r) => stable(spec.configOf(r))));
+    for (const f of fps) fingerprints.add(f);
+    console.log(`config ${l}: ${spec.describe(spec.configOf(byLabel.get(l)[0]))}${fps.size > 1 ? '   (this label mixes configs)' : ''}`);
+  }
+  if (fingerprints.size > 1) {
+    console.log('these runs were not measured the same way, so a delta would compare different benchmarks; rerun the odd label with the same flags');
+    process.exitCode = 1;
+    continue;
+  }
+  console.log('runs per label: ' + labels.map((l) => `${l}=${byLabel.get(l).length}`).join(', '));
+  console.log('');
+
+  const w = Math.max(...labels.map((l) => l.length), 10);
+  const delta = (vals, better) => {
+    if (labels.length < 2) return '';
+    const a = vals[0]; const b = vals[vals.length - 1];
+    if (!a || typeof a !== 'number' || typeof b !== 'number') return '';
+    const pct = ((b - a) / a) * 100;
+    const good = better === 'lower' ? pct < 0 : pct > 0;
+    return `   ${pct >= 0 ? '+' : ''}${pct.toFixed(0)}% ${Math.abs(pct) < 3 ? '' : good ? 'better' : 'worse'}`;
+  };
+  const line = (name, vals, suffix) => console.log(name.padEnd(26) + vals.map((v) => String(v).padStart(w + 2)).join('') + suffix);
+
+  console.log('metric'.padEnd(26) + labels.map((l) => l.padStart(w + 2)).join('') + (labels.length > 1 ? '   vs first' : ''));
+  for (const [key, name, better] of spec.rows) {
+    const vals = labels.map((l) => median(byLabel.get(l).map((r) => get(r.metrics, key))));
+    line(name, vals, delta(vals, better));
+  }
+
+  // Requests issued during the run, when the benchmark recorded them: a
+  // control that writes and refetches in a loop shows up here long before it
+  // shows up in the frame numbers.
+  const paths = [...new Set(labels.flatMap((l) => byLabel.get(l).flatMap((r) => (r.requests || []).map(([p]) => p))))];
+  if (paths.length) {
+    console.log('\nrequests (median per label)');
+    const rows = paths
+      .map((p) => ({ p, vals: labels.map((l) => median(byLabel.get(l).map((r) => new Map(r.requests || []).get(p) || 0))) }))
+      .sort((a, b) => Math.max(...b.vals) - Math.max(...a.vals))
+      .slice(0, 12);
+    for (const { p, vals } of rows) line(p.length > 25 ? p.slice(0, 25) : p, vals, delta(vals, 'lower'));
+  }
+
+  for (const l of labels) {
+    const top = byLabel.get(l)[0].metrics?.loafTop || [];
+    if (!top.length) continue;
+    console.log(`\nworst long animation frames (${l}, first run):`);
+    for (const e of top) {
+      const s = e.scripts.map((x) => `${x.fn || '?'}@${(x.src || '').split('/').pop().slice(0, 40)} ${x.dur}ms`).join('; ');
+      console.log(`  ${String(e.dur).padStart(5)} ms  at ${String(e.at ?? '?').padStart(6)} ms  style+layout ${String(e.styleLayout ?? '?').padStart(3)} ms  ${s}`);
+    }
   }
 }

--- a/web/src/components/ui/__tests__/animated-text.test.ts
+++ b/web/src/components/ui/__tests__/animated-text.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAnimatedText } from '../animated-text';
+
+const words = (n: number) => Array.from({ length: n }, (_, i) => `w${i}`).join(' ') + ' ';
+
+// These pin the snap thresholds only. jsdom gives framer-motion no frames, so
+// the reveal itself never advances here; e2e/perf/typewriter.spec.js covers it.
+
+describe('useAnimatedText catch-up', () => {
+  it('types a live-sized delta instead of snapping', () => {
+    const { result, rerender } = renderHook(({ text }) => useAnimatedText(text, { enabled: true }), {
+      initialProps: { text: 'seed ' },
+    });
+    expect(result.current).toBe('seed ');
+    const next = 'seed ' + words(30); // ~150 chars, one short chain
+    act(() => rerender({ text: next }));
+    expect(result.current.length).toBeLessThan(next.length);
+  });
+
+  it('snaps a backlog that lands in one update and keeps typing only the tail', () => {
+    const { result, rerender } = renderHook(({ text }) => useAnimatedText(text, { enabled: true }), {
+      initialProps: { text: 'seed ' },
+    });
+    const next = 'seed ' + words(400); // ~2.4k chars: a replay or a hidden-tab backlog
+    act(() => rerender({ text: next }));
+    // Everything but the last few hundred characters is shown at once.
+    expect(result.current.length).toBeGreaterThanOrEqual(next.length - 320);
+    expect(result.current.length).toBeLessThan(next.length);
+    expect(next.startsWith(result.current)).toBe(true);
+  });
+
+  it('keeps typing when a fast stream builds the same backlog chunk by chunk', () => {
+    const { result, rerender } = renderHook(({ text }) => useAnimatedText(text, { enabled: true }), {
+      initialProps: { text: 'seed ' },
+    });
+    let text = 'seed ';
+    for (let i = 0; i < 20; i++) {
+      text += words(20); // ~100 chars per chunk, 2k in total with no frame in between
+      act(() => rerender({ text }));
+    }
+    // The reveal lags, but nothing jumps ahead to the tail.
+    expect(result.current.length).toBeLessThan(text.length - 320);
+    expect(text.startsWith(result.current)).toBe(true);
+  });
+
+  describe('hidden tab', () => {
+    afterEach(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+    });
+
+    it('snaps a backlog that arrived while nobody was watching', () => {
+      const { result, rerender } = renderHook(({ text }) => useAnimatedText(text, { enabled: true }), {
+        initialProps: { text: 'seed ' },
+      });
+      Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+      let text = 'seed ';
+      for (let i = 0; i < 20; i++) {
+        text += words(20);
+        act(() => rerender({ text }));
+      }
+      // The lag is bounded by the snap threshold plus one chunk, not the whole backlog.
+      expect(result.current.length).toBeGreaterThanOrEqual(text.length - 720);
+      expect(text.startsWith(result.current)).toBe(true);
+    });
+  });
+
+  it('types out the hidden tail when the stream ends instead of popping it in', () => {
+    const { result, rerender } = renderHook(({ text, enabled }) => useAnimatedText(text, { enabled }), {
+      initialProps: { text: 'seed ', enabled: true },
+    });
+    const text = 'seed ' + words(60);
+    act(() => rerender({ text, enabled: true }));
+    expect(result.current.length).toBeLessThan(text.length);
+    act(() => rerender({ text, enabled: false }));
+    // The reveal keeps going from where it was rather than jumping to the end.
+    expect(result.current.length).toBeLessThan(text.length);
+    expect(text.startsWith(result.current)).toBe(true);
+  });
+
+  it('shows a finished message in full when it was never animating', () => {
+    const { result } = renderHook(() => useAnimatedText('a finished reply', { enabled: false }));
+    expect(result.current).toBe('a finished reply');
+  });
+});

--- a/web/src/components/ui/animated-text.ts
+++ b/web/src/components/ui/animated-text.ts
@@ -5,11 +5,41 @@ interface UseAnimatedTextOptions {
   enabled?: boolean;
 }
 
+// Text that lands in one update by more than CATCH_UP_CHARS is not a token
+// stream (a reconnect replay applied in one pass), and text that arrives while
+// the tab is hidden is not being watched; both show at once with only the last
+// LIVE_TAIL_CHARS left to type.
+const CATCH_UP_CHARS = 600;
+const LIVE_TAIL_CHARS = 320;
+
+// The reveal paces itself to the model. A slow model is read at BASE_WORDS_PER_SEC,
+// chunk by chunk. A fast one is followed at its own measured pace: each chain
+// drains the backlog in backlog/pace seconds, so a backlog worth exactly
+// TARGET_LAG_S refills to the same size and the reveal settles that far behind
+// the newest text: never running dry between chunks, never falling seconds
+// behind. The old fixed pace trailed a fast model by 2 to 3 seconds and the
+// leftover popped in whole when the stream ended. MIN_PACE and MAX_PACE bound
+// the reveal to 0.6x-2.5x the measured arrival rate, so it converges on
+// TARGET_LAG_S over a few chains instead of sprinting; past a backlog of
+// TARGET_LAG_S * MAX_PACE (~1.1s) it is already at that ceiling and speeds up
+// no further. The rate itself is a first-order filter of arrivals (RATE_TAU_S)
+// so a lumpy proxy or a batched read does not turn into surges in the reveal.
+const BASE_WORDS_PER_SEC = 32;
+const TARGET_LAG_S = 0.45;
+const RATE_TAU_S = 1.5;
+const MIN_PACE = 0.6;
+const MAX_PACE = 2.5;
+// When the stream ends, whatever is still hidden types out within this long.
+const FINISH_S = 0.35;
+const MIN_CHAIN_S = 0.05;
+
 /**
- * useAnimatedText - Smooth word-based typing animation for streamed text.
+ * useAnimatedText - Smooth typing animation for streamed text.
  *
- * Uses framer-motion's `animate()` with linear easing and animation chaining
- * to reveal text at a constant speed (~32 words/sec) regardless of chunk size.
+ * Every text update restarts framer-motion's `animate()` from the cursor to the
+ * new end, so the reveal is a linear lerp that is continuously re-targeted, not
+ * one animation that plays out. What it holds steady is the lag behind the
+ * stream (see the pacing constants), not the speed.
  */
 export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTextOptions = {}): string {
   const [displayText, setDisplayText] = useState('');
@@ -19,6 +49,20 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
   const controlsRef = useRef<AnimationPlaybackControls | null>(null);
   const mountedRef = useRef(false);  // tracks first effect run
   const lastUpdateTimeRef = useRef(0); // throttle onUpdate to ~30fps
+  const arrivalRef = useRef({ at: 0, cps: 0 }); // filtered arrival rate, chars/s
+  const finishingRef = useRef(false);
+
+  const noteArrival = useCallback((chars: number) => {
+    const now = performance.now();
+    const a = arrivalRef.current;
+    if (chars <= 0) return;
+    if (!a.at) { a.at = now; return; }
+    const dt = Math.max((now - a.at) / 1000, 0.001);
+    a.at = now;
+    const inst = chars / dt;
+    const k = a.cps ? 1 - Math.exp(-dt / RATE_TAU_S) : 1;
+    a.cps += (inst - a.cps) * k;
+  }, []);
 
   const startChain = useCallback(() => {
     const from = cursorRef.current;
@@ -32,10 +76,19 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
 
     animatingRef.current = true;
 
-    // Count words in the new segment to determine duration
     const segment = target.slice(from, to);
     const wordCount = segment.split(/\s+/).filter(Boolean).length || 1;
-    const duration = Math.max(Math.min(wordCount / 32, 2.5), 0.05);
+    let duration = wordCount / BASE_WORDS_PER_SEC;
+    const cps = arrivalRef.current.cps;
+    if (cps > 0) {
+      // How many seconds of stream are still hidden. Pace relative to the
+      // target lag: behind it, speed up; ahead, ease off.
+      const backlogS = segment.length / cps;
+      const pace = Math.min(Math.max(backlogS / TARGET_LAG_S, MIN_PACE), MAX_PACE);
+      duration = Math.min(duration, backlogS / pace);
+    }
+    if (finishingRef.current) duration = Math.min(duration, FINISH_S);
+    duration = Math.max(duration, MIN_CHAIN_S);
 
     controlsRef.current = animate(from, to, {
       duration,
@@ -57,6 +110,7 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
           startChain();
         } else {
           animatingRef.current = false;
+          finishingRef.current = false;
         }
       },
     });
@@ -64,9 +118,24 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
 
   useEffect(() => {
     if (!enabled) {
+      const behind = mountedRef.current && cursorRef.current > 0 && text.startsWith(targetRef.current.slice(0, cursorRef.current))
+        ? text.length - cursorRef.current
+        : 0;
+      targetRef.current = text;
+      if (behind > 0) {
+        // The stream ended with text still hidden: type the rest out quickly
+        // rather than popping it in whole.
+        finishingRef.current = true;
+        controlsRef.current?.stop();
+        animatingRef.current = false;
+        startChain();
+        return () => {
+          controlsRef.current?.stop();
+          animatingRef.current = false;
+        };
+      }
       setDisplayText(text);
       cursorRef.current = text.length;
-      targetRef.current = text;
       return;
     }
 
@@ -93,11 +162,26 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
       controlsRef.current?.stop();
       cursorRef.current = 0;
       animatingRef.current = false;
+      arrivalRef.current = { at: 0, cps: 0 };
     }
 
+    const delta = text.length - targetRef.current.length;
+    const arrivedAtOnce = delta > CATCH_UP_CHARS;
     targetRef.current = text;
+    if (!arrivedAtOnce) noteArrival(delta);
+    finishingRef.current = false;
 
-    // If an animation is already running, it will pick up the new target on complete
+    if ((arrivedAtOnce || document.hidden) && text.length - cursorRef.current > CATCH_UP_CHARS) {
+      controlsRef.current?.stop();
+      animatingRef.current = false;
+      cursorRef.current = text.length - LIVE_TAIL_CHARS;
+      setDisplayText(text.slice(0, cursorRef.current));
+    }
+
+    // The cleanup below stops the running animation before every re-run, so on
+    // the streaming path this always starts a fresh chain re-aimed at the new
+    // end. The guard still matters for the paths above that return without a
+    // cleanup (empty text, a reset), which can leave an animation in flight.
     if (!animatingRef.current) {
       startChain();
     }
@@ -109,5 +193,12 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [text, enabled]);
 
-  return enabled ? displayText : text;
+  // Decided during render, not in the effect: the render that turns `enabled`
+  // off runs before the effect, and returning the full text there would flash
+  // the whole tail for one frame before it types out. A strict prefix of the
+  // target is exactly the state that still has something left to type.
+  const behindNow = !enabled && displayText.length > 0
+    && displayText.length < text.length
+    && text.startsWith(displayText);
+  return enabled || behindNow ? displayText : text;
 }

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -54,6 +54,8 @@ const SPRING_SNAPPY = { type: 'spring' as const, stiffness: 200, damping: 22 };
 const SPRING_FOLD = { type: 'spring' as const, stiffness: 260, damping: 30 };
 /** Quick tween for live rows clearing out — exits shouldn't draw the eye. */
 const EXIT_TWEEN = { duration: 0.18, ease: 'easeIn' as const };
+// Derived from EXIT_TWEEN so the live zone's top gap closes with its last row.
+const LIVE_ZONE_MARGIN_MS = EXIT_TWEEN.duration * 1000;
 
 type LiveState = 'active' | 'completing' | 'completed' | 'failed';
 
@@ -391,98 +393,101 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
         )}
       </AnimatePresence>
 
-      {/* Live zone (bottom) -- active/completing items + preparing */}
-      <AnimatePresence initial={false}>
-        {(hasLive || hasPreparingTools) && (
-          <motion.div
-            key="live-zone"
-            className={`${hasCompleted ? 'mt-2 ' : '-mt-1 '}space-y-2`}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0, height: 0, marginTop: 0 }}
-            transition={SPRING_SNAPPY}
-            style={{ overflow: 'hidden' }}
-          >
-            {/* Live items in chronological order */}
-            <AnimatePresence initial={false}>
-              {liveItems.map(item => {
-                if (item.type === 'reasoning') {
-                  const { title: extractedTitle, body: extractedBody } = extractLeadingBoldHeader(item.content || '');
-                  const effectiveTitle = item.reasoningTitle || extractedTitle;
-                  const liveBody = extractedTitle ? extractedBody : item.content;
-                  return (
-                    <motion.div
-                      key={`live-r-${item.id}`}
-                      initial={{ opacity: 0, height: 0 }}
-                      animate={{ opacity: item._liveState === 'completing' ? 0.7 : 1, height: 'auto' }}
-                      exit={{ opacity: 0, height: 0, paddingTop: 0, paddingBottom: 0, transition: EXIT_TWEEN }}
-                      transition={SPRING_SNAPPY}
-                      style={{ overflow: 'hidden', paddingTop: '8px', paddingBottom: '8px' }}
-                      className="px-3"
-                    >
-                      <div
-                        className="flex items-center gap-2 mb-1"
-                        style={{ fontSize: '0.8125rem', color: 'var(--Labels-Secondary)' }}
-                      >
-                        <Brain className="h-4 w-4 flex-shrink-0" />
-                        {item._liveState === 'active' ? (
-                          <TextShimmer
-                            as="span"
-                            className="font-medium truncate text-[0.8125rem] [--base-color:var(--Labels-Secondary)] [--base-gradient-color:var(--color-text-primary)]"
-                            duration={1.5}
-                          >
-                            {effectiveTitle || t('toolArtifact.reasoningPending')}
-                          </TextShimmer>
-                        ) : (
-                          <span className="font-medium truncate">{effectiveTitle || t('toolArtifact.reasoningComplete')}</span>
-                        )}
-                      </div>
-
-                      {liveBody && (
-                        <AnimatedReasoningContent
-                          content={liveBody}
-                          isStreaming={item._liveState === 'active'}
-                        />
-                      )}
-                    </motion.div>
-                  );
-                }
-                if (item.type === 'tool_call') {
-                  return (
-                    <motion.div
-                      key={`live-t-${item.id || item.toolCallId}`}
-                      initial={{ opacity: 0, height: 0 }}
-                      animate={{ opacity: 1, height: 'auto' }}
-                      exit={{ opacity: 0, height: 0, transition: EXIT_TWEEN }}
-                      transition={SPRING_SNAPPY}
-                      style={{ overflow: 'hidden' }}
-                    >
-                      <ToolCallLiveRow tc={item} liveState={item._liveState} />
-                    </motion.div>
-                  );
-                }
-                return null;
-              })}
-            </AnimatePresence>
-
-            {/* Preparing tool call -- always at the bottom */}
-            <AnimatePresence initial={false}>
-              {hasPreparingTools && (
+      {/* Live zone (bottom) -- active/completing items + preparing.
+          A plain block that stays mounted: the rows animate their own height
+          in and out, so the container never carries one. An animated
+          container exit is a trap here -- the next tool call routinely lands
+          mid-collapse, and framer-motion restores a re-entering element by
+          animating the exit keys back to their remembered values, leaving an
+          inline pixel height that no later render clears. The gap from the
+          accordion collapses with the last row via a CSS transition. */}
+      <div
+        data-testid="activity-live-zone"
+        className="space-y-2"
+        style={{
+          // The former mt-2 / -mt-1, kept in rem so it still tracks --app-font-scale.
+          marginTop: hasLive || hasPreparingTools ? (hasCompleted ? '0.5rem' : '-0.25rem') : 0,
+          transition: `margin-top ${LIVE_ZONE_MARGIN_MS}ms ease-in`,
+        }}
+      >
+        {/* Live items in chronological order */}
+        <AnimatePresence initial={false}>
+          {liveItems.map(item => {
+            if (item.type === 'reasoning') {
+              const { title: extractedTitle, body: extractedBody } = extractLeadingBoldHeader(item.content || '');
+              const effectiveTitle = item.reasoningTitle || extractedTitle;
+              const liveBody = extractedTitle ? extractedBody : item.content;
+              return (
                 <motion.div
-                  key="preparing"
+                  key={`live-r-${item.id}`}
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: item._liveState === 'completing' ? 0.7 : 1, height: 'auto' }}
+                  exit={{ opacity: 0, height: 0, paddingTop: 0, paddingBottom: 0, transition: EXIT_TWEEN }}
+                  transition={SPRING_SNAPPY}
+                  style={{ overflow: 'hidden', paddingTop: '8px', paddingBottom: '8px' }}
+                  className="px-3"
+                >
+                  <div
+                    className="flex items-center gap-2 mb-1"
+                    style={{ fontSize: '0.8125rem', color: 'var(--Labels-Secondary)' }}
+                  >
+                    <Brain className="h-4 w-4 flex-shrink-0" />
+                    {item._liveState === 'active' ? (
+                      <TextShimmer
+                        as="span"
+                        className="font-medium truncate text-[0.8125rem] [--base-color:var(--Labels-Secondary)] [--base-gradient-color:var(--color-text-primary)]"
+                        duration={1.5}
+                      >
+                        {effectiveTitle || t('toolArtifact.reasoningPending')}
+                      </TextShimmer>
+                    ) : (
+                      <span className="font-medium truncate">{effectiveTitle || t('toolArtifact.reasoningComplete')}</span>
+                    )}
+                  </div>
+
+                  {liveBody && (
+                    <AnimatedReasoningContent
+                      content={liveBody}
+                      isStreaming={item._liveState === 'active'}
+                    />
+                  )}
+                </motion.div>
+              );
+            }
+            if (item.type === 'tool_call') {
+              return (
+                <motion.div
+                  key={`live-t-${item.id || item.toolCallId}`}
                   initial={{ opacity: 0, height: 0 }}
                   animate={{ opacity: 1, height: 'auto' }}
-                  exit={{ opacity: 0, height: 0 }}
+                  exit={{ opacity: 0, height: 0, transition: EXIT_TWEEN }}
                   transition={SPRING_SNAPPY}
                   style={{ overflow: 'hidden' }}
                 >
-                  <PreparingToolCallRow tc={preparingToolCall!} />
+                  <ToolCallLiveRow tc={item} liveState={item._liveState} />
                 </motion.div>
-              )}
-            </AnimatePresence>
-          </motion.div>
-        )}
-      </AnimatePresence>
+              );
+            }
+            return null;
+          })}
+        </AnimatePresence>
+
+        {/* Preparing tool call -- always at the bottom */}
+        <AnimatePresence initial={false}>
+          {hasPreparingTools && (
+            <motion.div
+              key="preparing"
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={SPRING_SNAPPY}
+              style={{ overflow: 'hidden' }}
+            >
+              <PreparingToolCallRow tc={preparingToolCall!} />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
     </div>
   );
 });
@@ -534,6 +539,9 @@ interface AnimatedReasoningContentProps {
   isStreaming: boolean;
 }
 
+/** Module scope, not a literal: a fresh object would defeat Markdown's memo on every tick. */
+const REASONING_STYLE = { opacity: 0.8 };
+
 function AnimatedReasoningContent({ content, isStreaming }: AnimatedReasoningContentProps): React.ReactElement {
   const displayText = useAnimatedText(content || '', { enabled: isStreaming });
   return (
@@ -541,7 +549,7 @@ function AnimatedReasoningContent({ content, isStreaming }: AnimatedReasoningCon
       variant="compact"
       content={displayText}
       className="text-xs"
-      style={{ opacity: 0.8 }}
+      style={REASONING_STYLE}
     />
   );
 }

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -1607,7 +1607,7 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
 
             {/* Input Area */}
             <div className={`flex-shrink-0 ${isMobile ? 'p-3' : 'p-4'} flex justify-center`}>
-              <div className="w-full max-w-3xl space-y-3">
+              <div className="w-full max-w-3xl space-y-3 relative">
                 {activeAgentId === 'main' ? (
                   <>
                     <TodoDrawer todoData={cards['todo-list-card']?.todoData ?? null} />
@@ -1641,16 +1641,6 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                     )}
                     {messageError && !isLoading && (
                       <ErrorBanner error={messageError} />
-                    )}
-                    {isReconnecting && (
-                      <div className="flex items-center gap-2 px-3 py-1.5 text-xs"
-                        role="status" aria-live="polite"
-                        style={{ color: 'var(--color-text-tertiary)' }}>
-                        <span aria-hidden="true" className="flex-shrink-0">
-                          <Loader size={14} className="text-[color:var(--color-accent-primary)]" />
-                        </span>
-                        {t('chat.reconnecting', 'Reconnecting…')}
-                      </div>
                     )}
                     <ModelStatusPill modelStatus={modelStatus} isLoading={isLoading} />
                     <FallbackSuggestionPill
@@ -1747,6 +1737,24 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
                       mode={isFlashMode ? 'fast' : 'ptc'}
                       selectedWorkspaceId={workspaceId}
                     />
+                    {/* Floats above the composer instead of sitting in it: a
+                        reconnect that painted before its backlog landed would
+                        otherwise remove this row on catch-up and drop the whole
+                        input by one line, the one visible hop left on a
+                        mid-stream reload. Last in the stack on purpose: the
+                        parent's space-y gives every sibling after the first a
+                        top margin, so a row mounted ahead of the composer
+                        would shift it by that margin and hand the hop back. */}
+                    {isReconnecting && (
+                      <div className="absolute bottom-full left-0 mb-1 flex items-center gap-2 px-3 py-1.5 text-xs"
+                        role="status" aria-live="polite"
+                        style={{ color: 'var(--color-text-tertiary)' }}>
+                        <span aria-hidden="true" className="flex-shrink-0">
+                          <Loader size={14} className="text-[color:var(--color-accent-primary)]" />
+                        </span>
+                        {t('chat.reconnecting', 'Reconnecting…')}
+                      </div>
+                    )}
                   </>
                 ) : activeAgent && activeAgent.type !== WORKFLOW_TASK_TYPE ? (
                   // Workflow runs are script-driven and take no steering input —

--- a/web/src/pages/ChatAgent/components/Markdown.tsx
+++ b/web/src/pages/ChatAgent/components/Markdown.tsx
@@ -59,7 +59,11 @@ interface CodeBlockProps {
 }
 
 // --- CodeBlock component ---
-function CodeBlock({ language, code, compact = false, codeTheme }: CodeBlockProps): React.ReactElement {
+// Memoized on its primitive props: prism re-tokenizes and rebuilds an element
+// per token on every render, which was the single largest cost of a streaming
+// reply once it contained a fence. The parent re-renders on every typewriter
+// tick; the code itself only changes while its own fence is still open.
+const CodeBlock = React.memo(function CodeBlock({ language, code, compact = false, codeTheme }: CodeBlockProps): React.ReactElement {
   const { theme } = useTheme();
   const effectiveTheme = codeTheme ?? theme;
   const [copied, setCopied] = useState(false);
@@ -141,7 +145,7 @@ function CodeBlock({ language, code, compact = false, codeTheme }: CodeBlockProp
       </div>
     </div>
   );
-}
+});
 
 // --- JSON auto-detection helper ---
 function tryFormatJson(code: string): { formatted: string; language: string } | null {
@@ -725,4 +729,16 @@ function Markdown({ content, variant = 'panel', className = '', style, onOpenFil
 }
 
 export { transformCitationBubbles, escapeHtmlAttr };
-export default Markdown;
+// Callers pass fresh inline `style` objects, so a plain memo would never hit.
+function markdownPropsEqual(a: MarkdownProps, b: MarkdownProps): boolean {
+  if (a.content !== b.content || a.variant !== b.variant || a.className !== b.className
+    || a.onOpenFile !== b.onOpenFile || a.codeTheme !== b.codeTheme) return false;
+  const sa = a.style, sb = b.style;
+  if (sa === sb) return true;
+  if (!sa || !sb) return false;
+  const ka = Object.keys(sa) as (keyof React.CSSProperties)[];
+  if (ka.length !== Object.keys(sb).length) return false;
+  return ka.every((k) => sa[k] === sb[k]);
+}
+
+export default React.memo(Markdown, markdownPropsEqual);

--- a/web/src/pages/ChatAgent/components/Markdown.tsx
+++ b/web/src/pages/ChatAgent/components/Markdown.tsx
@@ -14,6 +14,7 @@ import WorkspaceImage from './WorkspaceImage';
 import { isFilePath, isImagePath, normalizeFilePath, parseWsPath } from './FileCard';
 import { normalizeFileRefs } from '../utils/normalizeFileRefs';
 import { mapOutsideCode, mapOutsideMultilineCode } from '../utils/markdownSegments';
+import { splitMarkdownBlocks } from '../utils/markdownBlocks';
 import CitationBubble from './CitationBubble';
 
 // Sanitize schema: extends GitHub-style defaults to allow KaTeX output,
@@ -607,6 +608,39 @@ function transformCitationBubbles(content: string): string {
 
 type MarkdownVariant = 'chat' | 'panel' | 'compact';
 
+const REMARK_PLUGINS: React.ComponentProps<typeof ReactMarkdown>['remarkPlugins'] = [
+  [remarkGfm, { singleTilde: false }], remarkCjkFriendly, remarkMath,
+];
+const REHYPE_PLUGINS: React.ComponentProps<typeof ReactMarkdown>['rehypePlugins'] = [
+  [rehypeKatex, { strict: false }], rehypeRaw, [rehypeSanitize, sanitizeSchema],
+];
+
+interface MarkdownBlockProps {
+  source: string;
+  components: React.ComponentProps<typeof ReactMarkdown>['components'];
+}
+
+// One parsed block. Memoized on its source, so a streaming reply only re-parses
+// the block still receiving text; the blocks above it keep their DOM, and a
+// fence in them is highlighted once. The tree is keyed on the block's line
+// count so the block being streamed remounts on each newline, which clears a
+// stale inline-emphasis node React otherwise leaves behind mid-stream.
+//
+// The key is not scoped to prose blocks: a fence needs no such clearing, but a
+// block can hold both (an intro line with the fence opened right under it, no
+// blank line between), so there is no reliable per-block test. A fence still
+// arriving therefore re-highlights on each newline. The cost is bounded to the
+// one block receiving text, and the blocks already settled above it are
+// untouched, which is the whole point of splitting.
+const MarkdownBlock = React.memo(function MarkdownBlock({ source, components }: MarkdownBlockProps) {
+  const lineKey = useMemo(() => (source.match(/\n/g) || []).length, [source]);
+  return (
+    <ReactMarkdown key={lineKey} remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} components={components}>
+      {source}
+    </ReactMarkdown>
+  );
+});
+
 interface MarkdownProps {
   content: string;
   variant?: MarkdownVariant;
@@ -637,7 +671,7 @@ function Markdown({ content, variant = 'panel', className = '', style, onOpenFil
     );
   }, [content]);
 
-  const lineKey = useMemo(() => (processed.match(/\n/g) || []).length, [processed]);
+  const blocks = useMemo(() => splitMarkdownBlocks(processed), [processed]);
 
   const components = useMemo(() => {
     let result = config.components;
@@ -721,24 +755,19 @@ function Markdown({ content, variant = 'panel', className = '', style, onOpenFil
       className={`font-content ${config.className} ${className}`.trim()}
       style={{ ...config.style, ...style }}
     >
-      <ReactMarkdown key={lineKey} remarkPlugins={[[remarkGfm, { singleTilde: false }], remarkCjkFriendly, remarkMath]} rehypePlugins={[[rehypeKatex, { strict: false }], rehypeRaw, [rehypeSanitize, sanitizeSchema]]} components={components}>
-        {processed}
-      </ReactMarkdown>
+      {blocks.map((block, i) => (
+        <React.Fragment key={i}>
+          {/* mdast-to-hast puts a newline text node between top-level siblings;
+              keep the DOM identical to a whole-document render. */}
+          {i > 0 && '\n'}
+          <MarkdownBlock source={block} components={components} />
+        </React.Fragment>
+      ))}
     </div>
   );
 }
 
 export { transformCitationBubbles, escapeHtmlAttr };
-// Callers pass fresh inline `style` objects, so a plain memo would never hit.
-function markdownPropsEqual(a: MarkdownProps, b: MarkdownProps): boolean {
-  if (a.content !== b.content || a.variant !== b.variant || a.className !== b.className
-    || a.onOpenFile !== b.onOpenFile || a.codeTheme !== b.codeTheme) return false;
-  const sa = a.style, sb = b.style;
-  if (sa === sb) return true;
-  if (!sa || !sb) return false;
-  const ka = Object.keys(sa) as (keyof React.CSSProperties)[];
-  if (ka.length !== Object.keys(sb).length) return false;
-  return ka.every((k) => sa[k] === sb[k]);
-}
-
-export default React.memo(Markdown, markdownPropsEqual);
+// Shallow compare: a caller that varies `style` must hoist the object, or the
+// memo never hits and every tick re-parses the document.
+export default React.memo(Markdown);

--- a/web/src/pages/ChatAgent/components/ReasoningMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/ReasoningMessageContent.tsx
@@ -3,6 +3,9 @@ import { Brain, ChevronDown, ChevronUp } from 'lucide-react';
 import { Loader } from '@/components/ui/loader';
 import Markdown from './Markdown';
 
+/** Module scope, not a literal: a fresh object would defeat Markdown's memo on every tick. */
+const REASONING_BODY_STYLE = { borderLeft: '2px solid var(--color-border-elevated)' };
+
 interface ReasoningMessageContentProps {
   reasoningContent: string;
   isReasoning: boolean;
@@ -103,7 +106,7 @@ function ReasoningMessageContent({ reasoningContent, isReasoning, reasoningCompl
           variant="compact"
           content={reasoningContent}
           className="mt-2 pl-3 pr-0 py-1 text-xs"
-          style={{ borderLeft: '2px solid var(--color-border-elevated)' }}
+          style={REASONING_BODY_STYLE}
         />
       )}
     </div>

--- a/web/src/pages/ChatAgent/components/ToolCallMessageContent.tsx
+++ b/web/src/pages/ChatAgent/components/ToolCallMessageContent.tsx
@@ -18,6 +18,16 @@ const FILE_TOOLS = ['Write', 'Edit', 'Read'];
  */
 const INLINE_TOOLS = new Set(['Glob', 'Grep', 'Write', 'Read', 'Edit', 'ExecuteCode']);
 
+/** Module scope, not literals: a fresh object would defeat Markdown's memo on every tick. */
+const RESULT_STYLE = {
+  backgroundColor: 'var(--color-bg-elevated)',
+  border: '1px solid var(--color-border-muted)',
+};
+const RESULT_ERROR_STYLE = {
+  backgroundColor: 'var(--color-loss-soft)',
+  border: '1px solid var(--color-border-loss)',
+};
+
 interface ToolCallData {
   name?: string;
   args?: Record<string, unknown>;

--- a/web/src/pages/ChatAgent/components/__tests__/Markdown.blocks.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/Markdown.blocks.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Block-level rendering must be invisible: the HTML for a document rendered
+ * block by block has to equal the HTML for the same document rendered whole,
+ * at every point of a stream. The splitter is mocked so the same component
+ * produces both sides.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { buildReply } from '@e2e/perf/streamFixture';
+
+const mode = vi.hoisted(() => ({ whole: false }));
+vi.mock('../../utils/markdownBlocks', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/markdownBlocks')>('../../utils/markdownBlocks');
+  return {
+    splitMarkdownBlocks: (text: string) => (mode.whole ? [text] : actual.splitMarkdownBlocks(text)),
+  };
+});
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'dark', setTheme: () => {} }),
+}));
+
+import Markdown from '../Markdown';
+import { splitMarkdownBlocks } from '../../utils/markdownBlocks';
+
+function render(content: string, whole: boolean): string {
+  mode.whole = whole;
+  try {
+    return renderToStaticMarkup(<Markdown variant="chat" content={content} onOpenFile={() => {}} />);
+  } finally {
+    mode.whole = false;
+  }
+}
+
+const EDGE_DOCS: Record<string, string> = {
+  listAfterParagraph: 'Intro\n- one\n\n- two\n',
+  listAfterHeading: '# Title\n- a\n\n- b\n\nAfter\n',
+  looseList: 'Intro\n\n- one\n\n- two\n\n  nested paragraph\n\n- three\n\nOutro\n',
+  orderedRuns: '1. a\n2. b\n\nBreak\n\n3. c\n4. d\n',
+  nestedFence: '- step\n\n  ```bash\n  ls -la\n\n  pwd\n  ```\n\n- next\n',
+  mathBlock: 'Given\n\n$$\n\\alpha + \\beta\n\n= \\gamma\n$$\n\nso $x$.\n',
+  tableThenQuote: '| a | b |\n|---|---|\n| 1 | 2 |\n\n> quoted\n\n> second quote\n',
+  headingAfterFence: '```json\n{"a": 1}\n```\n## Next\ntext\n',
+  citations: 'Revenue grew ([10-Q](https://example.com/10q)) and margins ([call](https://example.com/call?price=$100)).\n\nNext para.\n',
+  currency: 'Costs $100 and $2,000 rose.\n\n$$E = mc^2$$\n\nInline $a+b$ math.\n',
+  html: '<details>\n<summary>More</summary>\n\nHidden **text**\n\n</details>\n\nAfter\n',
+  refs: 'See [docs][d].\n\n[d]: https://example.com\n',
+  fileRefs: 'Open `__wsref__/ws1/report.md` and [chart](__wsref__/ws1/chart.png).\n\nDone.\n',
+  emphasisTail: 'Some **bold and *nested* text',
+  crlf: 'a\r\n\r\nb\r\n',
+};
+
+describe('Markdown block rendering parity', () => {
+  it('matches whole-document rendering for the benchmark reply', () => {
+    const doc = buildReply();
+    expect(splitMarkdownBlocks(doc).length).toBeGreaterThan(20);
+    expect(render(doc, false)).toBe(render(doc, true));
+  });
+
+  it('matches whole-document rendering for every streaming prefix of the reply', () => {
+    const doc = buildReply();
+    for (let end = 37; end <= doc.length; end += 211) {
+      const prefix = doc.slice(0, end);
+      expect(render(prefix, false), `prefix ${end}`).toBe(render(prefix, true));
+    }
+  });
+
+  for (const [name, doc] of Object.entries(EDGE_DOCS)) {
+    it(`matches whole-document rendering: ${name}`, () => {
+      expect(render(doc, false)).toBe(render(doc, true));
+      for (let end = 5; end < doc.length; end += 7) {
+        const prefix = doc.slice(0, end);
+        expect(render(prefix, false), `prefix ${end}`).toBe(render(prefix, true));
+      }
+    });
+  }
+});

--- a/web/src/pages/ChatAgent/components/chatView/useChatScroll.ts
+++ b/web/src/pages/ChatAgent/components/chatView/useChatScroll.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { isNearBottom } from '../../utils/scrollHelpers';
 import { findMessageElement, resolveScrollContent, resolveScrollViewport } from '../../utils/scrollDom';
 import { scrollMemory } from '@/lib/scrollMemory';
@@ -117,7 +117,6 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
   const programmaticReleaseRef = useRef<(() => void) | null>(null);
   const settleQuietTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const settleHardCapRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const reapplyRafRef = useRef<number | null>(null);
   const restoredForThreadRef = useRef<string | null>(null);
   // Streaming auto-follow's deferred scroll, and the entry-restore frame —
   // tracked so a thread switch / unmount cancels a pending scroll instead of
@@ -252,27 +251,27 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
     [getScrollContainer, withProgrammaticScroll, armSettleTimers, setPillState],
   );
 
-  // Re-apply the pin target (rAF-coalesced); called by the ResizeObserver each
-  // time content settles, so async media finishing layout can't strand the user
-  // mid-thread ('bottom') or clamp a remembered offset short ('offset').
+  // Re-apply the pin target; called by the ResizeObserver each time content
+  // settles, so async media finishing layout can't strand the user mid-thread
+  // ('bottom') or clamp a remembered offset short ('offset'). Applied right
+  // there, not in a deferred frame: the observer already runs after layout and
+  // before paint, so the frame that shows the taller transcript is the frame
+  // that shows it scrolled. Deferring by a frame painted the growth first and
+  // the scroll a frame later, a visible snap on every reload and return.
   const reapplyPin = useCallback(() => {
-    if (reapplyRafRef.current != null) return;
-    reapplyRafRef.current = requestAnimationFrame(() => {
-      reapplyRafRef.current = null;
-      const c = getScrollContainer(scrollAreaRef);
-      const target = pinTargetRef.current;
-      if (!target || !c) return;
-      const top =
-        target.mode === 'bottom' ? c.scrollHeight : target.mode === 'offset' ? target.top : anchorTop(c, target.id);
-      if (top == null) {
-        // The anchored bubble left the transcript (edit / regenerate truncation).
-        pinTargetRef.current = null;
-        clearSettleTimers();
-        return;
-      }
-      withProgrammaticScroll(() => c.scrollTo({ top }), 'auto');
-      armSettleTimers();
-    });
+    const c = getScrollContainer(scrollAreaRef);
+    const target = pinTargetRef.current;
+    if (!target || !c) return;
+    const top =
+      target.mode === 'bottom' ? c.scrollHeight : target.mode === 'offset' ? target.top : anchorTop(c, target.id);
+    if (top == null) {
+      // The anchored bubble left the transcript (edit / regenerate truncation).
+      pinTargetRef.current = null;
+      clearSettleTimers();
+      return;
+    }
+    withProgrammaticScroll(() => c.scrollTo({ top }), 'auto');
+    armSettleTimers();
   }, [getScrollContainer, withProgrammaticScroll, armSettleTimers, clearSettleTimers]);
 
   // Scroll a bubble under the viewport top and hold it there through the settle
@@ -393,10 +392,6 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
       c.removeEventListener('wheel', handleUserIntent);
       c.removeEventListener('touchstart', handleUserIntent);
       ro?.disconnect();
-      if (reapplyRafRef.current != null) {
-        cancelAnimationFrame(reapplyRafRef.current);
-        reapplyRafRef.current = null;
-      }
     };
   }, [activeAgentId, getScrollContainer, getScrollContent, reapplyPin, clearSettleTimers]);
 
@@ -443,7 +438,10 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
   // remembered mid-thread offset (scrollMemory, survives route unmounts) wins
   // over the default bottom pin, so tabbing away and back lands where the user
   // left; 'bottom' / no memory pins to bottom through the async settle window.
-  useEffect(() => {
+  // A layout effect, applied in the same commit that renders the history: the
+  // first frame the user sees of the thread is already in position. The
+  // deferred frame remains only for a viewport that is not mounted yet.
+  useLayoutEffect(() => {
     if (!isActive) return;
     const tid = currentThreadId || threadId;
     if (!tid || tid === '__default__') return;
@@ -469,26 +467,33 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
       isNearBottomRef.current = false;
       pillBaselineLenRef.current = messagesLenRef.current;
       setPillState({ visible: true, hasNew: false, newCount: 0 });
-      entryRestoreRafRef.current = requestAnimationFrame(() => {
-        entryRestoreRafRef.current = null;
-        // The instance may have gone inactive (cached/hidden) before this frame.
-        const c = isActiveRef.current ? getScrollContainer(scrollAreaRef) : null;
-        if (!c) {
-          // The apply never ran — release the claim so a stale pin can't
-          // block follows when the instance reactivates.
-          if (pinTargetRef.current?.mode === 'offset') pinTargetRef.current = null;
-          return;
-        }
+    }
+    // One apply for both targets: run in this commit when the viewport is
+    // already mounted, on the next frame when it is not.
+    const apply = () => {
+      // The instance may have gone inactive (cached/hidden) before the frame.
+      const c = isActiveRef.current ? getScrollContainer(scrollAreaRef) : null;
+      if (!c) {
+        // Nothing was applied: release the claim so a stale pin can't block
+        // follows when the instance reactivates.
+        if (pinTargetRef.current?.mode === 'offset') pinTargetRef.current = null;
+        return;
+      }
+      if (typeof saved === 'number') {
         withProgrammaticScroll(() => {
           c.scrollTop = saved;
         });
         armSettleTimers();
-      });
+      } else {
+        pinToBottom('auto');
+      }
+    };
+    if (getScrollContainer(scrollAreaRef)) {
+      apply();
     } else {
       entryRestoreRafRef.current = requestAnimationFrame(() => {
         entryRestoreRafRef.current = null;
-        if (!isActiveRef.current) return;
-        pinToBottom('auto');
+        apply();
       });
     }
     return () => {
@@ -506,7 +511,6 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
     return () => {
       if (settleQuietTimerRef.current) clearTimeout(settleQuietTimerRef.current);
       if (settleHardCapRef.current) clearTimeout(settleHardCapRef.current);
-      if (reapplyRafRef.current != null) cancelAnimationFrame(reapplyRafRef.current);
       if (streamFollowTimerRef.current) clearTimeout(streamFollowTimerRef.current);
       if (entryRestoreRafRef.current != null) cancelAnimationFrame(entryRestoreRafRef.current);
     };

--- a/web/src/pages/ChatAgent/components/messageList/MessageBubble.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/MessageBubble.tsx
@@ -18,12 +18,18 @@ import type { AttachmentData, WidgetChipShape } from './attachments';
 import { MessageContentSegments } from './MessageContentSegments';
 import { OverflowCollapse } from './OverflowCollapse';
 import { useMessageActions } from './MessageActionsContext';
+import { useArrivalQuiet, useLiveToolRunning } from './useArrivalQuiet';
 import { isSteeringUserMessage } from './messagePredicates';
 import { assistantText } from './messageText';
 import { EMPTY_OBJ } from './types';
 import type { ContentSegmentRecord, FeedbackResult, MessageRecord, ToolCallProcessRecord } from './types';
 
 // --- MessageBubble ---
+
+/** Pause without new text before the streaming indicator fades back in. Longer
+ *  than a token-cadence gap and the typewriter's own lag, shorter than a tool
+ *  call or a thinking pause. */
+const ARRIVAL_QUIET_MS = 700;
 
 /** Collapsed bound for long user messages (~10 lines of chat text). */
 const USER_MESSAGE_COLLAPSE_PX = 240;
@@ -120,12 +126,21 @@ export const MessageBubble = memo(function MessageBubble({ message, turnIndex, i
   const canShowActions = !isSubagentView && !readOnly;
   const showActions = canShowActions && !(message.isStreaming as boolean) && !isLoading;
 
-  // Provenance count for the Sources pill, deduped by (source_type, identifier)
-  // — the same URL fetched twice in one turn counts once. The pill lives in its
-  // own always-visible row (not the hover-gated footer), so it shows mid-stream.
-  // This counts distinct sources (every result URL), so it intentionally runs
-  // ahead of the panel's visible row count: the panel groups a whole web search
-  // into one deck, but the pill still reports how many pages were actually read.
+  // The stream stamps `arrivalSeq` on every landed reply text, reasoning text
+  // or tool-argument chunk, whatever the typewriter has shown of it. The
+  // streaming indicator hides while it climbs and shows in the pauses. A tool
+  // whose card is visibly running counts as busy too.
+  const isStreaming = message.isStreaming as boolean;
+  const toolCallProcesses = message.toolCallProcesses as Record<string, ToolCallProcessRecord> | undefined;
+  const arrivalSeq = (message.arrivalSeq as number | undefined) ?? 0;
+  const toolRunning = useLiveToolRunning(toolCallProcesses, isStreaming);
+  const arrivalQuiet = useArrivalQuiet(arrivalSeq, isStreaming, ARRIVAL_QUIET_MS) && !toolRunning;
+
+  // Provenance count for the Sources pill, deduped by (source_type,
+  // identifier): the same URL fetched twice in one turn counts once. It counts
+  // distinct sources (every result URL), so it intentionally runs ahead of the
+  // panel's visible row count: the panel groups a whole web search into one
+  // deck, but the pill still reports how many pages were actually read.
   const sourceCount = useMemo(() => {
     if (!isAssistant || isSubagentView) return 0;
     return countDedupedSources(message.provenanceRecords as Record<string, ProvenanceRecord> | undefined);
@@ -340,19 +355,42 @@ export const MessageBubble = memo(function MessageBubble({ message, turnIndex, i
           )}
           </OverflowCollapse>
 
-          {/* Streaming indicator -- hidden when dot-loader is already showing for pending chunks */}
-          {(message.isStreaming as boolean) && !Object.keys((message.pendingToolCallChunks as Record<string, unknown>) || {}).length && (() => {
+          {/* Streaming indicator -- hidden when dot-loader is already showing
+              for pending chunks. Stays mounted for the whole stream and only
+              fades: while text is landing it is invisible (the text is the
+              liveness signal), in a pause it fades back in so the turn never
+              looks finished. Fading rather than unmounting keeps its row, so
+              the transcript bottom does not hop by a line on every pause. */}
+          {isStreaming && !Object.keys((message.pendingToolCallChunks as Record<string, unknown>) || {}).length && (() => {
             const contentSegments = message.contentSegments as ContentSegmentRecord[] | undefined;
             const hasContent = contentSegments?.some(s => s.content?.trim()) || (message.content as string)?.trim();
-            return <LissajousLoading className={`${hasContent ? "mt-2" : "mt-0"} ${isMobile ? 'w-5 h-5' : 'w-6 h-6'} text-neutral-500 dark:text-neutral-400`} />;
+            return (
+              <div
+                className={`${hasContent ? 'mt-2' : 'mt-0'} transition-opacity duration-200`}
+                style={{ opacity: arrivalQuiet ? 1 : 0 }}
+                aria-hidden={!arrivalQuiet}
+                data-testid="streaming-indicator"
+                data-quiet={arrivalQuiet ? 'true' : 'false'}
+              >
+                <LissajousLoading className={`${isMobile ? 'w-5 h-5' : 'w-6 h-6'} text-neutral-500 dark:text-neutral-400`} />
+              </div>
+            );
           })()}
         </div>
 
-        {/* Sources pill -- always-visible row (not the hover-gated footer below,
-            which is hidden during streaming). Surfaces the turn's tracked data
-            provenance; clicking opens the Sources tab in the right panel. */}
+        {/* Sources pill -- always-visible row (not the hover-gated footer
+            below). Mounted from the first source onward and only faded in once
+            the turn has finished: a count that climbs mid-stream reads as
+            activity, but unmounting the row until then would hop the whole
+            transcript by a line the moment the turn ends. While faded the row
+            is inert, so the invisible button takes neither a click nor a tab
+            stop. Clicking opens the Sources tab in the right panel. */}
         {isAssistant && !isSubagentView && sourceCount > 0 && (
-          <div className="flex justify-start mt-1">
+          <div
+            className="flex justify-start mt-1 transition-opacity duration-200"
+            style={{ opacity: isStreaming ? 0 : 1 }}
+            inert={isStreaming}
+          >
             <button
               type="button"
               onClick={() => onOpenSources?.(message.id as string)}

--- a/web/src/pages/ChatAgent/components/messageList/__tests__/MessageBubble.userQoL.test.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/__tests__/MessageBubble.userQoL.test.tsx
@@ -111,3 +111,29 @@ describe('MessageBubble — long user message collapse', () => {
     expect(screen.queryByTestId('overflow-collapse-toggle')).toBeNull();
   });
 });
+
+describe('MessageBubble — Sources pill while streaming', () => {
+  const provenance = {
+    r1: {
+      record_id: 'r1',
+      timestamp: '2026-08-01T00:00:00Z',
+      source_type: 'web_fetch',
+      identifier: 'https://example.com/report',
+    },
+  };
+  const assistant = (isStreaming: boolean) =>
+    makeMessage({ id: 'a-1', role: 'assistant', content: 'Margins widened.', isStreaming, provenanceRecords: provenance });
+
+  it('keeps the faded pill out of the tab order until the turn finishes', () => {
+    const { rerender } = renderBubble(assistant(true));
+    const pill = screen.getByTitle('Sources');
+    // Faded to opacity 0 mid-turn: a keyboard user must not land on it.
+    expect(pill.closest('[inert]')).not.toBeNull();
+    rerender(
+      <MessageActionsProvider actions={{ onEditMessage: vi.fn() }}>
+        <MessageBubble message={assistant(false)} turnIndex={0} isTurnTail={false} />
+      </MessageActionsProvider>,
+    );
+    expect(screen.getByTitle('Sources').closest('[inert]')).toBeNull();
+  });
+});

--- a/web/src/pages/ChatAgent/components/messageList/__tests__/useArrivalQuiet.test.ts
+++ b/web/src/pages/ChatAgent/components/messageList/__tests__/useArrivalQuiet.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useArrivalQuiet, useLiveToolRunning } from '../useArrivalQuiet';
+import type { ToolCallProcessRecord } from '../types';
+
+describe('useArrivalQuiet', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('starts quiet, goes busy on arrival, and returns to quiet after the window', () => {
+    const { result, rerender } = renderHook(({ seq }) => useArrivalQuiet(seq, true, 700), { initialProps: { seq: 0 } });
+    expect(result.current).toBe(true);
+    rerender({ seq: 1 });
+    expect(result.current).toBe(false);
+    act(() => { vi.advanceTimersByTime(400); });
+    rerender({ seq: 2 });
+    act(() => { vi.advanceTimersByTime(400); });
+    // Still inside the window of the latest arrival.
+    expect(result.current).toBe(false);
+    act(() => { vi.advanceTimersByTime(400); });
+    expect(result.current).toBe(true);
+  });
+
+  it('ignores arrivals while inactive', () => {
+    const { result, rerender } = renderHook(({ seq }) => useArrivalQuiet(seq, false, 700), { initialProps: { seq: 0 } });
+    rerender({ seq: 1 });
+    expect(result.current).toBe(true);
+  });
+
+  it('does not treat text that landed while inactive as a fresh arrival', () => {
+    const { result, rerender } = renderHook(
+      ({ seq, active }) => useArrivalQuiet(seq, active, 700),
+      { initialProps: { seq: 0, active: false } },
+    );
+    rerender({ seq: 3, active: false });
+    // Going active on the same sequence: nothing new arrived, so the
+    // indicator shows at once instead of hiding for the quiet window.
+    rerender({ seq: 3, active: true });
+    expect(result.current).toBe(true);
+  });
+
+  it('goes quiet again the moment it stops being active', () => {
+    const { result, rerender } = renderHook(
+      ({ seq, active }) => useArrivalQuiet(seq, active, 700),
+      { initialProps: { seq: 0, active: true } },
+    );
+    rerender({ seq: 1, active: true });
+    expect(result.current).toBe(false);
+    // The turn ends mid-arrival: the indicator must not be left reading busy.
+    rerender({ seq: 1, active: false });
+    expect(result.current).toBe(true);
+  });
+});
+
+describe('useLiveToolRunning', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const proc = (toolName: string, createdAt = Date.now()): ToolCallProcessRecord =>
+    ({ toolName, isInProgress: true, _createdAt: createdAt }) as unknown as ToolCallProcessRecord;
+
+  it('counts a running tool the live zone shows', () => {
+    const { result } = renderHook(() => useLiveToolRunning({ a: proc('bash') }, true));
+    expect(result.current).toBe(true);
+  });
+
+  it('ignores a running tool the transcript never draws', () => {
+    // manage_threads has no card, so nothing on screen says the turn is busy:
+    // the spinner must stay available rather than hide behind an invisible tool.
+    const { result } = renderHook(() => useLiveToolRunning({ a: proc('manage_threads') }, true));
+    expect(result.current).toBe(false);
+  });
+
+  it('stops counting a regular tool once it folds out of the live zone', () => {
+    const processes = { a: proc('bash', Date.now() - 14_990) };
+    const { result } = renderHook(() => useLiveToolRunning(processes, true));
+    expect(result.current).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/web/src/pages/ChatAgent/components/messageList/buildRenderBlocks.ts
+++ b/web/src/pages/ChatAgent/components/messageList/buildRenderBlocks.ts
@@ -4,11 +4,12 @@ import { normalizeSubagentText } from './normalizeSubagentText';
 import { MIN_LIVE_EXPOSURE_MS } from './liveZoneTiming';
 import type { ContentSegmentRecord, ToolCallProcessRecord } from './types';
 
-const MAX_IN_PROGRESS_MS = 15000; // max time a tool call can stay in-progress in live view before archiving (independent of MIN_LIVE_EXPOSURE_MS)
+export const MAX_IN_PROGRESS_MS = 15000; // max time a tool call can stay in-progress in live view before archiving (independent of MIN_LIVE_EXPOSURE_MS)
 /** Tools that should stay in the live zone for their entire duration (no MAX_IN_PROGRESS_MS cap) */
-const ALWAYS_LIVE_TOOLS = new Set(['TaskOutput', 'WebFetch']);
+export const ALWAYS_LIVE_TOOLS = new Set(['TaskOutput', 'WebFetch']);
 /** Tool calls that are never rendered as visible activity items — they have dedicated UI or are internal */
-const HIDDEN_TOOL_CALL_NAMES = new Set(['TodoWrite', 'task', 'Task', 'SubmitPlan', 'AskUserQuestion', 'manage_workspaces', 'ptc_agent', 'agent_output', 'manage_threads', 'ShowWidget']);
+/** Tools the transcript never draws a card for; the spinner gate skips them too. */
+export const HIDDEN_TOOL_CALL_NAMES = new Set(['TodoWrite', 'task', 'Task', 'SubmitPlan', 'AskUserQuestion', 'manage_workspaces', 'ptc_agent', 'agent_output', 'manage_threads', 'ShowWidget']);
 
 /** Render block types for the inline activity grouping */
 export interface ActivityRenderBlock {

--- a/web/src/pages/ChatAgent/components/messageList/buildRenderBlocks.ts
+++ b/web/src/pages/ChatAgent/components/messageList/buildRenderBlocks.ts
@@ -1,9 +1,9 @@
 import { chartInstanceKey, planChartAnnotationCards } from '../chartAnnotationGrouping';
 import { INLINE_ARTIFACT_TOOLS } from '../charts/InlineArtifactCards';
 import { normalizeSubagentText } from './normalizeSubagentText';
+import { MIN_LIVE_EXPOSURE_MS } from './liveZoneTiming';
 import type { ContentSegmentRecord, ToolCallProcessRecord } from './types';
 
-const MIN_LIVE_EXPOSURE_MS = 1800; // minimum time a just-completed item stays in the live zone before folding
 const MAX_IN_PROGRESS_MS = 15000; // max time a tool call can stay in-progress in live view before archiving (independent of MIN_LIVE_EXPOSURE_MS)
 /** Tools that should stay in the live zone for their entire duration (no MAX_IN_PROGRESS_MS cap) */
 const ALWAYS_LIVE_TOOLS = new Set(['TaskOutput', 'WebFetch']);

--- a/web/src/pages/ChatAgent/components/messageList/liveZoneTiming.ts
+++ b/web/src/pages/ChatAgent/components/messageList/liveZoneTiming.ts
@@ -1,0 +1,6 @@
+/**
+ * Minimum time a just-completed item stays in the live zone before folding.
+ * A leaf module with no imports: the e2e live-zone spec reads it from Node,
+ * where the rest of the render-block module graph (i18n JSON) cannot load.
+ */
+export const MIN_LIVE_EXPOSURE_MS = 1800;

--- a/web/src/pages/ChatAgent/components/messageList/useArrivalQuiet.ts
+++ b/web/src/pages/ChatAgent/components/messageList/useArrivalQuiet.ts
@@ -1,0 +1,75 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ALWAYS_LIVE_TOOLS, HIDDEN_TOOL_CALL_NAMES, MAX_IN_PROGRESS_MS } from './buildRenderBlocks';
+import type { ToolCallProcessRecord } from './types';
+
+/**
+ * True while no new text has landed for `quietMs`, false again the moment more
+ * arrives. Drives the streaming indicator: arriving text is its own proof the
+ * turn is alive, so the spinner shows only in the pauses (model thinking, a
+ * tool running) where nothing else says so. Starts quiet, so a turn that has
+ * produced nothing yet shows it at once, and returns to quiet when it goes
+ * inactive so a bubble that stopped mid-arrival is not left reading busy.
+ */
+export function useArrivalQuiet(seq: number, active: boolean, quietMs: number): boolean {
+  const [quiet, setQuiet] = useState(true);
+  const lastSeqRef = useRef(seq);
+  useEffect(() => {
+    if (!active) {
+      // Still note the sequence, so text that landed while inactive is not
+      // mistaken for a fresh arrival the moment the hook goes active again.
+      lastSeqRef.current = seq;
+      setQuiet(true);
+      return;
+    }
+    if (seq !== lastSeqRef.current) {
+      lastSeqRef.current = seq;
+      setQuiet(false);
+    }
+    const timer = setTimeout(() => setQuiet(true), quietMs);
+    return () => clearTimeout(timer);
+  }, [seq, active, quietMs]);
+  return quiet;
+}
+
+/**
+ * True while a running tool is still shown in the live zone. A tool's own card
+ * already says it is busy, but only while the zone shows it: a regular tool
+ * folds into the archive after MAX_IN_PROGRESS_MS and reads as finished there,
+ * and a reconnect stamps its tools folded from the start. The spinner may hide
+ * behind a visible card, never behind a folded or never-drawn one, so hidden
+ * tools do not count and this re-evaluates at the moment the youngest visible
+ * card folds.
+ */
+export function useLiveToolRunning(
+  processes: Record<string, ToolCallProcessRecord> | undefined,
+  active: boolean,
+): boolean {
+  const [now, setNow] = useState(() => Date.now());
+  const { running, nextFold } = useMemo(() => {
+    let running = false;
+    let nextFold = Infinity;
+    if (!active) return { running, nextFold };
+    for (const p of Object.values(processes ?? {})) {
+      if (!p.isInProgress) continue;
+      const toolName = p.toolName as string;
+      if (HIDDEN_TOOL_CALL_NAMES.has(toolName)) continue;
+      if (ALWAYS_LIVE_TOOLS.has(toolName)) {
+        running = true;
+        continue;
+      }
+      const createdAt = p._createdAt as number | undefined;
+      const foldAt = createdAt ? createdAt + MAX_IN_PROGRESS_MS : 0;
+      if (foldAt > now) {
+        running = true;
+        nextFold = Math.min(nextFold, foldAt);
+      }
+    }
+    return { running, nextFold };
+  }, [processes, active, now]);
+  useEffect(() => {
+    if (nextFold === Infinity) return;
+    const timer = setTimeout(() => setNow(Date.now()), Math.max(0, nextFold - Date.now()) + 1);
+    return () => clearTimeout(timer);
+  }, [nextFold]);
+  return running;
+}

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.reconnectNav.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.reconnectNav.test.ts
@@ -36,6 +36,23 @@ vi.mock('../../utils/api', async () => (await import('./chatHookHarness')).apiMo
 
 import { getWorkflowStatus, reconnectToWorkflowStream } from '../../utils/api';
 import { useChatMessages } from '../useChatMessages';
+import {
+  RECONNECT_BACKLOG_QUIET_MS, RECONNECT_BACKLOG_CAP_MS,
+} from '../../session/stream/lifecycle';
+import type { AssistantMessage } from '@/types/chat';
+
+/** Text rendered across the assistant bubbles, in segment order. */
+function assistantText(messages: { role: string }[]): string {
+  return (messages.filter((m) => m.role === 'assistant') as AssistantMessage[])
+    .flatMap((m) => m.contentSegments ?? [])
+    .map((seg) => (seg as { content?: string }).content ?? '')
+    .join('');
+}
+
+/** One assistant text chunk on the main stream. */
+const textChunk = (content: string) => ({
+  event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'text', content,
+});
 
 const mockStatus = getWorkflowStatus as Mock;
 const mockReconnect = reconnectToWorkflowStream as Mock;
@@ -183,6 +200,9 @@ describe('useChatMessages — cross-thread navigation reconnect', () => {
       // Live tokens arrive, then the reader hangs — the turn is still in progress.
       onEvent({ event: 'metadata', thread_id: 'th-live', run_id: 'run-live' });
       onEvent({ event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'text', content: 'streaming…' });
+      // The server marks where its replayed backlog ends; the client holds
+      // events until then and applies them in one pass.
+      onEvent({ event: 'caught_up' });
       return new Promise<{ disconnected: boolean; aborted: boolean }>((res) => {
         resolveStream = () => res({ disconnected: false, aborted: false });
       });
@@ -201,5 +221,92 @@ describe('useChatMessages — cross-thread navigation reconnect', () => {
     await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
     expect(result.current.isReconnecting).toBe(false);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  it('holds the replayed backlog until caught_up, then paints it before the live tail', async () => {
+    mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-live', active_tasks: [] });
+
+    let emit: ((e: Record<string, unknown>) => void) | undefined;
+    mockReconnect.mockImplementation((...args: unknown[]) => {
+      emit = args[3] as (e: Record<string, unknown>) => void;
+      emit({ event: 'metadata', thread_id: 'th-live', run_id: 'run-live' });
+      emit(textChunk('already '));
+      emit(textChunk('written'));
+      return new Promise<{ disconnected: boolean; aborted: boolean }>(() => {});
+    });
+
+    const { result } = renderHookWithProviders(() => useChatMessages('ws', 'th-live'));
+    await waitFor(() => expect(mockReconnect).toHaveBeenCalledTimes(1));
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+
+    // Backlog in flight: nothing rendered yet, spinner still on.
+    expect(assistantText(result.current.messages)).toBe('');
+    expect(result.current.isReconnecting).toBe(true);
+
+    await act(async () => { emit?.({ event: 'caught_up' }); });
+    expect(assistantText(result.current.messages)).toBe('already written');
+    expect(result.current.isReconnecting).toBe(false);
+
+    // The live tail streams through as it arrives.
+    await act(async () => { emit?.(textChunk(' and live')); });
+    expect(assistantText(result.current.messages)).toBe('already written and live');
+  });
+
+  it('a held event restarts the quiet window; the backlog paints once it goes quiet', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-live', active_tasks: [] });
+      let emit: ((e: Record<string, unknown>) => void) | undefined;
+      mockReconnect.mockImplementation((...args: unknown[]) => {
+        emit = args[3] as (e: Record<string, unknown>) => void;
+        emit({ event: 'metadata', thread_id: 'th-live', run_id: 'run-live' });
+        emit(textChunk('older '));
+        return new Promise<{ disconnected: boolean; aborted: boolean }>(() => {});
+      });
+
+      const { result } = renderHookWithProviders(() => useChatMessages('ws', 'th-live'));
+      await waitFor(() => expect(mockReconnect).toHaveBeenCalledTimes(1));
+
+      // A second held event lands just before the first one's window closes:
+      // the window restarts, so a slow replay is never cut in half.
+      await act(async () => { vi.advanceTimersByTime(RECONNECT_BACKLOG_QUIET_MS - 200); });
+      await act(async () => { emit?.(textChunk('server')); });
+      await act(async () => { vi.advanceTimersByTime(RECONNECT_BACKLOG_QUIET_MS - 200); });
+      expect(assistantText(result.current.messages)).toBe('');
+
+      await act(async () => { vi.advanceTimersByTime(300); });
+      expect(assistantText(result.current.messages)).toBe('older server');
+      expect(result.current.isReconnecting).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('paints at the cap when held events keep the quiet window alive', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockStatus.mockResolvedValue({ can_reconnect: true, status: 'running', run_id: 'run-live', active_tasks: [] });
+      let emit: ((e: Record<string, unknown>) => void) | undefined;
+      mockReconnect.mockImplementation((...args: unknown[]) => {
+        emit = args[3] as (e: Record<string, unknown>) => void;
+        emit({ event: 'metadata', thread_id: 'th-live', run_id: 'run-live' });
+        emit(textChunk('x'));
+        return new Promise<{ disconnected: boolean; aborted: boolean }>(() => {});
+      });
+
+      const { result } = renderHookWithProviders(() => useChatMessages('ws', 'th-live'));
+      await waitFor(() => expect(mockReconnect).toHaveBeenCalledTimes(1));
+
+      // A marker-less stream that keeps trickling would restart the window
+      // forever; the cap ends the hold.
+      for (let elapsed = 0; elapsed < RECONNECT_BACKLOG_CAP_MS; elapsed += 1000) {
+        await act(async () => { vi.advanceTimersByTime(1000); });
+        await act(async () => { emit?.(textChunk('x')); });
+      }
+      expect(assistantText(result.current.messages)).not.toBe('');
+      expect(result.current.isReconnecting).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
+++ b/web/src/pages/ChatAgent/hooks/__tests__/useChatMessages.stop.test.ts
@@ -366,6 +366,7 @@ describe('useChatMessages — stopWorkflow (hard stop)', () => {
       onEvent({ event: 'metadata', thread_id: 'th-stop', run_id: 'run-1' });
       onEvent({ event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'reasoning_signal', content: 'start' });
       onEvent({ event: 'message_chunk', role: 'assistant', agent: 'main', content_type: 'reasoning', content: 'resuming...' });
+      onEvent({ event: 'caught_up' });
       return hang.promise;
     });
 

--- a/web/src/pages/ChatAgent/hooks/useChatMessages.ts
+++ b/web/src/pages/ChatAgent/hooks/useChatMessages.ts
@@ -45,7 +45,7 @@ import { useMarketWatch } from './useMarketWatch';
 import type {
   MessageRecord, TokenUsage, PendingInterrupt, PendingRejection,
   SSEEvent, ModelOptions, OffloadBatch, SubagentHistoryEntry, TaskRefs,
-  HistoryInterruptInfo,
+  HistoryInterruptInfo, StreamProcessorRefs,
   ModelStatus, FallbackSuggestion,
 } from '../session/types';
 import { SECRETARY_ACTION_TYPES, setCardStatus } from '../session/interrupts/buckets';
@@ -454,22 +454,27 @@ export function useChatMessages(
     isNewConversation?: boolean;
     isReconnect?: boolean;
     withUnresolvedInterrupt?: boolean;
-  } = {}) => ({
-    contentOrderCounterRef,
-    currentReasoningIdRef,
-    currentToolCallIdRef,
-    steeringAtOrderRef,
-    updateTodoListCard: updateTodoListCard || undefined,
-    isNewConversation: o.isNewConversation ?? false,
-    subagentStateRefs: subagentStateRefsRef.current,
-    updateSubagentCard: !updateSubagentCard
-      ? (() => {})
-      : o.isReconnect
-        ? (agentId: string, data: Record<string, unknown>) => updateSubagentCard(agentId, { ...data, isReconnect: true })
-        : updateSubagentCard,
-    ...(o.isReconnect ? { isReconnect: true } : {}),
-    ...(o.withUnresolvedInterrupt ? { unresolvedHistoryInterruptRef } : {}),
-  });
+  } = {}): StreamProcessorRefs => {
+    const refs: StreamProcessorRefs = {
+      contentOrderCounterRef,
+      currentReasoningIdRef,
+      currentToolCallIdRef,
+      steeringAtOrderRef,
+      updateTodoListCard: updateTodoListCard || undefined,
+      isNewConversation: o.isNewConversation ?? false,
+      subagentStateRefs: subagentStateRefsRef.current,
+      updateSubagentCard: updateSubagentCard || (() => {}),
+      ...(o.isReconnect ? { isReconnect: true } : {}),
+      ...(o.withUnresolvedInterrupt ? { unresolvedHistoryInterruptRef } : {}),
+    };
+    // Read at call time: a reconnect flips the bag live once its backlog is
+    // applied, and the cards it updates after that are live too.
+    if (updateSubagentCard && o.isReconnect) {
+      refs.updateSubagentCard = (agentId: string, data: Record<string, unknown>) =>
+        updateSubagentCard(agentId, refs.isReconnect ? { ...data, isReconnect: true } : data);
+    }
+    return refs;
+  };
 
   // Per-task running total of token usage. Backend emits per-call deltas via
   // `context_window/token_usage` events; we sum here. The ref is the source

--- a/web/src/pages/ChatAgent/hooks/utils/contextWindowEvent.ts
+++ b/web/src/pages/ChatAgent/hooks/utils/contextWindowEvent.ts
@@ -6,6 +6,7 @@
 import type { SSEEvent, ContextWindowCallbacks, TokenUsage } from '../../session/types';
 import type { AssistantMessage } from '@/types/chat';
 import { updateMessage } from './messageHelpers';
+import { nextArrivalSeq } from '../../session/streamRefs';
 
 /**
  * Shared handler for context_window SSE events (token_usage, summarize, offload).
@@ -58,6 +59,7 @@ function handleContextWindowEvent(event: SSEEvent, { getMsgId, nextOrder, setMes
           return {
             ...aMsg,
             contentSegments: [...(aMsg.contentSegments || []), { type: 'notification' as const, content: text, order, detail }],
+            arrivalSeq: nextArrivalSeq(aMsg),
           };
         }));
       } else {
@@ -109,6 +111,7 @@ function handleContextWindowEvent(event: SSEEvent, { getMsgId, nextOrder, setMes
               return {
                 ...aMsg,
                 contentSegments: [...(aMsg.contentSegments || []), { type: 'notification' as const, content: text, order }],
+                arrivalSeq: nextArrivalSeq(aMsg),
               };
             }));
           } else {

--- a/web/src/pages/ChatAgent/session/stream/__tests__/reconnectStamps.test.ts
+++ b/web/src/pages/ChatAgent/session/stream/__tests__/reconnectStamps.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { handleReasoningSignal, handleToolCalls } from '../mainEventHandlers';
+import { dispatchWithReplayStamp } from '../processStreamEvent';
+import type { MessageRecord, SetMessages } from '../../../hooks/utils/types';
+import type { StreamRefs } from '../../streamRefs';
+
+// React applies a setMessages updater after the synchronous flush of a
+// reconnect backlog has already flipped the refs bag live. The live-zone
+// stamps must therefore be read when the event arrives, not when the
+// updater runs, or every completion the backlog carried takes a live turn
+// and folds away 1.8 s after catch-up.
+function deferredSetMessages(initial: MessageRecord[]) {
+  const updaters: ((prev: MessageRecord[]) => MessageRecord[])[] = [];
+  const setMessages = ((updater: (prev: MessageRecord[]) => MessageRecord[]) => {
+    updaters.push(updater);
+  }) as unknown as SetMessages;
+  const apply = () => updaters.reduce((msgs, u) => u(msgs), initial);
+  return { setMessages, apply };
+}
+
+function reconnectRefs(): StreamRefs {
+  return {
+    contentOrderCounterRef: { current: 0 },
+    currentReasoningIdRef: { current: null },
+    currentToolCallIdRef: { current: null },
+    isReconnect: true,
+  };
+}
+
+describe('reconnect stamps are read on arrival', () => {
+  it('a reasoning completion held in the backlog folds even if the bag flips before the updater runs', () => {
+    const refs = reconnectRefs();
+    const { setMessages, apply } = deferredSetMessages([{ id: 'a', role: 'assistant', contentSegments: [] } as MessageRecord]);
+    handleReasoningSignal({ assistantMessageId: 'a', signalContent: 'start', refs, setMessages });
+    handleReasoningSignal({ assistantMessageId: 'a', signalContent: 'complete', refs, setMessages });
+    refs.isReconnect = false;
+    const [msg] = apply();
+    const [proc] = Object.values(msg.reasoningProcesses as Record<string, Record<string, unknown>>);
+    expect(proc._completedAt).toBe(1);
+  });
+
+  it('a tool call held in the backlog folds even if the bag flips before the updater runs', () => {
+    const refs = reconnectRefs();
+    const { setMessages, apply } = deferredSetMessages([{ id: 'a', role: 'assistant', contentSegments: [] } as MessageRecord]);
+    handleToolCalls({
+      assistantMessageId: 'a',
+      toolCalls: [{ id: 't1', name: 'bash', args: {} }],
+      finishReason: undefined,
+      refs,
+      setMessages,
+    });
+    refs.isReconnect = false;
+    const [msg] = apply();
+    expect((msg.toolCallProcesses as Record<string, Record<string, unknown>>).t1._createdAt).toBe(1);
+  });
+
+  it('a live tool call gets a real timestamp', () => {
+    const refs = { ...reconnectRefs(), isReconnect: false };
+    const { setMessages, apply } = deferredSetMessages([{ id: 'a', role: 'assistant', contentSegments: [] } as MessageRecord]);
+    handleToolCalls({ assistantMessageId: 'a', toolCalls: [{ id: 't1', name: 'bash', args: {} }], finishReason: undefined, refs, setMessages });
+    const [msg] = apply();
+    expect((msg.toolCallProcesses as Record<string, Record<string, unknown>>).t1._createdAt as number).toBeGreaterThan(1);
+  });
+});
+
+describe('replay frames from the thread mux', () => {
+  const seen = (refs: { isReconnect?: boolean }, reconnectOrigin: boolean, replay: boolean) => {
+    let stamp: boolean | undefined;
+    dispatchWithReplayStamp(refs, reconnectOrigin, { event: 'message_chunk', ...(replay ? { _replay: true } : {}) }, () => {
+      stamp = refs.isReconnect;
+    });
+    return [stamp, refs.isReconnect];
+  };
+
+  it('fold as history on a reconnect-born processor whose bag already flipped live', () => {
+    expect(seen({ isReconnect: false }, true, true)).toEqual([true, false]);
+  });
+
+  it('stay live on a send-born processor, where a replay from 0 is the fresh transcript', () => {
+    expect(seen({ isReconnect: false }, false, true)).toEqual([false, false]);
+  });
+
+  it('leave an unmarked frame and a still-replaying bag alone', () => {
+    expect(seen({ isReconnect: false }, true, false)).toEqual([false, false]);
+    expect(seen({ isReconnect: true }, true, true)).toEqual([true, true]);
+  });
+});

--- a/web/src/pages/ChatAgent/session/stream/__tests__/threadStreamMux.test.ts
+++ b/web/src/pages/ChatAgent/session/stream/__tests__/threadStreamMux.test.ts
@@ -153,6 +153,20 @@ describe('ThreadStreamMux (v2 contract client)', () => {
     mux.detach();
   }, 15000);
 
+  it('marks frames as replay until the channel reports caught up', async () => {
+    const tid = freshThread();
+    const { sink, events } = makeSink();
+    const mux = getThreadMux(tid);
+    mux.attach(sink);
+    const c1 = await connected(1);
+    c1.push(chanOpen('r1', 'task:t1'));
+    c1.push(taskFrame('r1', 'task:t1', '1-0', 1, 'a'));
+    c1.push(`event: chan_caught_up\ndata: ${JSON.stringify({ chan: 'run:r1' })}\n\n`);
+    c1.push(taskFrame('r1', 'task:t1', '2-0', 2, 'b'));
+    expect(events.map((e) => [e.content, e._replay])).toEqual([['a', true], ['b', undefined]]);
+    mux.detach();
+  }, 15000);
+
   it('drain-closing a predecessor run is not task-terminal while the successor is open', async () => {
     const tid = freshThread();
     const { sink, events, closures } = makeSink();

--- a/web/src/pages/ChatAgent/session/stream/lifecycle.ts
+++ b/web/src/pages/ChatAgent/session/stream/lifecycle.ts
@@ -21,6 +21,13 @@ import type { AssistantMessage } from '@/types/chat';
 import type { SSEEvent, HistoryInterruptInfo, StreamProcessorRefs } from '../types';
 import type { RecoveryRuntime } from '../runtime';
 
+/** Quiet gap after the last held event before a reconnect stream that never
+ *  sends `caught_up` paints what it has. */
+export const RECONNECT_BACKLOG_QUIET_MS = 1500;
+/** Ceiling measured from the first held event, so a replay that keeps the
+ *  quiet window alive still paints instead of being held indefinitely. */
+export const RECONNECT_BACKLOG_CAP_MS = 6000;
+
 export interface ReconnectOptions {
   activeTasks?: string[];
   runId?: string | null;
@@ -339,18 +346,77 @@ export const reconnectToStream = async (
       rt.isReconnectingOwnerRef.current = null;
     }
   };
+  // The per-run log replays its backlog in a burst before the live tail.
+  // Applied event by event, that burst is presented as if it were live: the
+  // bubble mounts empty, the typewriter re-types everything already written,
+  // and the scroll follow chases it. So the backlog is held until the server's
+  // `caught_up` marker and applied in one synchronous pass, which React
+  // batches into a single render: the turn appears as it was, and only what
+  // arrives afterwards streams. The timers are the fallback for a stream that
+  // never sends the marker; they cost a delayed first paint, never lost events.
+  let backlog: SSEEvent[] | null = [];
+  let backlogTimer: ReturnType<typeof setTimeout> | null = null;
+  let backlogCapAt = 0;
+  // One processor for the whole stream: it owns closure state a steering
+  // continuation rewrites (the bubble it appends to, pending task ids), so
+  // the tail cannot be handed to a fresh one. Handlers read `isReconnect` off
+  // the bag on arrival, so flipping it after the synchronous flush is what
+  // turns the tail live. Only the stream that still owns the reader may paint
+  // what it held: a superseded or stopped one discards its backlog, and the
+  // cursor stays put, so the reconnect that replaced it replays the same
+  // events from the log.
+  const flushBacklog = () => {
+    if (!backlog) return;
+    const held = backlog;
+    backlog = null;
+    if (backlogTimer) clearTimeout(backlogTimer);
+    backlogTimer = null;
+    if (rt.wasStoppedRef.current || rt.mainStreamAbortRef.current !== abortController) return;
+    for (const heldEvent of held) baseProcessEvent(heldEvent);
+    refs.isReconnect = false;
+    // Reaching this point is itself proof the stream is attached and current.
+    markReconnected();
+  };
+  // Restart the quiet window on every held event so a slow replay is not cut
+  // in half, but never hold past the cap.
+  const armBacklogTimer = () => {
+    const now = Date.now();
+    if (!backlogCapAt) backlogCapAt = now + RECONNECT_BACKLOG_CAP_MS;
+    if (backlogTimer) clearTimeout(backlogTimer);
+    backlogTimer = setTimeout(
+      flushBacklog,
+      Math.max(0, Math.min(RECONNECT_BACKLOG_QUIET_MS, backlogCapAt - now)),
+    );
+  };
   const processEvent = (event: SSEEvent) => {
-    receivedEvent = true;
     // Progress resets the re-arm budget: a healthy run with an occasional
     // >idleAbortMs gap must never accrue toward the wedged-run cap.
     idleRearms = 0;
+    bumpIdle?.();
+    // The marker is transport, not content: a stream that sent only it has
+    // rendered nothing, and must read as such when it closes.
+    if (event.event === 'caught_up') {
+      flushBacklog();
+      return;
+    }
+    receivedEvent = true;
+    if (backlog) {
+      backlog.push(event);
+      armBacklogTimer();
+      return;
+    }
     baseProcessEvent(event);
     markReconnected();
-    bumpIdle?.();
   };
   // Arm before the first read so an un-started run (no events at all) still
   // trips the watchdog instead of hanging forever.
   bumpIdle?.();
+  // Bound the hold from the first read, not the first held event: a stream
+  // that sends neither marker nor data (the head probe failed with the
+  // cursor already at the head) would otherwise keep the spinner up until
+  // the model speaks again.
+  backlogCapAt = Date.now() + RECONNECT_BACKLOG_CAP_MS;
+  backlogTimer = setTimeout(flushBacklog, RECONNECT_BACKLOG_CAP_MS);
 
   try {
     // Replay buffered events first — this processes artifact{task,spawned} events
@@ -363,6 +429,10 @@ export const reconnectToStream = async (
       processEvent,
       abortController.signal,
     );
+    // A stream that ended (or dropped) before the marker still shows what it
+    // delivered, and advances the cursor so a retry resumes after it. Not on
+    // a user stop: stopWorkflow already finalized the bubble.
+    flushBacklog();
     // User stop aborted the reader — stopWorkflow owns teardown; bail.
     // Exception: a foreground handler aborted this stream because the tab
     // resumed (background abort, not a user stop) — re-kick the reconnect.
@@ -428,6 +498,7 @@ export const reconnectToStream = async (
       deps.attachSubagentMux(tid, processEvent, snapshotAtMs);
     }
   } catch (err: unknown) {
+    flushBacklog();
     // User stop aborted the reader — stopWorkflow owns teardown; bail before
     // surfacing this as a reconnect error.
     if ((err as Error)?.name === 'AbortError' || rt.wasStoppedRef.current) {
@@ -444,6 +515,7 @@ export const reconnectToStream = async (
   } finally {
     // Stop the idle watchdog (no-op when it already fired or was never armed).
     if (idleTimer) clearTimeout(idleTimer);
+    if (backlogTimer) clearTimeout(backlogTimer);
     // Clean up empty reconnect messages (no content segments = nothing was
     // streamed). Skip on a user stop: finalizeStreamingMessage just stamped
     // this bubble `stopped: true` (with the "⏹ Stopped" chip) but left it

--- a/web/src/pages/ChatAgent/session/stream/mainEventHandlers.ts
+++ b/web/src/pages/ChatAgent/session/stream/mainEventHandlers.ts
@@ -30,6 +30,10 @@ export function handleReasoningSignal({ assistantMessageId, signalContent, refs,
   eventId?: number | null;
 }): boolean {
   const { contentOrderCounterRef, currentReasoningIdRef } = refs;
+  // Stamped on arrival, not inside the updater: React runs the updater after
+  // a reconnect flush has already flipped the bag live, and a completion the
+  // backlog carried must still fold on arrival rather than take a live turn.
+  const completedAt = refs.isReconnect ? 1 : Date.now();
 
   if (signalContent === 'start') {
     // Reasoning process has started - create new reasoning process
@@ -83,7 +87,7 @@ export function handleReasoningSignal({ assistantMessageId, signalContent, refs,
               isReasoning: false,
               reasoningComplete: true,
               reasoningTitle: null,
-              _completedAt: refs.isReconnect ? 1 : Date.now(),
+              _completedAt: completedAt,
             };
           }
 
@@ -252,21 +256,17 @@ export function handleToolCalls({ assistantMessageId, toolCalls, finishReason: _
   eventId?: number | null;
 }): boolean {
   const { contentOrderCounterRef } = refs;
+  // Same arrival-time rule as the reasoning stamp: read before the updater.
+  const createdAt = refs.isReconnect ? 1 : Date.now();
 
   if (!toolCalls || !Array.isArray(toolCalls)) {
     return false;
   }
 
-  // Track creation times outside React state so handleToolCallResult can read them synchronously
-  if (!refs._toolCreatedAt) refs._toolCreatedAt = {};
-
   toolCalls.forEach((toolCall: ToolCallRecord, toolIndex: number) => {
     const toolCallId = toolCall.id;
 
     if (toolCallId) {
-      if (!refs.isReconnect && !refs._toolCreatedAt![toolCallId]) {
-        refs._toolCreatedAt![toolCallId] = Date.now();
-      }
       setMessages((prev: MessageRecord[]) =>
         prev.map((msg: MessageRecord) => {
           if (msg.id !== assistantMessageId) return msg;
@@ -293,7 +293,7 @@ export function handleToolCalls({ assistantMessageId, toolCalls, finishReason: _
               toolCallResult: null,
               isInProgress: true,
               isComplete: false,
-              _createdAt: refs.isReconnect ? 1 : Date.now(),
+              _createdAt: createdAt,
               order: currentOrder,
             };
           } else {

--- a/web/src/pages/ChatAgent/session/stream/mainEventHandlers.ts
+++ b/web/src/pages/ChatAgent/session/stream/mainEventHandlers.ts
@@ -10,7 +10,7 @@ import type { MessageRecord, SetMessages, ToolCallRecord, ToolCallResultRecord, 
 import type { ProvenanceEvent } from '@/types/sse';
 import type { ProvenanceRecord, SubagentTaskRecord } from '@/types/chat';
 import { provenanceEventToRecord, provenanceRecordKey } from './provenance';
-import { extractLastReasoningTitle } from '../streamRefs';
+import { extractLastReasoningTitle, nextArrivalSeq } from '../streamRefs';
 import type { StreamRefs, ToolCallChunkRecord } from '../streamRefs';
 
 /**
@@ -142,6 +142,7 @@ export function handleReasoningContent({ assistantMessageId, content, refs, setM
         return {
           ...msg,
           reasoningProcesses,
+          arrivalSeq: nextArrivalSeq(msg),
         };
       })
     );
@@ -219,6 +220,7 @@ export function handleTextContent({ assistantMessageId, content, finishReason, r
           content: accumulatedText,
           contentType: 'text',
           isStreaming: true,
+          arrivalSeq: nextArrivalSeq(msg),
         };
       })
     );
@@ -632,7 +634,7 @@ export function handleToolCallChunks({ assistantMessageId, chunks, setMessages }
           firstSeenAt: existing.firstSeenAt,
         };
 
-        return { ...msg, pendingToolCallChunks: pending };
+        return { ...msg, pendingToolCallChunks: pending, arrivalSeq: nextArrivalSeq(msg) };
       })
     );
   });

--- a/web/src/pages/ChatAgent/session/stream/processStreamEvent.ts
+++ b/web/src/pages/ChatAgent/session/stream/processStreamEvent.ts
@@ -64,6 +64,7 @@ export interface StreamRouterDeps {
  */
 // TODO: type properly — refs should use a proper interface matching StreamRefs from streamEventHandlers
 export const createStreamEventProcessor = (rt: StreamRuntime, deps: StreamRouterDeps, assistantMessageId: string, refs: StreamProcessorRefs, getTaskIdFromEvent: (event: SSEEvent) => string | null, wasInterruptedRef: { current: boolean } | null = null) => {
+  const reconnectOrigin = refs.isReconnect === true;
   const setMessagesForHandlers = rt.setMessages as unknown as (
     updater: (prev: Record<string, unknown>[]) => Record<string, unknown>[]
   ) => void;
@@ -129,7 +130,7 @@ export const createStreamEventProcessor = (rt: StreamRuntime, deps: StreamRouter
     rt.updateSubagentCard(taskId, { ...card, messages: updatedMessages });
   };
 
-  const processEvent = (event: SSEEvent): void => {
+  const dispatch = (event: SSEEvent): void => {
     const eventType = event.event || 'message_chunk';
 
     // Check if this is a subagent event — filtered from the main chat view
@@ -1037,5 +1038,33 @@ export const createStreamEventProcessor = (rt: StreamRuntime, deps: StreamRouter
     }
   };
 
+  const processEvent = (event: SSEEvent): void =>
+    dispatchWithReplayStamp(refs, reconnectOrigin, event, dispatch);
+
   return processEvent;
+};
+
+/**
+ * Dispatch a mux frame with the stamp its channel asks for. A frame marked
+ * `_replay` existed before the channel opened, so a processor born on a
+ * reconnect (its bag flipped live once the main backlog flushed) folds it
+ * as history. A processor born on a send ignores the mark: there a task's
+ * replay from 0 is its whole, fresh transcript.
+ */
+export const dispatchWithReplayStamp = (
+  refs: { isReconnect?: boolean },
+  reconnectOrigin: boolean,
+  event: SSEEvent,
+  dispatch: (event: SSEEvent) => void,
+): void => {
+  if (event._replay !== true || !reconnectOrigin || refs.isReconnect) {
+    dispatch(event);
+    return;
+  }
+  refs.isReconnect = true;
+  try {
+    dispatch(event);
+  } finally {
+    refs.isReconnect = false;
+  }
 };

--- a/web/src/pages/ChatAgent/session/stream/threadStreamMux.ts
+++ b/web/src/pages/ChatAgent/session/stream/threadStreamMux.ts
@@ -20,6 +20,7 @@
  * being buffered.
  */
 import { openThreadMuxStream } from '../../utils/api';
+import { RECONNECT_BACKLOG_CAP_MS } from './lifecycle';
 import { taskIdFromAgentId } from '../../utils/agentId';
 
 type SSEEventObj = Record<string, unknown>;
@@ -49,6 +50,12 @@ interface RunChannel {
   // Server-declared run start (epoch ms, ledger row truth; 0 = undeclared).
   // Outcome voting orders by this — close order never decides.
   startedAt: number;
+  // Between chan_open and chan_caught_up the frames are the backlog that
+  // existed when the channel opened, and carry `_replay` so the sink can
+  // present them as already rendered. The timer bounds a marker that never
+  // comes (a failed head probe) at the main stream's own backlog cap.
+  replaying: boolean;
+  replayCap: ReturnType<typeof setTimeout> | null;
 }
 
 interface ParsedFrame {
@@ -59,6 +66,7 @@ interface ParsedFrame {
 
 const CONTROL_EVENTS = new Set([
   'chan_open',
+  'chan_caught_up',
   'chan_close',
   'resync_required',
   'transport_error',
@@ -229,6 +237,7 @@ export class ThreadStreamMux {
     if (this.disposed) return;
     this.disposed = true;
     this.controller?.abort();
+    for (const chan of this.runs.values()) this.endReplay(chan);
     this.onDispose();
   }
 
@@ -353,6 +362,7 @@ export class ThreadStreamMux {
       ev._drain = true;
       if (chan.startedAt) ev._runStartedMs = chan.startedAt;
     }
+    if (chan.replaying) ev._replay = true;
     try {
       this.sink?.onTaskEvent(ev);
       // Cursor and high-water advance only after successful delivery: the
@@ -382,6 +392,13 @@ export class ThreadStreamMux {
       chan.closed = false;
       chan.drain = data.mode === 'drain';
       if (typeof data.started === 'number') chan.startedAt = data.started;
+      this.beginReplay(chan);
+      return;
+    }
+    if (event === 'chan_caught_up') {
+      const runId = runIdFromChanName(data.chan);
+      const chan = runId ? this.runs.get(runId) : undefined;
+      if (chan) this.endReplay(chan);
       return;
     }
     if (event === 'resync_required' && typeof data.chan !== 'string') {
@@ -410,6 +427,7 @@ export class ThreadStreamMux {
       if (!runId) return;
       const chan = this.runs.get(runId);
       if (!chan || chan.closed) return;
+      this.endReplay(chan);
       if (data.reason === 'resync_required') {
         // Our cursor points below a lost head. Drop the cursor and force one
         // reconnect: the channel re-attaches in replay mode from 0, and the
@@ -468,6 +486,18 @@ export class ThreadStreamMux {
     // here (the report-back watch has its own transport until M8).
   }
 
+  private beginReplay(chan: RunChannel): void {
+    if (chan.replayCap) clearTimeout(chan.replayCap);
+    chan.replaying = true;
+    chan.replayCap = setTimeout(() => this.endReplay(chan), RECONNECT_BACKLOG_CAP_MS);
+  }
+
+  private endReplay(chan: RunChannel): void {
+    if (chan.replayCap) clearTimeout(chan.replayCap);
+    chan.replayCap = null;
+    chan.replaying = false;
+  }
+
   private getOrCreateRun(runId: string, lane: string): RunChannel {
     let chan = this.runs.get(runId);
     if (!chan) {
@@ -480,6 +510,8 @@ export class ThreadStreamMux {
         outcome: null,
         drain: false,
         startedAt: 0,
+        replaying: false,
+        replayCap: null,
       };
       this.runs.set(runId, chan);
     } else if (lane && !chan.lane) {

--- a/web/src/pages/ChatAgent/session/streamRefs.ts
+++ b/web/src/pages/ChatAgent/session/streamRefs.ts
@@ -40,6 +40,16 @@ interface ToolCallChunkRecord {
 }
 
 /**
+ * Next value of a message's monotonic arrival counter. Every landed reply
+ * text, reasoning text or tool-argument chunk bumps it, so a bubble can tell
+ * "text is still flowing" from "the turn has gone quiet" without re-measuring
+ * everything it holds.
+ */
+export function nextArrivalSeq(msg: { arrivalSeq?: unknown }): number {
+  return ((msg.arrivalSeq as number) ?? 0) + 1;
+}
+
+/**
  * Extracts the last markdown bold title (**...**) from reasoning content for the icon label.
  * Used only during live streaming; history always shows "Reasoning".
  * @param {string} content - Accumulated reasoning text

--- a/web/src/pages/ChatAgent/session/streamRefs.ts
+++ b/web/src/pages/ChatAgent/session/streamRefs.ts
@@ -25,8 +25,7 @@ interface StreamRefs {
   currentReasoningIdRef: { current: string | null };
   currentToolCallIdRef: { current: string | null };
   subagentStateRefs?: Record<string, TaskRefs>;
-  isReconnect?: boolean | number;
-  _toolCreatedAt?: Record<string, number>;
+  isReconnect?: boolean;
   updateTodoListCard?: (data: Record<string, unknown>, isNew: boolean) => void;
   isNewConversation?: boolean;
   [key: string]: unknown;

--- a/web/src/pages/ChatAgent/session/subagents/liveEventHandlers.ts
+++ b/web/src/pages/ChatAgent/session/subagents/liveEventHandlers.ts
@@ -11,7 +11,7 @@ import {
   type WorkflowLifecycleFrame, type WorkflowRunState,
 } from './workflowRunState';
 import type { MessageRecord, ToolCallRecord, ToolCallResultRecord } from '../../hooks/utils/types';
-import { getOrCreateTaskRefs, extractLastReasoningTitle } from '../streamRefs';
+import { getOrCreateTaskRefs, extractLastReasoningTitle, nextArrivalSeq } from '../streamRefs';
 import { isTaskAgentId } from '../../utils/agentId';
 import type {
   StreamRefs, TaskRefs, ToolCallChunkRecord, UpdateSubagentCard,
@@ -209,6 +209,7 @@ export function handleSubagentMessageChunk({
       ...prev,
       contentSegments: nextContentSegments,
       reasoningProcesses,
+      arrivalSeq: nextArrivalSeq(prev),
     };
     taskRefs.messages = updatedMessages;
     updateSubagentCard(taskId, { messages: updatedMessages });
@@ -249,6 +250,7 @@ export function handleSubagentMessageChunk({
       content: ((prev.content as string) || '') + content,
       contentType: 'text',
       isStreaming: true,
+      arrivalSeq: nextArrivalSeq(prev),
     };
 
     taskRefs.messages = updatedMessages;
@@ -314,6 +316,7 @@ export function handleSubagentToolCallChunks({ taskId, assistantMessageId, chunk
   });
 
   msg.pendingToolCallChunks = pending;
+  msg.arrivalSeq = nextArrivalSeq(msg);
   updatedMessages[messageIndex] = msg;
   taskRefs.messages = updatedMessages;
 

--- a/web/src/pages/ChatAgent/session/types.ts
+++ b/web/src/pages/ChatAgent/session/types.ts
@@ -8,6 +8,7 @@ import type React from 'react';
 import type { ChatMessage } from '@/types/chat';
 import type { ActionRequest, ToolCallData } from '@/types/sse';
 import type { SubagentTokenUsage } from '../utils/tokenUsage';
+import type { StreamRefs } from './streamRefs';
 
 // --- Internal types for useChatMessages ---
 
@@ -56,6 +57,9 @@ interface SSEEvent {
   role?: string;
   turn_index?: number;
   _eventId?: number | string;
+  // Set by the thread mux on a frame from a channel still replaying the
+  // backlog that existed when it opened; cleared by chan_caught_up.
+  _replay?: boolean;
   timestamp?: string | number;
   metadata?: Record<string, unknown>;
   tool_calls?: ToolCallData[];
@@ -222,19 +226,12 @@ interface SubagentHistoryData {
   projectedRunStartedMs?: number;
 }
 
-/** Refs passed to createStreamEventProcessor and its processEvent closure. */
-interface StreamProcessorRefs {
-  contentOrderCounterRef: { current: number };
-  currentReasoningIdRef: { current: string | null };
-  currentToolCallIdRef: { current: string | null };
+/** Refs passed to createStreamEventProcessor and its processEvent closure:
+ *  the handler-facing bag plus the fields only the main stream carries. */
+interface StreamProcessorRefs extends StreamRefs {
   steeringAtOrderRef?: { current: number | null };
-  updateTodoListCard?: ((data: Record<string, unknown>, isNew: boolean) => void) | undefined;
-  isNewConversation?: boolean;
-  subagentStateRefs?: Record<string, TaskRefs>;
   updateSubagentCard?: ((agentId: string, data: Record<string, unknown>) => void);
-  isReconnect?: boolean;
   unresolvedHistoryInterruptRef?: React.MutableRefObject<HistoryInterruptInfo[]>;
-  [key: string]: unknown;
 }
 
 /** Pair state tracked per turn_index during history replay. */

--- a/web/src/pages/ChatAgent/utils/__tests__/markdownBlocks.test.ts
+++ b/web/src/pages/ChatAgent/utils/__tests__/markdownBlocks.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { splitMarkdownBlocks } from '../markdownBlocks';
+
+describe('splitMarkdownBlocks', () => {
+  it('reproduces the input when joined and cuts at paragraph breaks', () => {
+    const doc = '# Title\n\nFirst paragraph.\n\nSecond paragraph.\n';
+    const blocks = splitMarkdownBlocks(doc);
+    expect(blocks.join('')).toBe(doc);
+    expect(blocks).toEqual(['# Title\n\n', 'First paragraph.\n\n', 'Second paragraph.\n']);
+  });
+
+  it('keeps a fenced code block whole across blank lines, closed or not', () => {
+    const closed = 'Intro\n\n```python\na = 1\n\nb = 2\n```\n\nAfter\n';
+    expect(splitMarkdownBlocks(closed)).toEqual(['Intro\n\n', '```python\na = 1\n\nb = 2\n```\n\n', 'After\n']);
+    const open = 'Intro\n\n```python\na = 1\n\nb = 2\n';
+    expect(splitMarkdownBlocks(open)).toEqual(['Intro\n\n', '```python\na = 1\n\nb = 2\n']);
+  });
+
+  it('keeps display math whole across blank lines', () => {
+    const doc = 'Solve\n\n$$\nx = 1\n\ny = 2\n$$\n\nDone\n';
+    expect(splitMarkdownBlocks(doc)).toEqual(['Solve\n\n', '$$\nx = 1\n\ny = 2\n$$\n\n', 'Done\n']);
+  });
+
+  it('keeps loose lists and indented continuations in one block', () => {
+    const loose = '- a\n\n- b\n\n1. c\n\nPara\n';
+    expect(splitMarkdownBlocks(loose)).toEqual(['- a\n\n- b\n\n1. c\n\n', 'Para\n']);
+    const nested = '- item\n\n  continued paragraph\n\n  ```sh\n  ls\n  ```\n\nPara\n';
+    expect(splitMarkdownBlocks(nested)).toEqual(['- item\n\n  continued paragraph\n\n  ```sh\n  ls\n  ```\n\n', 'Para\n']);
+  });
+
+  it('renders whole when a construct has cross-block meaning', () => {
+    for (const doc of [
+      'See [spec][1].\n\n[1]: https://example.com\n',
+      'Claim[^1].\n\n[^1]: Footnote.\n',
+      '<div align="center">\n\n**bold**\n\n</div>\n',
+      // Tag names are case-insensitive to the parser, so they are here too.
+      '<DETAILS>\n\n<SUMMARY>More</SUMMARY>\n\n</DETAILS>\n',
+      // Allowed containers outside CommonMark's list keep their children too.
+      '<picture>\n\n<source srcset="a.avif" />\n<img src="a.png" />\n\n</picture>\n',
+      '<svg viewBox="0 0 10 10">\n\n<circle r="4" />\n\n</svg>\n',
+      '<math>\n\n<mi>x</mi>\n\n</math>\n',
+      '<!-- note -->\n\nPara\n',
+      // A definition keeps document scope inside a block quote or list item.
+      '> [ref]: https://example.com\n\nSee [spec][ref].\n',
+      '- [ref]: https://example.com\n\nSee [spec][ref].\n',
+      '1. > [^1]: Footnote.\n\nClaim[^1].\n',
+    ]) {
+      expect(splitMarkdownBlocks(doc)).toEqual([doc]);
+    }
+  });
+
+  it('ignores cross-block lookalikes inside a fence or display math', () => {
+    const fenced = 'Para\n\n```html\n<div>\n[label]: value\n```\n\nAfter\n';
+    expect(splitMarkdownBlocks(fenced)).toEqual(['Para\n\n', '```html\n<div>\n[label]: value\n```\n\n', 'After\n']);
+    const math = 'Para\n\n$$\n<p>\n$$\n\nAfter\n';
+    expect(splitMarkdownBlocks(math)).toEqual(['Para\n\n', '$$\n<p>\n$$\n\n', 'After\n']);
+  });
+
+  it('does not treat an inline citation element as block HTML', () => {
+    const doc = '<cite-bubble label="a" href="https://x"></cite-bubble> leads.\n\nNext\n';
+    expect(splitMarkdownBlocks(doc)).toHaveLength(2);
+  });
+
+  it('handles empty input and runs of blank lines', () => {
+    expect(splitMarkdownBlocks('')).toEqual(['']);
+    expect(splitMarkdownBlocks('\n\n')).toEqual(['\n\n']);
+    expect(splitMarkdownBlocks('a\n\n\n\nb')).toEqual(['a\n\n\n\n', 'b']);
+  });
+});

--- a/web/src/pages/ChatAgent/utils/markdownBlocks.ts
+++ b/web/src/pages/ChatAgent/utils/markdownBlocks.ts
@@ -1,0 +1,100 @@
+/**
+ * Splits a markdown document into independently renderable blocks.
+ *
+ * A streaming reply re-renders on every typewriter tick, and the parser, the
+ * syntax highlighter and React all pay for the whole document each time. Cut
+ * at blank lines the parser would also stop at, and everything but the last
+ * block becomes a fixed string the renderer can memoize.
+ *
+ * Correctness over granularity: a cut in the wrong place changes the rendered
+ * output, a missed cut only costs memoization. So a blank line inside a fence,
+ * a display-math block, or a loose list never splits, an indented line after a
+ * blank line is treated as a continuation, and a document that uses constructs
+ * with cross-block meaning (link reference definitions, footnotes, block-level
+ * raw HTML) is rendered whole.
+ *
+ * That last bail is decided per call against the text so far, so a reply that
+ * streams its first raw HTML tag or reference definition collapses from many
+ * blocks to one at that tick and remounts once. It stays whole from there on,
+ * since the text only grows.
+ */
+import { FENCE_OPEN_RE, closesFence } from './markdownSegments';
+
+const BLANK_RE = /^[ \t]*$/;
+const LIST_ITEM_RE = /^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)/;
+const INDENTED_RE = /^[ \t]/;
+/**
+ * Block-quote and list-item markers a line may open with. A definition keeps
+ * its document-wide scope inside those containers, so they are stripped
+ * before the cross-block test rather than hiding it.
+ */
+const CONTAINER_PREFIX_RE = /^(?: {0,3}(?:>|[-*+]|\d{1,9}[.)])(?:[ \t]|$))+/;
+/**
+ * A line opening a construct whose meaning depends on other blocks: render
+ * the whole document. The tag list is CommonMark's block-HTML set plus the
+ * containers the sanitizer lets through beyond it (picture, svg, math),
+ * whose children may sit past a blank line. Tested per line outside fences and display math, where
+ * the same text is literal, with any container prefix removed first.
+ */
+const CROSS_BLOCK_RE = /^ {0,3}(?:\[[^\]]+\]:|<(?:!--|\/?(?:address|article|aside|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|math|menu|nav|noframes|ol|optgroup|option|p|param|picture|pre|script|section|source|style|summary|svg|table|tbody|td|textarea|tfoot|th|thead|title|tr|track|ul)\b))/i;
+
+/**
+ * Returns the blocks in order; joining them reproduces the input exactly.
+ * Trailing blank lines belong to the block before them.
+ */
+export function splitMarkdownBlocks(content: string): string[] {
+  if (!content) return [content];
+
+  const lines = content.split(/(?<=\n)/);
+  const blocks: string[] = [];
+  let current = '';
+  let fence: string | null = null;
+  let inMath = false;
+  let pendingBlank = false;
+  // A list item anywhere in the block keeps its list open to the block's end
+  // (a lazy or indented line never closes one), so a following item after a
+  // blank line is the same loose list even when the block opened with a
+  // paragraph or heading the item interrupted.
+  let listOpen = false;
+
+  for (const line of lines) {
+    const body = line.replace(/\r?\n$/, '');
+
+    if (fence !== null) {
+      current += line;
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+    if (inMath) {
+      current += line;
+      if ((body.match(/\$\$/g) || []).length % 2 === 1) inMath = false;
+      continue;
+    }
+
+    if (BLANK_RE.test(body)) {
+      current += line;
+      pendingBlank = current.trim().length > 0;
+      continue;
+    }
+    if (CROSS_BLOCK_RE.test(body.replace(CONTAINER_PREFIX_RE, ''))) return [content];
+
+    if (pendingBlank) {
+      pendingBlank = false;
+      const continues = INDENTED_RE.test(body) || (listOpen && LIST_ITEM_RE.test(body));
+      if (!continues) {
+        blocks.push(current);
+        current = '';
+        listOpen = false;
+      }
+    }
+
+    current += line;
+    if (LIST_ITEM_RE.test(body)) listOpen = true;
+    const open = FENCE_OPEN_RE.exec(line);
+    if (open) fence = open[1];
+    else if ((body.match(/\$\$/g) || []).length % 2 === 1) inMath = true;
+  }
+
+  if (current) blocks.push(current);
+  return blocks.length ? blocks : [content];
+}

--- a/web/src/pages/ChatAgent/utils/markdownSegments.ts
+++ b/web/src/pages/ChatAgent/utils/markdownSegments.ts
@@ -15,11 +15,11 @@ interface Span {
 }
 
 /** Opening fence: up to 3 spaces of indent, then 3+ backticks or tildes. */
-const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})/;
+export const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})/;
 /** Closing fence: same character as the opener, at least as long, nothing else. */
 const FENCE_CLOSE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/;
 
-function closesFence(line: string, opener: string): boolean {
+export function closesFence(line: string, opener: string): boolean {
   // The terminator has to come off first: JavaScript's `$` does not match ahead
   // of a trailing newline, so testing the raw line never matches.
   const match = FENCE_CLOSE_RE.exec(line.replace(/\r?\n$/, ''));

--- a/web/src/pages/Onboarding/OnboardingProvider.tsx
+++ b/web/src/pages/Onboarding/OnboardingProvider.tsx
@@ -266,14 +266,15 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
       ((pathname === '/dashboard' && !personalizationSnoozed) ||
         pathname === '/chat/t/__default__'));
 
-  // Getting-started: auto-complete route-visit tasks. markTaskDone aborts when
-  // already stamped, so repeat visits are write-free.
+  // Getting-started: auto-complete route-visit tasks. markTaskDone owns the
+  // once-per-task guard, so a refused write is not re-sent on the prefs
+  // identities its rollback and refetch produce.
   useEffect(() => {
     if (isLoading) return;
     for (const task of OFFERED_TASKS) {
-      if (task.visitRoute?.(pathname, search) && prefs.gettingStartedDoneAt[task.id] == null) {
-        markTaskDone(task.id);
-      }
+      if (!task.visitRoute?.(pathname, search)) continue;
+      if (prefs.gettingStartedDoneAt[task.id] != null) continue;
+      markTaskDone(task.id);
     }
   }, [isLoading, pathname, search, prefs, markTaskDone]);
 

--- a/web/src/pages/Onboarding/__tests__/useOnboardingPrefs.test.tsx
+++ b/web/src/pages/Onboarding/__tests__/useOnboardingPrefs.test.tsx
@@ -2,8 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 const mockWrite = vi.fn().mockReturnValue(true);
+const mockRemoteUpdateGen = { current: 0 };
 vi.mock('../onboardingPrefsWriter', () => ({
-  useOnboardingPrefsWriter: () => ({ writeOnboardingPrefs: mockWrite }),
+  useOnboardingPrefsWriter: () => ({ writeOnboardingPrefs: mockWrite, remoteUpdateGen: mockRemoteUpdateGen }),
 }));
 
 let mockPreferences: unknown = { other_preference: {} };
@@ -26,6 +27,7 @@ function applyUpdater(callIndex: number, cur: OnboardingPrefs): OnboardingPrefs 
 describe('useOnboardingPrefs', () => {
   beforeEach(() => {
     mockWrite.mockClear();
+    mockRemoteUpdateGen.current = 0;
     mockPreferences = { other_preference: {} };
     mockLoading = false;
     localStorage.clear();
@@ -65,6 +67,61 @@ describe('useOnboardingPrefs', () => {
     expect(
       applyUpdater(0, { ...emptyOnboardingPrefs(), pageIntrosSeen: { chat: 5 } })
     ).toBeNull();
+  });
+
+  it('markTaskDone attempts each task once per session, even when the write never lands', () => {
+    // A rejected PUT rolls the cache back and then refetches: two new prefs
+    // identities, both still unstamped. Callers stamp from effects keyed on
+    // those prefs (route visits, the stocks and workspace probes), so the
+    // guard has to live here or the same write is re-sent in a tight loop.
+    // The writer accepts the attempt (true); the PUT fails later, async.
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => {
+      result.current.markTaskDone('dashboard');
+      result.current.markTaskDone('dashboard');
+    });
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+
+    // Another task is unaffected.
+    act(() => result.current.markTaskDone('stocks'));
+    expect(mockWrite).toHaveBeenCalledTimes(2);
+
+    // A reset un-stamps every task, so its attempt starts over.
+    act(() => {
+      result.current.resetAll();
+      result.current.markTaskDone('dashboard');
+    });
+    expect(mockWrite).toHaveBeenCalledTimes(4);
+  });
+
+  it('markTaskDone tries again after another tab lands a write, never on its own', () => {
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => result.current.markTaskDone('dashboard'));
+    act(() => result.current.markTaskDone('dashboard'));
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+
+    // Another tab reset the guides: its write bumps the remote count, and the
+    // task this tab already gave up on is unstamped again on the server.
+    mockRemoteUpdateGen.current += 1;
+    act(() => result.current.markTaskDone('dashboard'));
+    expect(mockWrite).toHaveBeenCalledTimes(2);
+    // Still one attempt per remote update, not a loop.
+    act(() => result.current.markTaskDone('dashboard'));
+    expect(mockWrite).toHaveBeenCalledTimes(2);
+  });
+
+  it('markTaskDone does not spend its attempt on a cold-cache refusal', () => {
+    // The prefs query failed once: preferences is null with isLoading false,
+    // so the guard is reached but the writer refuses (false). A later refetch
+    // fills the cache; the visit effect runs again and must still stamp.
+    mockWrite.mockReturnValueOnce(false);
+    const { result } = renderHook(() => useOnboardingPrefs());
+    act(() => result.current.markTaskDone('dashboard'));
+    act(() => result.current.markTaskDone('dashboard'));
+    expect(mockWrite).toHaveBeenCalledTimes(2);
+    // Accepted the second time: from here it is once per session.
+    act(() => result.current.markTaskDone('dashboard'));
+    expect(mockWrite).toHaveBeenCalledTimes(2);
   });
 
   it('markTaskDone stamps once and aborts when already done', () => {

--- a/web/src/pages/Onboarding/onboardingPrefsWriter.ts
+++ b/web/src/pages/Onboarding/onboardingPrefsWriter.ts
@@ -48,6 +48,11 @@ export function useOnboardingPrefsWriter() {
   const pendingRef = useRef<PendingBatch | null>(null);
 
   const bcRef = useRef<BroadcastChannel | null>(null);
+  // Bumped on every write another tab lands. Read lazily by guards that key
+  // off this tab's own history (markTaskDone's once-per-task set): a remote
+  // reset un-stamps tasks this tab already tried, and the count moving is
+  // how it learns to try again without re-rendering anything.
+  const remoteUpdateGen = useRef(0);
   useEffect(() => {
     if (typeof BroadcastChannel === 'undefined') return;
     const chan = new BroadcastChannel(ONBOARDING_BROADCAST_CHANNEL);
@@ -58,6 +63,7 @@ export function useOnboardingPrefsWriter() {
     // re-opening a popup another tab already dismissed. Mirrors useDashboardPrefs.
     chan.onmessage = (e: MessageEvent) => {
       if ((e.data as { type?: string } | null)?.type !== 'updated') return;
+      remoteUpdateGen.current += 1;
       queryClient.invalidateQueries({ queryKey: queryKeys.user.preferences() });
     };
     return () => {
@@ -161,5 +167,5 @@ export function useOnboardingPrefsWriter() {
     [queryClient, send, currentUserId]
   );
 
-  return { writeOnboardingPrefs };
+  return { writeOnboardingPrefs, remoteUpdateGen };
 }

--- a/web/src/pages/Onboarding/useOnboardingPrefs.ts
+++ b/web/src/pages/Onboarding/useOnboardingPrefs.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { usePreferences } from '@/hooks/usePreferences';
 import { migrateOnboardingPrefs, emptyOnboardingPrefs } from './onboardingPrefsSchema';
 import { useOnboardingPrefsWriter } from './onboardingPrefsWriter';
@@ -16,7 +16,7 @@ function readOnboarding(preferences: unknown): unknown {
  */
 export function useOnboardingPrefs() {
   const { preferences, isLoading } = usePreferences();
-  const { writeOnboardingPrefs } = useOnboardingPrefsWriter();
+  const { writeOnboardingPrefs, remoteUpdateGen } = useOnboardingPrefsWriter();
 
   const prefs = useMemo<OnboardingPrefs>(
     () => migrateOnboardingPrefs(readOnboarding(preferences)),
@@ -50,19 +50,37 @@ export function useOnboardingPrefs() {
     [writeOnboardingPrefs, fallbackOther, isLoading]
   );
 
+  // One write attempt per task per session. A refused PUT moves the prefs
+  // entry twice (optimistic rollback, then the settle refetch), and callers
+  // that stamp from an effect keyed on those prefs would re-send the same
+  // write for as long as the server kept refusing it. Only an accepted write
+  // counts: a cold-cache refusal (the writer returns false) leaves the task
+  // for the next visit once the cache fills. The attempts also restart when
+  // another tab's write lands (it may have been a reset that un-stamped a
+  // task this tab already tried); this tab's own failed PUTs never move that
+  // count, so the loop the guard exists for stays closed.
+  const taskAttemptsRef = useRef({ gen: remoteUpdateGen.current, ids: new Set<string>() });
+
   /** Stamp a getting-started task complete. */
   const markTaskDone = useCallback(
     (id: string) => {
       if (isLoading) return;
-      writeOnboardingPrefs(
+      const attempts = taskAttemptsRef.current;
+      if (attempts.gen !== remoteUpdateGen.current) {
+        attempts.gen = remoteUpdateGen.current;
+        attempts.ids.clear();
+      }
+      if (attempts.ids.has(id)) return;
+      const accepted = writeOnboardingPrefs(
         (cur) =>
           cur.gettingStartedDoneAt[id] != null
             ? null
             : { ...cur, gettingStartedDoneAt: { ...cur.gettingStartedDoneAt, [id]: Date.now() } },
         { fallbackOther }
       );
+      if (accepted) attempts.ids.add(id);
     },
-    [writeOnboardingPrefs, fallbackOther, isLoading]
+    [writeOnboardingPrefs, remoteUpdateGen, fallbackOther, isLoading]
   );
 
   /** Hide the getting-started card permanently. */
@@ -127,6 +145,8 @@ export function useOnboardingPrefs() {
    * write was refused (cold cache), so the caller can skip an empty toast. */
   const resetAll = useCallback((): boolean => {
     if (isLoading) return false;
+    // A reset un-stamps every task, so the session's attempts start over too.
+    taskAttemptsRef.current.ids.clear();
     return writeOnboardingPrefs(emptyOnboardingPrefs(), { fallbackOther, clearMirror: true });
   }, [writeOnboardingPrefs, fallbackOther, isLoading]);
 

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -429,6 +429,10 @@ export interface AssistantMessage {
   // Set when the user hard-stopped this turn (live finalize or history replay
   // of a stopped turn). Drives the per-message "⏹ Stopped" chip.
   stopped?: boolean;
+  /** Monotonic counter bumped by every landed reply text, reasoning text or
+   *  tool-argument chunk (`nextArrivalSeq`). The streaming indicator reads it
+   *  to tell arriving text from a pause. */
+  arrivalSeq?: number;
 }
 
 export type NotificationVariant = 'info' | 'success' | 'warning';

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -12,7 +12,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "paths": { "@/*": ["./src/*"] }
+    "paths": { "@/*": ["./src/*"], "@e2e/*": ["./e2e/*"] }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "e2e"]

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -71,6 +71,9 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),
+        // Fixtures a unit test shares with the Playwright specs. Kept in step
+        // with vitest.config.ts; nothing in the app graph imports it.
+        '@e2e': path.resolve(__dirname, './e2e'),
       },
     },
     build: {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // Fixtures a unit test shares with the Playwright specs.
+      '@e2e': path.resolve(__dirname, './e2e'),
     },
   },
 });


### PR DESCRIPTION
## Summary

Chat streaming is 2.7x smoother on a slow machine and frame-perfect on a fast one. On the same 8,000-character reply, the frame rate under a 4x CPU throttle goes from 39.5 to 106.7 fps, time spent frozen drops from 6.2 s to 0.6 s, and long animation frames from 64 to 2. Unthrottled, the branch holds a 120 Hz display's cap for the whole stream with zero frames over 33 ms, where main dropped 17.

### What a user sees

| Before | After |
|---|---|
| A long reply stutters as it streams: the page freezes for up to a quarter second at every heading, list or code block, and the typewriter lurches to catch up. | The reply types at a steady pace. Under a 4x throttle the worst pause is a third of what it was; unthrottled there is none. |
| Reloading, or leaving for the dashboard and coming back mid-run, blinks the transcript, flings the view to the top and re-types the whole reply from the start. | The transcript comes back already caught up, in place. At most 37 characters of on-screen reply text change across the catch-up, and the view does not move. |
| After a burst of reasoning or tool calls folds into its accordion, the space it used stays empty for seconds. | The live zone shrinks with its rows. |
| The streaming spinner sits under the reply the whole time it types, and the Sources pill pops in mid-stream. | The spinner shows only in the pauses when the model has gone quiet, and disappears while text flows. Sources appear once the reply completes. |
| A tool that is still running but has folded into the accordion hides every activity indicator, so a long silent execution looks finished. | A folded tool no longer suppresses the spinner; a tool counts as busy only while its card is visibly running. |
| Opening a thread scrolls twice: one paint at the top, then a jump to the bottom. | The entry scroll lands before the first paint. |
| Every stream of a fresh account issued about 40 preference writes a second for as long as it ran, whenever the getting-started write failed. | One write per route visit. |

### Measured

Same streamed reply on the production build, medians of 3 runs, main against this branch (`web/e2e/perf/streaming-smoothness.spec.js`):

| | CPU x4 throttle, main | CPU x4, this branch | no throttle, main | no throttle, this branch |
|---|---|---|---|---|
| frames per second | 39.5 | 106.7 | 100.8 | 119.8 |
| frame gap p95 | 99.7 ms | 16.6 ms | 17.5 ms | 9.1 ms |
| frame gap p99 | 166.7 ms | 33 ms | 33.3 ms | 9.3 ms |
| worst frame gap | 284 ms | 100 ms | 84 ms | 17 ms |
| frames over 33 ms | 87 | 13 | 17 | 0 |
| time frozen | 6.2 s | 0.6 s | 0.7 s | 0 |
| long animation frames | 64 | 2 | 1 | 0 |
| DOM nodes added / removed | 2045 / 1829 | 470 / 148 | 2823 / 2575 | 477 / 157 |

On a live 74 s PTC turn in Chrome at 120 Hz: 119.6 fps, p95 gap 9.2 ms, no frame over 33 ms, the spinner visible only in four sub-second gaps.

### How

The server marks where the replayed backlog ends and the client applies everything before that mark in one pass. Markdown renders per block so a growing reply re-parses only its tail. The typewriter paces off a target lag instead of a fixed rate. The activity live zone keeps its size after a fold. The spinner keys off a per-message arrival counter, and the entry scroll lands before paint. The benchmark family under `web/e2e/perf/` (frame gaps, long animation frames, mutation counts, request tally, compositor frames) is part of the change, so every number above can be rerun on any machine.

## Why this way

- **Client-side batching, not a tail endpoint.** The replay already carries every event; it lacked a boundary. A `caught_up` marker is one event and no server state. A quiet timer and a hard cap bound the wait if it never comes.
- **One processor for the whole stream.** The backlog itself moves state (a `steering_delivered` retargets the bubble), so a fresh tail processor would write to the wrong one. The refs bag flips `isReconnect` after the flush, and handlers read it on arrival, never inside a `setMessages` updater, which React runs after the flip.
- **Per-block markdown, not a whole-document memo.** Every chunk invalidates a whole-document memo; block keys let React keep settled blocks untouched. Lists stay open to block end so a loose list is not split into two tight ones.
- **Typewriter pace** is `backlog / clamp(backlog / TARGET_LAG, MIN, MAX)`: a fixed lag behind a steady model, catch-up when it bursts.

## How it works

- `run_stream_reader.py` emits `caught_up` at the replay boundary, immediately if the head probe fails.
- `lifecycle.ts` holds reconnect events until the marker, flushes them through the same processor, then flips `refs.isReconnect`. The flush checks ownership and the stop flag itself, and the marker does not count as a rendered event.
- `streamRefs.ts` stamps `arrivalSeq` per chunk; `useArrivalQuiet` and `useLiveToolRunning` drive the spinner, so only a visibly running tool counts as busy.
- `markdownBlocks.ts` splits at block boundaries; `Markdown.tsx` renders each under a stable key with `React.memo`.
- `useOnboardingPrefs.ts` owns the once-per-visit guard for `markTaskDone`.

## Overview

| | Files | Added | Removed |
|---|---|---|---|
| Modified | 35 | 937 | 232 |
| New | 22 | 1895 | 0 |
| Total | 57 | 2832 | 232 |
| Net excluding tests and e2e | 31 | 932 | 211 |

- **Backend**: `src/server/handlers/chat/run_stream_reader.py`.
- **Web, stream session**: `session/stream/lifecycle.ts`, `mainEventHandlers.ts`, `subagents/liveEventHandlers.ts`, `streamRefs.ts`, `types.ts`, `hooks/useChatMessages.ts`, `hooks/utils/contextWindowEvent.ts`, `types/chat.ts`.
- **Web, rendering**: `utils/markdownBlocks.ts` (new), `Markdown.tsx`, `markdownSegments.ts`, `ui/animated-text.ts`, `messageList/useArrivalQuiet.ts` and `liveZoneTiming.ts` (new), `MessageBubble.tsx`, `buildRenderBlocks.ts`, `ActivityBlock.tsx`, `ReasoningMessageContent.tsx`, `ToolCallMessageContent.tsx`, `ChatView.tsx`, `chatView/useChatScroll.ts`.
- **Web, onboarding**: `useOnboardingPrefs.ts`, `OnboardingProvider.tsx`.
- **Tests and tooling**: backend stream-reader and event-ledger tests; five new web unit suites (`animated-text`, `Markdown.blocks`, `useArrivalQuiet`, `markdownBlocks`, `reconnectStamps`) and three updated; Playwright `web/e2e/perf/` (smoothness, typewriter, return-glitch benchmarks and their harness), `activity-live-zone.spec.js`, shared `chatScenario.js`, mock server additions, `scripts/perf-summary.mjs`, `@e2e` alias; `web/AGENTS.md`.

## Risk

- The 6 s flush cap means a replay slower than that still shows its tail live.
- A tool that folds while the model is silent now shows the spinner where it showed nothing. Intended, but visible.
- The perf specs are opt-in (`PERF=1`) and machine-sensitive; the return-glitch assertions are bounded to what is not (reply drop under 100 chars, scroll travel under 2000 px).

## Test plan

- [x] Backend unit suite; web typecheck, eslint and vitest, after the review fixes
- [x] Playwright chat and live-zone specs; the three `PERF=1` benchmarks, return-glitch rerun after the fixes (4 cases, max reply drop 37 chars)
- [x] Live turn on the dev stack: 119.6 fps, no frame over 33 ms

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791152063&installation_model_id=432753&pr_number=393&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F393&signature=cbb4c02c89c7c54ac9ce2967ed26c12e1e9948b9cad5ff749d958f53161873c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved reconnect handling so replayed chat activity transitions cleanly into live updates.
  - Added smoother streaming text animation that catches up gracefully without losing visible content.
  - Chat messages now render progressively with less unnecessary reprocessing, improving responsiveness.

- **Bug Fixes**
  - Prevented reconnect status indicators from shifting the message composer.
  - Improved live activity zone sizing during interrupted transitions.
  - Reduced repeated onboarding completion attempts during a session.
  - Kept Sources controls non-interactive until streaming finishes.

- **Documentation**
  - Added guidance for running streaming performance benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->