### PR TITLE
feat: store workspace file bytes as content-addressed objects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,11 @@ LANGSMITH_PROJECT=langalpha
 # S3_BUCKET_NAME=
 # S3_REGION=us-east-1
 # S3_PUBLIC_URL_BASE=https://d1234.cloudfront.net
+# The public URL base is for the keys the app links to directly (avatars,
+# captured chart images). Workspace file bytes live under blobs/ in the same
+# bucket and are only ever read through the API or a short-lived presigned
+# URL, so the CDN or bucket policy behind the public base must not serve
+# blobs/ or memo/.
 
 # Bucket addressing: virtual (default) | path | auto.
 # Most cloud S3-compatible services use virtual-hosted addressing; self-hosted /
@@ -105,6 +110,14 @@ LANGSMITH_PROJECT=langalpha
 # give the BARE host with no bucket subdomain — embedding the bucket doubles the key.
 # STORAGE_ADDRESSING_STYLE=virtual
 # STORAGE_ENDPOINT_URL=https://{bare-host}
+
+# How workspace file bytes move between a sandbox and the object store:
+# auto (default) | direct | relay. "direct" has the sandbox upload and download
+# blobs itself over short-lived presigned URLs bound to each file's sha256;
+# "relay" streams every byte through the backend. "auto" picks direct for a
+# Daytona sandbox on an S3-compatible store and relay otherwise. Can also be
+# set as storage.blob_transfer in agent_config.yaml.
+# STORAGE_BLOB_TRANSFER=auto
 
 # --- Cloudflare R2 ---
 # R2_ACCOUNT_ID=

--- a/migrations/versions/039_workspace_file_blobs.py
+++ b/migrations/versions/039_workspace_file_blobs.py
@@ -1,0 +1,250 @@
+"""Move workspace file bytes out of Postgres into content-addressed object storage.
+
+``workspace_files`` stored each file's bytes inline (``content_text`` /
+``content_binary``, up to 1GB per workspace), which bloats the database,
+amplifies every backup and replica stream, and pays TOAST overhead on rows that
+are otherwise pure metadata. A blob-backed row instead keeps its bytes under
+``blobs/{user_id}/{sha256}`` in object storage and leaves both content columns
+NULL; ``workspace_file_blobs`` is the registry that records which digests each
+user has written. Content addressing is what lets a forked workspace share
+bytes instead of copying TOAST.
+
+The registry is keyed by ``(user_id, sha256)`` and the manifest points at it by
+digest alone, so there is no foreign key from ``workspace_files`` to the
+registry: a manifest row has no ``user_id`` of its own, and a single-column
+constraint cannot reference a composite key. Reference integrity is the sweep's
+job instead. A registry row is deleted only under its row lock after a
+re-check that no manifest row of the same user names its digest, and a writer
+registers before it publishes a pointer, so no row ever points at an object the
+sweep can take.
+
+Four things ride along, because they are the same manifest:
+
+* ``kind`` and ``symlink_target``. Backup walked the sandbox with ``find -type
+  f``, so an empty directory, a symlink, or a file's mode never reached the
+  manifest and never came back on restore. The ``permissions`` column from 001
+  now holds the octal mode string it was declared for.
+* ``workspaces.files_restore_incomplete_at``. ``sync_to_db`` prunes manifest
+  rows whose files are absent from the sandbox, reading that absence as a user
+  deletion; a restore that failed produces the identical signature. The sandbox's
+  own ``.file_sync_marker`` cannot carry the distinction, because every way of
+  failing to read it degrades to "no restore ever failed", which is the answer
+  that permits pruning. Postgres is where this project keeps cross-worker truth,
+  and putting the flag beside the manifest means the flag and the rows it
+  protects fail together instead of independently. NULL means no restore is
+  known to have failed, the correct reading for every pre-existing row.
+* ``last_referenced_at`` and ``condemned_at`` on the registry. Every save of a
+  changed file writes a new object and orphans its predecessor, and
+  the sweep cannot be a plain delete-unreferenced: the upload happens in the
+  sandbox and the manifest row that references it lands seconds later in its own
+  transaction. Writers touch ``last_referenced_at`` before they upload; the
+  sweep condemns a row only after a grace period with no touch and no reference,
+  then deletes it a further grace period later under a row lock. A condemned row
+  is invisible to writers, which re-upload and revive.
+* ``pack_sha256`` and ``pack_offset``. Backup and restore are bound by the
+  sandbox's CPU, and that cost is per object, not per byte. A pack is the
+  concatenation, in sorted path order, of every regular file at or below a size
+  cutoff, split at file boundaries into chunks and stored as ordinary
+  content-addressed blobs. A member row points at its chunk and its byte offset
+  in it; ``file_size`` is its length and ``content_hash`` stays the file's own
+  digest, so change detection and byte verification are untouched.
+  ``blob_sha256`` and ``pack_sha256`` are mutually exclusive on a row.
+
+Lock discipline. ``workspace_files`` is hot, so every catalog change it needs is
+one ALTER TABLE: five nullable-or-constant-default columns (metadata-only on
+Postgres 11+, no rewrite) and both CHECKs, NOT VALID. ALTER TABLE runs its
+subcommands in phases, adding columns before constraints, so a constraint in
+the list may name a column in the same list. One ACCESS EXCLUSIVE acquisition
+rather than seven, and it either lands whole or hits the lock timeout and lands
+not at all.
+
+Everything that does not need that lock runs afterwards in an autocommit block,
+under no timeout: VALIDATE takes SHARE UPDATE EXCLUSIVE and blocks neither
+readers nor writers, and CREATE INDEX CONCURRENTLY spends most of its life
+waiting on transactions that can still see the table. Those waits are lock
+waits, so a 5s cap fails the build on any table taking continuous writes and
+leaves an INVALID index behind. Every existing row is NULL on both pointers and
+carries the default ``kind``, so no validation here can fail.
+
+Revision ID: 039
+Revises: 038
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision = "039"
+down_revision = "038"
+branch_labels = None
+depends_on = None
+
+_BLOB_INDEX = "idx_workspace_files_blob_sha256"
+_PACK_INDEX = "idx_workspace_files_pack_sha256"
+_KIND_CHECK = "chk_workspace_files_kind"
+_POINTER_CHECK = "chk_workspace_files_one_pointer"
+_CONDEMNED_INDEX = "idx_workspace_file_blobs_condemned"
+_LIVE_INDEX = "idx_workspace_file_blobs_live_referenced"
+_MOVED_ROWS_SQL = """
+    SELECT count(*) FROM workspace_files
+    WHERE blob_sha256 IS NOT NULL OR pack_sha256 IS NOT NULL
+"""
+_FLAGGED_WORKSPACES_SQL = """
+    SELECT count(*) FROM workspaces WHERE files_restore_incomplete_at IS NOT NULL
+"""
+
+
+def upgrade() -> None:
+    op.execute("SET lock_timeout = '5s'")
+
+    # The PK doubles as an object key (blobs/{user_id}/{sha256}), so the CHECK is
+    # the last line of defense against a non-digest reaching the bucket. All
+    # CHECKs are inline and therefore valid from birth, which an empty table
+    # gets for free. ``user_id`` matches ``workspaces.user_id``.
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS workspace_file_blobs (
+            user_id VARCHAR(255) NOT NULL,
+            sha256 VARCHAR(64) NOT NULL
+                CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+            byte_len BIGINT NOT NULL CHECK (byte_len >= 0),
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            last_referenced_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            condemned_at TIMESTAMPTZ,
+            PRIMARY KEY (user_id, sha256)
+        )
+    """)
+
+    # Sweep pass 2 walks condemned rows oldest-first; pass 1 walks live rows by
+    # last touch. Both partial, since each pass only ever wants one side. Built
+    # inline: the registry is created empty right above, and it stays a fraction
+    # of ``workspace_files`` with a handful of inserts per sync.
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS {_CONDEMNED_INDEX} "
+        "ON workspace_file_blobs (condemned_at) WHERE condemned_at IS NOT NULL"
+    )
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS {_LIVE_INDEX} "
+        "ON workspace_file_blobs (last_referenced_at) WHERE condemned_at IS NULL"
+    )
+
+    op.execute(
+        "ALTER TABLE workspaces "
+        "ADD COLUMN IF NOT EXISTS files_restore_incomplete_at TIMESTAMPTZ"
+    )
+
+    # The one ACCESS EXCLUSIVE window on the hot table. The DROPs make the whole
+    # statement re-runnable: ADD CONSTRAINT has no IF NOT EXISTS, and a
+    # migration that aborted in the autocommit block below is re-run from here.
+    op.execute(f"""
+        ALTER TABLE workspace_files
+            ADD COLUMN IF NOT EXISTS blob_sha256 VARCHAR(64),
+            ADD COLUMN IF NOT EXISTS kind VARCHAR(8) NOT NULL DEFAULT 'file',
+            ADD COLUMN IF NOT EXISTS symlink_target TEXT,
+            ADD COLUMN IF NOT EXISTS pack_sha256 VARCHAR(64),
+            ADD COLUMN IF NOT EXISTS pack_offset BIGINT,
+            DROP CONSTRAINT IF EXISTS {_KIND_CHECK},
+            DROP CONSTRAINT IF EXISTS {_POINTER_CHECK},
+            ADD CONSTRAINT {_KIND_CHECK}
+                CHECK (kind IN ('file', 'dir', 'symlink')) NOT VALID,
+            ADD CONSTRAINT {_POINTER_CHECK}
+                CHECK (blob_sha256 IS NULL OR pack_sha256 IS NULL) NOT VALID
+    """)
+
+    with op.get_context().autocommit_block():
+        # No cap here, for the reason the docstring gives. Nothing below takes a
+        # lock worth bounding, and a cap on CREATE INDEX CONCURRENTLY is a way
+        # to leave an INVALID index behind rather than a way to protect anyone.
+        op.execute("SET lock_timeout = 0")
+        op.execute(f"ALTER TABLE workspace_files VALIDATE CONSTRAINT {_KIND_CHECK}")
+        op.execute(f"ALTER TABLE workspace_files VALIDATE CONSTRAINT {_POINTER_CHECK}")
+
+        # Drop before create, always. IF NOT EXISTS matches on NAME alone, so on
+        # its own it adopts whatever index already wears the name, and a failed
+        # CONCURRENTLY build leaves an INVALID one that Postgres keeps
+        # maintaining on every write while no planner will use it. That skips
+        # silently and never shows up in alembic_version. Dropping first makes
+        # the definitions below the only ones that can survive this migration.
+        #
+        # Partial: only blob-backed and packed rows matter. These back the
+        # garbage collector's reference check and the orphan report's anti-join.
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_BLOB_INDEX}")
+        op.execute(f"""
+            CREATE INDEX CONCURRENTLY {_BLOB_INDEX}
+                ON workspace_files (blob_sha256)
+                WHERE blob_sha256 IS NOT NULL
+        """)
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_PACK_INDEX}")
+        op.execute(f"""
+            CREATE INDEX CONCURRENTLY {_PACK_INDEX}
+                ON workspace_files (pack_sha256)
+                WHERE pack_sha256 IS NOT NULL
+        """)
+
+
+def downgrade() -> None:
+    """Drop the blob schema.
+
+    DESTRUCTIVE AFTER A BACKFILL. ``blob_sha256`` and ``pack_sha256`` are a
+    moved row's only reference to its bytes, and the registry holds the digests
+    those bytes are keyed by: the objects survive in the bucket but nothing can
+    say which file each one belongs to. Run
+    ``scripts/ops/backfill_workspace_file_blobs.py --reverse --apply`` first to
+    pull the bytes back inline, blob-backed and packed rows alike; the
+    downgrade refuses to run while any row still points into storage.
+
+    Dropping ``files_restore_incomplete_at`` re-arms the deletion it exists to
+    prevent: any workspace currently flagged loses the only record that its
+    sandbox is missing files, and the next sync prunes its manifest rows. The
+    downgrade refuses while any workspace is flagged; starting the workspace
+    retries the restore and clears the flag when it completes.
+
+    Both checks run under an exclusive lock on the tables they read, held
+    through the DDL in the same transaction: a worker that is still running
+    can publish a blob-backed row the instant after an unlocked count, and
+    the column drop that follows would strand that file's bytes. The lock
+    waits at most ``lock_timeout`` for in-flight syncs, then fails; a
+    downgrade should run with the application stopped in any case.
+    """
+    bind = op.get_bind()
+    bind.execute(text("SET LOCAL lock_timeout = '5s'"))
+    bind.execute(
+        text("LOCK TABLE workspace_files, workspaces IN ACCESS EXCLUSIVE MODE")
+    )
+    moved = bind.execute(text(_MOVED_ROWS_SQL)).scalar()
+    if moved:
+        raise RuntimeError(
+            f"{moved} workspace_files rows keep their bytes in object storage; "
+            "run scripts/ops/backfill_workspace_file_blobs.py --reverse --apply "
+            "before downgrading"
+        )
+    flagged = bind.execute(text(_FLAGGED_WORKSPACES_SQL)).scalar()
+    if flagged:
+        raise RuntimeError(
+            f"{flagged} workspace(s) have an incomplete file restore recorded in "
+            "files_restore_incomplete_at; start each one so the restore completes "
+            "before downgrading"
+        )
+
+    # The partial indexes go with their columns below. Dropping them
+    # CONCURRENTLY first would need an autocommit block, which commits the
+    # transaction and releases the lock the checks were made under.
+
+    # Rows that describe a directory or a symlink have no meaning to the
+    # previous release's readers, which would surface them as empty files. This
+    # has to run while ``kind`` still exists.
+    op.execute("DELETE FROM workspace_files WHERE kind <> 'file'")
+
+    op.execute(f"""
+        ALTER TABLE workspace_files
+            DROP CONSTRAINT IF EXISTS {_POINTER_CHECK},
+            DROP CONSTRAINT IF EXISTS {_KIND_CHECK},
+            DROP COLUMN IF EXISTS pack_offset,
+            DROP COLUMN IF EXISTS pack_sha256,
+            DROP COLUMN IF EXISTS symlink_target,
+            DROP COLUMN IF EXISTS kind,
+            DROP COLUMN IF EXISTS blob_sha256
+    """)
+    op.execute("DROP TABLE IF EXISTS workspace_file_blobs")
+    op.execute(
+        "ALTER TABLE workspaces DROP COLUMN IF EXISTS files_restore_incomplete_at"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dependencies = [
     # __all__, so a 0.x minor is free to delete them without notice — 0.7.0
     # dropped WriteResult.files_update exactly that way. Bump deliberately.
     "deepagents>=0.6.11,<0.8",
-    "daytona>=0.200.1",
+    "daytona>=0.210.0",
     "boto3>=1.42.28",
     "tavily-python>=0.7.18",
     "PyJWT[crypto]>=2.8",

--- a/scripts/ops/_db.py
+++ b/scripts/ops/_db.py
@@ -1,0 +1,30 @@
+"""The Postgres URI the operator scripts under ``scripts/ops/`` connect with.
+
+Read from the environment directly rather than importing ``src.config``: that
+fires the app's ``load_dotenv()`` and would silently retarget a mutating script
+at whatever ``.env`` happens to be on disk.
+"""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import quote_plus
+
+
+def build_db_uri(prefix: str = "DB_") -> str:
+    """Assemble ``<prefix>HOST``/``PORT``/``NAME``/``USER``/``PASSWORD`` into a URI.
+
+    ``prefix`` picks the pool: the app data database is ``DB_``, the LangGraph
+    checkpointer ``MEMORY_DB_``. TLS policy is one setting for the server, so
+    ``DB_SSLMODE`` is read unprefixed either way.
+    """
+    host = os.getenv(f"{prefix}HOST", "localhost")
+    port = os.getenv(f"{prefix}PORT", "5432")
+    name = os.getenv(f"{prefix}NAME", "postgres")
+    user = os.getenv(f"{prefix}USER", "postgres")
+    password = os.getenv(f"{prefix}PASSWORD", "postgres")
+    sslmode = os.getenv("DB_SSLMODE", "prefer")
+    return (
+        f"postgresql://{quote_plus(user)}:{quote_plus(password)}"
+        f"@{host}:{port}/{name}?sslmode={sslmode}"
+    )

--- a/scripts/ops/backfill_workspace_file_blobs.py
+++ b/scripts/ops/backfill_workspace_file_blobs.py
@@ -1,0 +1,656 @@
+"""Move existing inline workspace file bytes into content-addressed object storage.
+
+Migration 039 adds ``workspace_files.blob_sha256`` but backfills nothing: rows
+written before it keep their bytes in ``content_text`` / ``content_binary``.
+This script uploads those bytes to ``blobs/{user_id}/{sha256}`` under the
+workspace owner, registers the digest, and NULLs the inline columns: the
+actual reduction in database size, backup volume, and replica traffic that
+motivated the change.
+
+Run it AFTER the new code is deployed and verified, never before: a row whose
+bytes have moved is unreadable to code that doesn't know about ``blob_sha256``.
+``--reverse`` pulls the bytes back inline and clears the pointer, which is the
+rollback path — NULLing the columns is otherwise a one-way door.
+
+Usage:
+    uv run python scripts/ops/backfill_workspace_file_blobs.py            # dry-run
+    uv run python scripts/ops/backfill_workspace_file_blobs.py --workspace UUID --apply
+    uv run python scripts/ops/backfill_workspace_file_blobs.py --apply
+    uv run python scripts/ops/backfill_workspace_file_blobs.py --reverse --apply
+
+Rows whose owner has a non-UUID id are left inline unless
+``--include-legacy-owners`` is passed: such an account is re-keyed by its first
+platform login, and objects keyed by the old id would not follow it.
+
+Idempotent in both directions. Connects via the same DB_* env vars the app
+uses (``src/server/database/pool.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import logging
+import sys
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import psycopg
+from psycopg.rows import dict_row
+
+# Run as a script, sys.path[0] is scripts/ops — not the repo root the `src`
+# package lives under. Same prelude as scripts/utils/render_prompt.py.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+# Every one of these is import-clean: _db reads os.environ, blob_keys imports
+# only `re`, and src.utils.storage only os + yaml + the provider SDK.
+# Deliberately NOT src.server.database.workspace_file_blobs, which pulls
+# database/pool -> src.config.env -> load_dotenv() and would silently retarget
+# a mutating operator script at whatever .env happens to be on disk.
+from scripts.ops._db import build_db_uri
+from src.server.database.blob_keys import (
+    BLOB_BACKED_SQL,
+    BLOB_CONTENT_TYPE,
+    CLAIM_SQL,
+    MAX_BLOB_BYTES,
+    REGISTER_SQL,
+    blob_key,
+)
+from src.utils.storage import (
+    get_bytes,
+    get_bytes_range,
+    is_storage_enabled,
+    upload_bytes,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("backfill_workspace_file_blobs")
+
+# Uploads in flight per chunk, and the byte ceiling that overrides the count so
+# a chunk of large files can't hold UPLOAD_CONCURRENCY x MAX_BLOB_BYTES at once.
+UPLOAD_CONCURRENCY = 8
+INFLIGHT_MAX_BYTES = 64 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class _Pending:
+    """One row whose bytes are in hand, waiting to be uploaded and repointed."""
+
+    file_id: str
+    user_id: str
+    sha256: str
+    data: bytes
+    stored_hash: str | None
+    workspace_id: str
+    file_path: str
+
+
+@dataclass
+class _Counts:
+    moved: int = 0
+    moved_bytes: int = 0
+    # Stored content_hash disagrees with the inline bytes: the inline copy is
+    # lossy and must not be canonized. Distinct from `raced`.
+    skipped_lossy: int = 0
+    skipped_empty: int = 0
+    # The owner's id is not the UUID a platform login presents, so a legacy
+    # login could still re-key the account and leave its objects behind.
+    skipped_legacy_owner: int = 0
+    # The row changed between reading its bytes and writing the pointer.
+    skipped_raced: int = 0
+    failed: int = 0
+    pending: list[_Pending] = field(default_factory=list)
+    pending_bytes: int = 0
+
+
+def _inline_bytes(row: dict) -> bytes | None:
+    """Return a row's inline bytes, preferring the lossless BYTEA column."""
+    content_binary = row.get("content_binary")
+    if content_binary is not None:
+        return bytes(content_binary)
+    content_text = row.get("content_text")
+    if content_text is not None:
+        return content_text.encode("utf-8")
+    return None
+
+
+async def _next_ids(
+    conn: psycopg.AsyncConnection,
+    where: str,
+    after: str | None,
+    limit: int,
+    workspace_id: str | None,
+) -> list[str]:
+    """Fetch the next page of matching ids, keyset-paginated on the PK.
+
+    Ids only. A 500-row SELECT that includes the content columns detoasts up to
+    500 x 100MB into memory at once; this reads only the null bitmap.
+    """
+    params: list = []
+    scope_clause = ""
+    if workspace_id is not None:
+        scope_clause = "AND workspace_id = %s::uuid"
+        params.append(workspace_id)
+    cursor_clause = ""
+    if after is not None:
+        cursor_clause = "AND workspace_file_id > %s::uuid"
+        params.append(after)
+    params.append(limit)
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            f"""
+            SELECT workspace_file_id
+            FROM workspace_files
+            WHERE {where} {scope_clause} {cursor_clause}
+            ORDER BY workspace_file_id
+            LIMIT %s
+            """,
+            params,
+        )
+        return [str(r["workspace_file_id"]) for r in await cur.fetchall()]
+
+
+async def _load_row(conn: psycopg.AsyncConnection, file_id: str) -> dict | None:
+    """One row with its bytes and its owner, who names the storage namespace."""
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            SELECT f.workspace_file_id, f.workspace_id, w.user_id, f.file_path,
+                   f.content_hash, f.content_text, f.content_binary,
+                   f.blob_sha256, f.pack_sha256, f.pack_offset, f.file_size,
+                   f.is_binary
+            FROM workspace_files f
+            JOIN workspaces w ON w.workspace_id = f.workspace_id
+            WHERE f.workspace_file_id = %s::uuid
+            """,
+            (file_id,),
+        )
+        return await cur.fetchone()
+
+
+async def _upload_chunk(pending: list[_Pending]) -> list[bool | BaseException]:
+    """Upload a chunk concurrently. A serial round trip per row measures ~3
+    rows/s, which is untenable for a large table."""
+    sem = asyncio.Semaphore(UPLOAD_CONCURRENCY)
+
+    async def _one(item: _Pending) -> bool:
+        async with sem:
+            return await asyncio.to_thread(
+                upload_bytes,
+                blob_key(item.user_id, item.sha256),
+                item.data,
+                BLOB_CONTENT_TYPE,
+                max_size=MAX_BLOB_BYTES,
+            )
+
+    return await asyncio.gather(
+        *(_one(item) for item in pending), return_exceptions=True
+    )
+
+
+async def _repoint_row(conn: psycopg.AsyncConnection, item: _Pending) -> bool:
+    """Register the digest and move the row onto it. Returns False if it raced.
+
+    One transaction: the sweep only spares objects with a registry row, so a
+    crash between the two must not leave a row pointing at an unregistered
+    digest.
+    """
+    async with conn.transaction(), conn.cursor() as cur:
+        await cur.execute(REGISTER_SQL, (item.user_id, item.sha256, len(item.data)))
+        # The content_hash predicate makes this safe against a concurrent
+        # re-sync that rewrote the row while we held its bytes: a changed row
+        # doesn't match and stays inline.
+        await cur.execute(
+            """
+            UPDATE workspace_files
+               SET blob_sha256 = %s,
+                   content_text = NULL,
+                   content_binary = NULL,
+                   file_size = %s
+             WHERE workspace_file_id = %s::uuid
+               AND blob_sha256 IS NULL
+               AND pack_sha256 IS NULL
+               AND content_hash IS NOT DISTINCT FROM %s
+            """,
+            (item.sha256, len(item.data), item.file_id, item.stored_hash),
+        )
+        return bool(cur.rowcount)
+
+
+async def _flush(conn: psycopg.AsyncConnection, counts: _Counts) -> None:
+    """Upload the pending chunk concurrently, then apply its DB writes serially
+    (psycopg connections are not safe to share across concurrent tasks)."""
+    if not counts.pending:
+        return
+    # Claim any digest the sweeper has condemned before uploading it, so a
+    # concurrent reap cannot delete the object between the PUT and the row.
+    # The registry is keyed per user, so the claim is one statement per owner.
+    by_user: dict[str, list[str]] = {}
+    for item in counts.pending:
+        by_user.setdefault(item.user_id, []).append(item.sha256)
+    async with conn.cursor() as cur:
+        for user_id, digests in by_user.items():
+            await cur.execute(CLAIM_SQL, (user_id, digests))
+    uploads = await _upload_chunk(counts.pending)
+
+    for item, ok in zip(counts.pending, uploads, strict=True):
+        if ok is not True:
+            counts.failed += 1
+            logger.error(
+                "upload failed for %s (%d bytes): %s",
+                blob_key(item.user_id, item.sha256),
+                len(item.data),
+                ok if isinstance(ok, BaseException) else "rejected",
+            )
+            continue
+        if await _repoint_row(conn, item):
+            counts.moved += 1
+            counts.moved_bytes += len(item.data)
+        else:
+            counts.skipped_raced += 1
+            logger.warning(
+                "row changed under us, left inline: %s %s",
+                item.workspace_id,
+                item.file_path,
+            )
+
+    counts.pending = []
+    counts.pending_bytes = 0
+
+
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(str(value))
+    except ValueError:
+        return False
+    return True
+
+
+async def _forward(
+    conn: psycopg.AsyncConnection,
+    apply: bool,
+    batch: int,
+    workspace_id: str | None,
+    include_legacy_owners: bool = False,
+) -> int:
+    where = (
+        "blob_sha256 IS NULL "
+        "AND (content_text IS NOT NULL OR content_binary IS NOT NULL)"
+    )
+    after: str | None = None
+    counts = _Counts()
+    legacy_owners: set[str] = set()
+
+    while True:
+        ids = await _next_ids(conn, where, after, batch, workspace_id)
+        if not ids:
+            break
+        after = ids[-1]
+
+        for file_id in ids:
+            row = await _load_row(conn, file_id)
+            if row is None or row["blob_sha256"] is not None:
+                continue
+            if not include_legacy_owners and not _is_uuid(row["user_id"]):
+                # Objects are keyed by owner id. An account whose id predates
+                # platform auth is re-keyed by its first login, and nothing
+                # moves its objects with it; leave its bytes inline until the
+                # operator confirms no such login can still arrive.
+                if row["user_id"] not in legacy_owners:
+                    legacy_owners.add(row["user_id"])
+                    logger.warning(
+                        "owner %s has a non-UUID id; leaving its rows inline "
+                        "(--include-legacy-owners to move them)",
+                        row["user_id"],
+                    )
+                counts.skipped_legacy_owner += 1
+                continue
+            data = _inline_bytes(row)
+            if data is None:
+                counts.skipped_empty += 1
+                continue
+
+            sha256 = hashlib.sha256(data).hexdigest()
+            stored = row["content_hash"]
+            if stored and stored != sha256:
+                # content_text is NUL-stripped at write time while content_hash
+                # covers the ORIGINAL bytes, so a disagreement means the inline
+                # copy is lossy. Rewriting the hash would canonize that lossy
+                # copy as authoritative — report and leave the row alone.
+                counts.skipped_lossy += 1
+                logger.warning(
+                    "hash mismatch, left inline: %s %s (stored %s, inline %s)",
+                    row["workspace_id"],
+                    row["file_path"],
+                    stored,
+                    sha256,
+                )
+                continue
+
+            if not apply:
+                counts.moved += 1
+                counts.moved_bytes += len(data)
+                continue
+
+            counts.pending.append(
+                _Pending(
+                    file_id=file_id,
+                    user_id=row["user_id"],
+                    sha256=sha256,
+                    data=data,
+                    stored_hash=stored,
+                    workspace_id=str(row["workspace_id"]),
+                    file_path=row["file_path"],
+                )
+            )
+            counts.pending_bytes += len(data)
+            if (
+                len(counts.pending) >= UPLOAD_CONCURRENCY
+                or counts.pending_bytes >= INFLIGHT_MAX_BYTES
+            ):
+                await _flush(conn, counts)
+
+        await _flush(conn, counts)
+        logger.info(
+            "progress: %d moved, %d bytes, %d failed",
+            counts.moved,
+            counts.moved_bytes,
+            counts.failed,
+        )
+
+    logger.info(
+        "%s %d file(s), %d bytes; %d skipped (lossy inline copy), "
+        "%d skipped (raced), %d skipped (no content), "
+        "%d skipped (legacy owner), %d failed",
+        "moved" if apply else "would move",
+        counts.moved,
+        counts.moved_bytes,
+        counts.skipped_lossy,
+        counts.skipped_raced,
+        counts.skipped_empty,
+        counts.skipped_legacy_owner,
+        counts.failed,
+    )
+    return 1 if counts.failed else 0
+
+
+def _inline_columns(data: bytes, is_binary: bool) -> tuple[str | None, bytes | None]:
+    """Choose the inline columns to restore ``data`` into.
+
+    Rollback is the whole point of this mode, so the row has to be readable by
+    the code being rolled back to, which checks ``is_binary`` first and tests
+    ``content_binary`` for truthiness.
+
+    Empty files therefore go to TEXT even when binary: ``b""`` is falsy, so the
+    old reader skips a BYTEA column holding it and 404s the file. Bytes that
+    can't round-trip through TEXT go to BYTEA, and the caller marks those rows
+    binary. Postgres rejects NUL in TEXT and a lone invalid byte has no TEXT
+    spelling at all; substituting either one writes a lossy copy while
+    ``content_hash`` still covers the original bytes, precisely the state
+    ``_forward`` refuses to touch. Decoding is therefore strict: a file
+    classified as text by a 64KiB NUL scan can still hold invalid UTF-8 further
+    in, and ``errors="replace"`` would silently canonize U+FFFD in its place.
+    """
+    if not data:
+        return "", None
+    if is_binary:
+        return None, data
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return None, data
+    if "\x00" in text:
+        return None, data
+    return text, None
+
+
+async def _reverse(
+    conn: psycopg.AsyncConnection, apply: bool, batch: int, workspace_id: str | None
+) -> int:
+    where = BLOB_BACKED_SQL
+    after: str | None = None
+    restored = failed = as_binary = raced = 0
+    restored_bytes = 0
+
+    while True:
+        ids = await _next_ids(conn, where, after, batch, workspace_id)
+        if not ids:
+            break
+        after = ids[-1]
+
+        for file_id in ids:
+            row = await _load_row(conn, file_id)
+            if row is None or (row["blob_sha256"] is None and row["pack_sha256"] is None):
+                continue
+            sha256 = row["blob_sha256"]
+            pack_sha256 = row["pack_sha256"]
+
+            if not apply:
+                restored += 1
+                continue
+
+            expected_len = row["file_size"]
+            if sha256 is not None:
+                data = await asyncio.to_thread(
+                    get_bytes, blob_key(row["user_id"], sha256)
+                )
+                # A whole-file row's own digest is the object key.
+                expected_hash = sha256
+            else:
+                # A packed row: its bytes are a slice of the chunk, and its
+                # own digest is content_hash.
+                data = await asyncio.to_thread(
+                    get_bytes_range,
+                    blob_key(row["user_id"], pack_sha256),
+                    int(row["pack_offset"] or 0),
+                    int(expected_len or 0),
+                )
+                expected_hash = row["content_hash"]
+            if data is None:
+                failed += 1
+                logger.error(
+                    "blob %s unreadable, left pointing at storage: %s %s",
+                    sha256 or pack_sha256,
+                    row["workspace_id"],
+                    row["file_path"],
+                )
+                continue
+            # Length always, digest whenever the row records one. This write
+            # NULLs the only pointer to the good bytes, so bytes that fail
+            # either check must stay in storage and be reported: an unverified
+            # restore is a silently corrupted file the rollback then keeps.
+            if expected_len is not None and len(data) != int(expected_len):
+                failed += 1
+                logger.error(
+                    "blob %s length mismatch, left pointing at storage: %s %s "
+                    "(row says %s bytes, read %d)",
+                    sha256 or pack_sha256,
+                    row["workspace_id"],
+                    row["file_path"],
+                    expected_len,
+                    len(data),
+                )
+                continue
+            if expected_hash is not None:
+                actual = hashlib.sha256(data).hexdigest()
+                if actual != expected_hash:
+                    failed += 1
+                    logger.error(
+                        "blob %s hash mismatch, left pointing at storage: %s %s "
+                        "(got %s)",
+                        sha256 or pack_sha256,
+                        row["workspace_id"],
+                        row["file_path"],
+                        actual,
+                    )
+                    continue
+
+            content_text, content_binary = _inline_columns(data, row["is_binary"])
+            # The rollback target reads BYTEA only when is_binary is true, so a
+            # NUL-bearing text row put into content_binary has to be relabelled
+            # or the code we are rolling back to cannot read it — which would
+            # make this whole mode a no-op for exactly the rows it exists for.
+            is_binary = row["is_binary"] or content_binary is not None
+            if content_binary is not None and not row["is_binary"]:
+                as_binary += 1
+                logger.warning(
+                    "text file is not clean UTF-8 (NUL or invalid bytes), "
+                    "restored to BYTEA and marked binary so the rollback "
+                    "target can read it: %s %s",
+                    row["workspace_id"],
+                    row["file_path"],
+                )
+
+            # Every column the read observed is in the CAS, not just the two
+            # pointers: a repack can hand a different chunk the same digest
+            # with different member boundaries, so digest equality alone would
+            # let a re-pointed row take a slice cut for its predecessor.
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    UPDATE workspace_files
+                       SET content_text = %s,
+                           content_binary = %s,
+                           is_binary = %s,
+                           blob_sha256 = NULL,
+                           pack_sha256 = NULL,
+                           pack_offset = NULL
+                     WHERE workspace_file_id = %s::uuid
+                       AND blob_sha256 IS NOT DISTINCT FROM %s
+                       AND pack_sha256 IS NOT DISTINCT FROM %s
+                       AND content_hash IS NOT DISTINCT FROM %s
+                       AND pack_offset IS NOT DISTINCT FROM %s
+                       AND file_size IS NOT DISTINCT FROM %s
+                    """,
+                    (
+                        content_text,
+                        content_binary,
+                        is_binary,
+                        file_id,
+                        sha256,
+                        pack_sha256,
+                        row["content_hash"],
+                        row["pack_offset"],
+                        row["file_size"],
+                    ),
+                )
+                if cur.rowcount:
+                    restored += 1
+                    restored_bytes += len(data)
+                else:
+                    # The CAS missed: a sync re-pointed this row while we held
+                    # its bytes. Silence here would be the dangerous outcome —
+                    # the row is still blob-backed, and the caller is about to
+                    # treat a zero exit as "safe to downgrade".
+                    raced += 1
+                    logger.warning(
+                        "row re-pointed mid-reverse, still blob-backed: %s %s",
+                        row["workspace_id"],
+                        row["file_path"],
+                    )
+
+    logger.info(
+        "%s %d file(s) inline, %d bytes; %d as BYTEA (text that is not clean "
+        "UTF-8), %d raced, %d failed",
+        "restored" if apply else "would restore",
+        restored,
+        restored_bytes,
+        as_binary,
+        raced,
+        failed,
+    )
+    if apply:
+        left = await _count_blob_backed(conn, workspace_id)
+        if left:
+            logger.error(
+                "%d row(s) still reference storage — DO NOT run the migration "
+                "downgrade; re-run --reverse --apply until this reaches zero",
+                left,
+            )
+            return 1
+    return 1 if (failed or raced) else 0
+
+
+async def _count_blob_backed(
+    conn: psycopg.AsyncConnection, workspace_id: str | None
+) -> int:
+    """Rows still pointing at object storage. Zero is the downgrade precondition."""
+    sql = f"SELECT count(*) FROM workspace_files WHERE {BLOB_BACKED_SQL}"
+    params: tuple = ()
+    if workspace_id:
+        sql += " AND workspace_id = %s::uuid"
+        params = (workspace_id,)
+    async with conn.cursor() as cur:
+        await cur.execute(sql, params)
+        row = await cur.fetchone()
+    return row[0] if row else 0
+
+
+async def _run(
+    apply: bool,
+    reverse: bool,
+    batch: int,
+    workspace_id: str | None,
+    include_legacy_owners: bool = False,
+) -> int:
+    if not is_storage_enabled():
+        logger.error(
+            "Object storage is disabled (STORAGE_PROVIDER=none / "
+            "agent_config.yaml storage.provider). Refusing to run."
+        )
+        return 2
+    if not apply:
+        logger.info("DRY RUN — nothing will be written. Re-run with --apply.")
+    async with await psycopg.AsyncConnection.connect(
+        build_db_uri(), autocommit=True
+    ) as conn:
+        if reverse:
+            return await _reverse(conn, apply, batch, workspace_id)
+        return await _forward(
+            conn, apply, batch, workspace_id, include_legacy_owners
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true", help="Mutate rows (default: dry-run)."
+    )
+    parser.add_argument(
+        "--reverse",
+        action="store_true",
+        help="Pull blob bytes back into the inline columns (rollback path).",
+    )
+    parser.add_argument(
+        "--batch", type=int, default=500, help="Ids fetched per page (default: 500)."
+    )
+    parser.add_argument(
+        "--workspace",
+        metavar="UUID",
+        help="Limit to one workspace, so the rollout can be staged and verified "
+        "before the whole table moves.",
+    )
+    parser.add_argument(
+        "--include-legacy-owners",
+        action="store_true",
+        help="Also move rows whose owner has a non-UUID id. Such an account is "
+        "re-keyed by its first platform login and its objects would not follow; "
+        "pass this once no such login can still arrive, or on a build without "
+        "platform auth, where every id is local.",
+    )
+    args = parser.parse_args()
+    return asyncio.run(
+        _run(
+            args.apply,
+            args.reverse,
+            args.batch,
+            args.workspace,
+            args.include_legacy_owners,
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/report_orphan_blobs.py
+++ b/scripts/ops/report_orphan_blobs.py
@@ -1,0 +1,170 @@
+"""Report workspace file blobs that no manifest row references. Read-only.
+
+Content addressing means every save of a changed file writes a new
+``blobs/{user_id}/{sha256}`` and orphans its predecessor. The in-process sweeper
+(``services/workspace_file_gc.py``) condemns an orphan after a grace period
+with no reference and no writer touch, and deletes its object a further
+grace period later. This script shows where that pipeline stands: how much is
+orphaned, how much of it is condemned, and how much is past the second grace
+and waiting on the next cycle. A growing reclaimable count means the reap
+batch is not keeping up with churn.
+
+Usage:
+    uv run python scripts/ops/report_orphan_blobs.py
+    uv run python scripts/ops/report_orphan_blobs.py --list 50
+
+Never mutates anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+import psycopg
+from psycopg.rows import dict_row
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+from scripts.ops._db import build_db_uri  # noqa: E402
+from src.server.database.blob_keys import (  # noqa: E402  import-free by design
+    GC_CONDEMNED_GRACE_HOURS,
+    GC_GRACE_DAYS,
+    REFERENCED_SQL,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("report_orphan_blobs")
+
+# An orphan is exactly a blob the sweep considers unreferenced, so this is
+# the sweep's own predicate negated rather than a second spelling of it: a
+# report that disagreed with the condemn pass would send an operator hunting
+# for rows the GC is never going to touch.
+_ORPHAN_PREDICATE = f"NOT {REFERENCED_SQL}"
+
+# Over orphans only: a referenced blob untouched for the grace period is not
+# condemnable, and a condemned one that regained a reference is revived by the
+# reap, so counting either reports a backlog the sweep will never work through.
+_GC_BACKLOG_SQL = f"""
+    SELECT COUNT(*) FILTER (WHERE b.condemned_at IS NOT NULL) AS condemned_rows,
+           COALESCE(SUM(b.byte_len) FILTER (WHERE b.condemned_at IS NOT NULL), 0)
+               AS condemned_bytes,
+           COUNT(*) FILTER (
+               WHERE b.condemned_at < NOW() - make_interval(hours => %s)
+           ) AS reclaimable_rows,
+           COUNT(*) FILTER (
+               WHERE b.condemned_at IS NULL
+                 AND b.last_referenced_at < NOW() - make_interval(days => %s)
+           ) AS past_grace_rows
+    FROM workspace_file_blobs b
+    WHERE {_ORPHAN_PREDICATE}
+"""
+
+
+def _human(num_bytes: int) -> str:
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(value) < 1024.0:
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{value:.1f} PiB"
+
+
+async def _report(list_limit: int) -> int:
+    async with await psycopg.AsyncConnection.connect(build_db_uri()) as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT COUNT(*) AS total_rows,
+                       COALESCE(SUM(byte_len), 0) AS total_bytes
+                FROM workspace_file_blobs
+                """
+            )
+            totals = await cur.fetchone()
+
+            await cur.execute(
+                f"""
+                SELECT COUNT(*) AS orphan_rows,
+                       COALESCE(SUM(b.byte_len), 0) AS orphan_bytes,
+                       MIN(b.created_at) AS oldest
+                FROM workspace_file_blobs b
+                WHERE {_ORPHAN_PREDICATE}
+                """
+            )
+            orphans = await cur.fetchone()
+
+            await cur.execute(
+                _GC_BACKLOG_SQL, (GC_CONDEMNED_GRACE_HOURS, GC_GRACE_DAYS)
+            )
+            gc = await cur.fetchone()
+
+            samples = []
+            if list_limit > 0 and orphans["orphan_rows"]:
+                await cur.execute(
+                    f"""
+                    SELECT b.user_id, b.sha256, b.byte_len, b.created_at
+                    FROM workspace_file_blobs b
+                    WHERE {_ORPHAN_PREDICATE}
+                    ORDER BY b.byte_len DESC
+                    LIMIT %s
+                    """,
+                    (list_limit,),
+                )
+                samples = await cur.fetchall()
+
+    total_rows = int(totals["total_rows"])
+    total_bytes = int(totals["total_bytes"])
+    orphan_rows = int(orphans["orphan_rows"])
+    orphan_bytes = int(orphans["orphan_bytes"])
+    share = (orphan_bytes / total_bytes * 100) if total_bytes else 0.0
+
+    logger.info(
+        "registry: %d blob(s), %s total", total_rows, _human(total_bytes)
+    )
+    logger.info(
+        "orphaned: %d blob(s), %s (%.1f%% of stored bytes)",
+        orphan_rows,
+        _human(orphan_bytes),
+        share,
+    )
+    if orphans["oldest"] is not None:
+        logger.info("oldest orphan registered at %s", orphans["oldest"])
+    logger.info(
+        "gc: %d condemned (%s), %d reclaimable on the next cycle, "
+        "%d live row(s) untouched for over %dd",
+        int(gc["condemned_rows"]),
+        _human(int(gc["condemned_bytes"])),
+        int(gc["reclaimable_rows"]),
+        int(gc["past_grace_rows"]),
+        GC_GRACE_DAYS,
+    )
+
+    for row in samples:
+        logger.info(
+            "  %s/%s  %s  registered %s",
+            row["user_id"],
+            row["sha256"],
+            _human(int(row["byte_len"])),
+            row["created_at"],
+        )
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--list",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Also list the N largest orphans (default: 0, summary only).",
+    )
+    args = parser.parse_args()
+    return asyncio.run(_report(args.list))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/scrub_nul_checkpoint.py
+++ b/scripts/ops/scrub_nul_checkpoint.py
@@ -23,13 +23,18 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-import os
 import sys
+from pathlib import Path
 from typing import Any
-from urllib.parse import quote_plus
 
 import psycopg
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+# Run as a script, sys.path[0] is scripts/ops, not the repo root the sibling
+# helper is imported from.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.ops._db import build_db_uri  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("scrub_nul_checkpoint")
@@ -94,19 +99,8 @@ def _strip_nul(value: Any) -> tuple[Any, int]:
 
 
 def _build_db_uri() -> str:
-    db_host = os.getenv("MEMORY_DB_HOST", "localhost")
-    db_port = os.getenv("MEMORY_DB_PORT", "5432")
-    db_name = os.getenv("MEMORY_DB_NAME", "postgres")
-    db_user = os.getenv("MEMORY_DB_USER", "postgres")
-    db_password = os.getenv("MEMORY_DB_PASSWORD", "postgres")
-    # Read directly rather than importing src.config: that would pull in the app's
-    # load_dotenv() and silently retarget this script at whatever .env names —
-    # unacceptable for a tool that mutates rows under --apply.
-    sslmode = os.getenv("DB_SSLMODE", "prefer")
-    return (
-        f"postgresql://{quote_plus(db_user)}:{quote_plus(db_password)}"
-        f"@{db_host}:{db_port}/{db_name}?sslmode={sslmode}"
-    )
+    """The checkpointer's database, from the MEMORY_DB_* vars it uses."""
+    return build_db_uri("MEMORY_DB_")
 
 
 async def _scrub_table(

--- a/src/ptc_agent/core/sandbox/_shared.py
+++ b/src/ptc_agent/core/sandbox/_shared.py
@@ -37,6 +37,11 @@ _MCP_SHARED_RUNTIME_FILES: tuple[str, ...] = (
 # (e.g. ``market_protocol/instruments.yaml``) can never silently drop.
 _SANDBOX_INTERNAL_PACKAGES: tuple[str, ...] = ("data_client", "market_protocol")
 
+#: Backend-owned script that walks, hashes and moves workspace files inside the
+#: sandbox. Lives beside this module on the host; ships to ``_internal/src/``.
+TRANSFER_RUNTIME_SANDBOX_NAME = "wsfiles_transfer.py"
+_TRANSFER_RUNTIME_SOURCE = Path(__file__).with_name("wsfiles_transfer_runtime.py")
+
 
 @dataclass
 class ChartData:
@@ -92,6 +97,10 @@ def _internal_package_files(src_dir: Path) -> list[tuple[Path, Path]]:
     if not src_init.exists():
         return []
     files: list[tuple[Path, Path]] = [(src_init, Path("__init__.py"))]
+    # The file-transfer runtime rides the same all-or-nothing module so it is
+    # hashed into the manifest and re-shipped whenever it changes; the vault
+    # helper's unhashed upload is the precedent this deliberately avoids.
+    files.append((_TRANSFER_RUNTIME_SOURCE, Path(TRANSFER_RUNTIME_SANDBOX_NAME)))
     for pkg in _SANDBOX_INTERNAL_PACKAGES:
         pkg_dir = (src_dir / pkg).resolve()
         if not pkg_dir.exists():

--- a/src/ptc_agent/core/sandbox/providers/daytona_secrets.py
+++ b/src/ptc_agent/core/sandbox/providers/daytona_secrets.py
@@ -24,15 +24,15 @@ def daytona_error_status(exc: Exception) -> int | None:
 
 
 def daytona_error_code(exc: Exception) -> str | None:
-    """Extract the SDK's machine-readable ``error_code`` through wrapper chains.
+    """Extract the SDK's machine-readable ``code`` through wrapper chains.
 
     Structured and stable where the message text is not — it is what separates a
     per-path ``FILE_NOT_FOUND`` from a sandbox-level ``NOT_FOUND``, both of which
-    arrive as HTTP 404.
+    arrive as HTTP 404. Only a string counts: ``code`` is a common attribute
+    name, and an integer on some wrapped exception is not an SDK envelope.
     """
 
-    code = _walk_chain_attrs(exc, ("error_code",))
-    return str(code) if code else None
+    return _walk_chain_attrs(exc, ("code",))
 
 
 def _walk_chain_attrs(exc: Exception, attrs: tuple[str, ...]) -> Any | None:
@@ -46,6 +46,11 @@ def _walk_chain_attrs(exc: Exception, attrs: tuple[str, ...]) -> Any | None:
             value = getattr(current, attr, None)
             if attr in ("status", "status_code"):
                 if isinstance(value, int):
+                    return value
+            elif attr == "code":
+                # ``code`` is a common name; an integer on an outer wrapper
+                # (HTTPError, SystemExit) must not hide the SDK's string.
+                if isinstance(value, str) and value:
                     return value
             elif value:
                 return value

--- a/src/ptc_agent/core/sandbox/providers/docker.py
+++ b/src/ptc_agent/core/sandbox/providers/docker.py
@@ -121,6 +121,7 @@ class DockerRuntime(SandboxRuntime):
         self._host_port_map: dict[int, int] = host_port_map or {}
         self._port_map: dict[int, int] = {}  # agent port → container proxy port
         self._forwarder_pids: dict[int, str] = {}  # container proxy port → socat PID
+        self._owner_id_cache: tuple[int, int] | None = None  # uid/gid inside the container
 
     # -- Properties --
 
@@ -298,12 +299,14 @@ class DockerRuntime(SandboxRuntime):
 
         # Build one tar archive with full absolute paths.
         buf = io.BytesIO()
+        uid, gid = await self._owner_ids()
         with tarfile.open(fileobj=buf, mode="w") as tar:
             for data, dest_path in prepared:
                 tar_name = dest_path.lstrip("/")
                 info = tarfile.TarInfo(name=tar_name)
                 info.size = len(data)
                 info.mode = 0o644
+                info.uid, info.gid = uid, gid
                 tar.addfile(info, io.BytesIO(data))
         buf.seek(0)
 
@@ -598,6 +601,27 @@ class DockerRuntime(SandboxRuntime):
 
     # -- Internal: tar-based file I/O --
 
+    async def _owner_ids(self) -> tuple[int, int]:
+        """The uid/gid the container runs as, cached for the runtime's life.
+
+        ``put_archive`` extracts with each tar entry's ownership, and an entry
+        built here defaults to root. A file the container's own user does not
+        own can be read but never chmod'd or utime'd, which is exactly what
+        placing a restored workspace file has to do.
+        """
+        if self._owner_id_cache is None:
+            res = await self.exec("id -u; id -g", timeout=10)
+            try:
+                uid, gid = (int(x) for x in res.stdout.split()[:2])
+            except ValueError:
+                logger.warning(
+                    "Could not read the container's uid/gid; uploading as root",
+                    runtime_id=self._id,
+                )
+                uid, gid = 0, 0
+            self._owner_id_cache = (uid, gid)
+        return self._owner_id_cache
+
     async def _tar_upload(self, dest_path: str, content: bytes) -> None:
         """Upload a single file into the container via a tar archive.
 
@@ -608,12 +632,14 @@ class DockerRuntime(SandboxRuntime):
         if parent:
             await self.exec(f"mkdir -p {shlex.quote(parent)}", timeout=10)
 
+        uid, gid = await self._owner_ids()
         buf = io.BytesIO()
         tar_name = dest_path.lstrip("/")
         with tarfile.open(fileobj=buf, mode="w") as tar:
             info = tarfile.TarInfo(name=tar_name)
             info.size = len(content)
             info.mode = 0o644
+            info.uid, info.gid = uid, gid
             tar.addfile(info, io.BytesIO(content))
         buf.seek(0)
 

--- a/src/ptc_agent/core/sandbox/wsfiles_transfer_runtime.py
+++ b/src/ptc_agent/core/sandbox/wsfiles_transfer_runtime.py
@@ -1,0 +1,1179 @@
+"""Workspace file transfer runtime, uploaded into the sandbox verbatim.
+
+The backend moves metadata only. This script walks the workspace, hashes
+files, and moves bytes straight between the sandbox disk and object storage
+through presigned URLs. It runs on the sandbox's bare python3, so it is
+standard library only and imports nothing from the host repo.
+
+CLI: ``python3 wsfiles_transfer.py <op> (--spec-b64 <base64 json> | <in.json>)``
+where ``op`` is scan, push, pull, pack or unlink. The result is the last
+stdout line, behind ``RESULT_MARKER``, and the process exits 0 even on partial
+failure; exit 2 is reserved for unreadable or invalid input.
+"""
+
+import base64
+import codecs
+import hashlib
+import http.client
+import json
+import os
+import shutil
+import socket
+import ssl
+import stat
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+_CHUNK = 1024 * 1024
+# Defaults for a spec that names no concurrency. The server always sends its
+# own (transfer.py's PUSH_CONCURRENCY / PULL_CONCURRENCY); these are the same
+# measured knees, so a runtime driven by hand behaves like the server's.
+_PUSH_CONCURRENCY = 16
+_PULL_CONCURRENCY = 32
+_PACK_DIR = "_internal/packs"
+_PACK_STALE_S = 3600.0
+# Every transient file this runtime or the server writes into the workspace
+# sits at the root under this prefix, and the scan skips it there and only
+# there: a user's own ``sub/.wsfiles-notes`` is a file like any other.
+_TEMP_PREFIX = ".wsfiles-"
+_RELAY_STAGING_PREFIX = ".wsfiles-relay-"
+_MAX_ATTEMPTS = 3
+_BACKOFF_S = (0.5, 2.0)
+_ERROR_BODY_LIMIT = 64 * 1024
+
+
+# ---------------------------------------------------------------------------
+# shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _hash_file(path: str) -> tuple[str, bool, int]:
+    """Hash and classify the file in one read; returns (sha256, is_binary, size).
+
+    The size is the byte count the digest covers, not a separate stat: a file
+    that grows between the two would otherwise be reported with a digest of
+    the new bytes and the length of the old.
+
+    Binary means a NUL anywhere, or bytes anywhere that are not strict UTF-8.
+    Neither is sampled from a leading window: text is stored in a column that
+    cannot hold a NUL, so one further in is dropped on the way to the row and
+    the stored bytes stop hashing to the row's own digest, and a blob row is
+    never re-read on the way out, so a bad sequence after the first pages
+    would be served as text with replacement marks. The decoder is dropped at
+    the first NUL or failure, so the rest of a binary costs only the hash.
+    """
+    h = hashlib.sha256()
+    size = 0
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(_CHUNK), b""):
+            h.update(chunk)
+            if decoder is not None:
+                if b"\0" in chunk:
+                    decoder = None
+                else:
+                    try:
+                        decoder.decode(chunk)
+                    except UnicodeDecodeError:
+                        decoder = None
+            size += len(chunk)
+    if decoder is not None:
+        try:
+            decoder.decode(b"", final=True)
+        except UnicodeDecodeError:
+            decoder = None
+    return h.hexdigest(), decoder is None, size
+
+
+def _resolve_under_root(root: str, rel: str) -> str | None:
+    """Return the absolute final path, or None when ``rel`` escapes ``root``.
+
+    The check is lexical on purpose: a symlink already inside the workspace
+    pointing outside is the user's own arrangement, but a JSON item must never
+    name a location outside the root it was given.
+    """
+    if not rel or rel.startswith("/") or os.path.isabs(rel):
+        return None
+    norm = os.path.normpath(rel)
+    if norm == "." or os.path.isabs(norm):
+        return None
+    parts = norm.split(os.sep)
+    # Only a whole ".." component escapes; a name that merely starts with two
+    # dots ("..notes") is an ordinary file.
+    if ".." in parts:
+        return None
+    return os.path.join(root, norm)
+
+
+def _result(status: str, http_status: int | None = None, error: str | None = None) -> dict[str, Any]:
+    return {"status": status, "http": http_status, "error": error}
+
+
+def _read_error_body(resp: Any) -> str:
+    try:
+        return resp.read(_ERROR_BODY_LIMIT).decode("utf-8", "replace")
+    except Exception:
+        return ""
+
+
+def _is_connection_error(exc: BaseException) -> bool:
+    if isinstance(exc, (urllib.error.HTTPError, _HttpStatusError)):
+        return False
+    return isinstance(
+        exc,
+        (
+            urllib.error.URLError,
+            socket.timeout,
+            TimeoutError,
+            ConnectionError,
+            OSError,
+            http.client.HTTPException,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# scan
+# ---------------------------------------------------------------------------
+
+
+def scan(spec: dict[str, Any]) -> dict[str, Any]:
+    root = os.path.abspath(spec["root"])
+    exclude_dir_names = set(spec.get("exclude_dir_names") or ())
+    exclude_rel_dirs = {p.strip("/") for p in (spec.get("exclude_rel_dirs") or ())}
+    exclude_rel_dir_prefixes = tuple(
+        p.strip("/") for p in (spec.get("exclude_rel_dir_prefixes") or ())
+    )
+    exclude_basenames = set(spec.get("exclude_basenames") or ())
+    exclude_rel_files = {p.strip("/") for p in (spec.get("exclude_rel_files") or ())}
+    exclude_root_basenames = set(spec.get("exclude_root_basenames") or ())
+    exclude_root_prefixes = tuple(spec.get("exclude_root_basename_prefixes") or ())
+    exclude_suffixes = tuple(spec.get("exclude_suffixes") or ())
+    max_file_bytes = spec.get("max_file_bytes")
+    prior = spec.get("prior") or {}
+
+    entries: list[dict[str, Any]] = []
+    oversized: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    counts = {"hashed": 0, "reused": 0}
+
+    def excluded_dir(name: str, rel: str) -> bool:
+        return (
+            name in exclude_dir_names
+            or rel in exclude_rel_dirs
+            or rel.startswith(exclude_rel_dir_prefixes)
+        )
+
+    def excluded_name(name: str) -> bool:
+        return name in exclude_dir_names or name in exclude_basenames
+
+    def file_entry(abs_path: str, rel: str) -> None:
+        st = os.stat(abs_path, follow_symlinks=False)
+        size = st.st_size
+        if max_file_bytes is not None and size > max_file_bytes:
+            oversized.append({"path": rel, "size": size})
+            return
+        known = prior.get(rel)
+        # The backend stores mtimes at microsecond precision, so the reuse
+        # check compares at that granularity; an exact ns compare would rehash
+        # every file on every scan.
+        if (
+            known
+            and len(known) >= 3
+            and known[0] == size
+            and known[2]
+            and int(known[1]) // 1000 == st.st_mtime_ns // 1000
+        ):
+            digest, is_binary = known[2], None
+            counts["reused"] += 1
+        else:
+            digest, is_binary, size = _hash_file(abs_path)
+            counts["hashed"] += 1
+        entries.append(
+            {
+                "path": rel,
+                "kind": "file",
+                "size": size,
+                "mtime_ns": st.st_mtime_ns,
+                "mode": stat.S_IMODE(st.st_mode),
+                "sha256": digest,
+                "symlink_target": None,
+                "is_binary": is_binary,
+            }
+        )
+
+    def symlink_entry(abs_path: str, rel: str) -> None:
+        st = os.lstat(abs_path)
+        entries.append(
+            {
+                "path": rel,
+                "kind": "symlink",
+                "size": 0,
+                "mtime_ns": st.st_mtime_ns,
+                "mode": 0,
+                "sha256": None,
+                "symlink_target": os.readlink(abs_path),
+            }
+        )
+
+    def walk(abs_dir: str, rel_dir: str) -> None:
+        """Post-order walk: a directory's own row follows its children's."""
+        try:
+            with os.scandir(abs_dir) as it:
+                children = sorted(it, key=lambda e: e.name)
+        except OSError as exc:
+            errors.append({"path": rel_dir or ".", "error": str(exc), "errno": exc.errno})
+            return
+        for child in children:
+            rel = f"{rel_dir}/{child.name}" if rel_dir else child.name
+            # Reserved root names are skipped whatever the entry is: the
+            # pull op's sweep removes any root ``.wsfiles-`` entry no item
+            # claims, directories included, so a row for one would only
+            # promise what the next restore deletes.
+            if not rel_dir and (
+                child.name in exclude_root_basenames
+                or child.name.startswith(exclude_root_prefixes)
+            ):
+                continue
+            try:
+                if child.is_symlink():
+                    if excluded_name(child.name) or rel in exclude_rel_files:
+                        continue
+                    symlink_entry(child.path, rel)
+                elif child.is_dir(follow_symlinks=False):
+                    if excluded_dir(child.name, rel):
+                        continue
+                    walk(child.path, rel)
+                    # Every directory gets a row, not only empty leaves: a
+                    # directory's mode is user data too (a read-only tree
+                    # has to come back read-only).
+                    st = child.stat(follow_symlinks=False)
+                    entries.append(
+                        {
+                            "path": rel,
+                            "kind": "dir",
+                            "size": 0,
+                            "mtime_ns": st.st_mtime_ns,
+                            "mode": stat.S_IMODE(st.st_mode),
+                            "sha256": None,
+                            "symlink_target": None,
+                        }
+                    )
+                elif child.is_file(follow_symlinks=False):
+                    if (
+                        child.name in exclude_basenames
+                        or rel in exclude_rel_files
+                        or child.name.endswith(exclude_suffixes)
+                    ):
+                        continue
+                    file_entry(child.path, rel)
+            except OSError as exc:
+                errors.append({"path": rel, "error": str(exc), "errno": exc.errno})
+
+    walk(root, "")
+    entries.sort(key=lambda e: e["path"])
+    return {
+        "entries": entries,
+        "oversized": oversized,
+        "errors": errors,
+        "hashed": counts["hashed"],
+        "reused": counts["reused"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTTP with per-thread connection reuse
+# ---------------------------------------------------------------------------
+#
+# The sandbox's environment routes HTTPS through an egress proxy that exists
+# to substitute platform secrets into headers. A presigned URL carries its
+# own credentials, so the store needs none of that, and the proxy is shared
+# by every sandbox on the node: under load it stalls a CONNECT for tens of
+# seconds or refuses it outright. Each worker thread therefore connects to
+# the store directly, uses the proxy only where direct egress is blocked,
+# and keeps one connection per host so a restore is not a handshake per
+# object.
+
+_local = threading.local()
+_CONNECT_TIMEOUT_S = 5.0
+# Opening every worker's connection at the same instant drops SYNs somewhere
+# between the sandbox and the store, and a dropped SYN costs its retransmit
+# backoff (1 s, then 3 s, then 7 s). Handshakes go through this gate a few
+# at a time; established connections are pooled, so the gate is paid once.
+# Width 8 was measured and is worse: the sandbox runs on a one-CPU quota,
+# and handshakes are the most CPU-expensive thing a worker does.
+_CONNECT_GATE = threading.BoundedSemaphore(4)
+# One TLS context for the process so a session ticket from the first
+# handshake to a host resumes every later one: the store's certificate is
+# verified once per process instead of once per worker thread. On a
+# one-CPU sandbox the saving is CPU, not round trips.
+_SSL_CTX = ssl.create_default_context()
+_SESSIONS: dict[str, Any] = {}
+_HANDSHAKES = {"full": 0, "resumed": 0}
+_HANDSHAKES_LOCK = threading.Lock()
+
+
+class _HttpsConnection(http.client.HTTPSConnection):
+    """HTTPSConnection that offers the host's cached TLS session on connect."""
+
+    def connect(self) -> None:
+        http.client.HTTPConnection.connect(self)
+        server_hostname = self._tunnel_host or self.host
+        session = _SESSIONS.get(server_hostname)
+        self.sock = _SSL_CTX.wrap_socket(self.sock, server_hostname=server_hostname, session=session)
+        with _HANDSHAKES_LOCK:
+            _HANDSHAKES["resumed" if self.sock.session_reused else "full"] += 1
+
+
+def _remember_session(conn: Any) -> None:
+    """Cache the session once the server has sent its ticket.
+
+    With TLS 1.3 the ticket follows the handshake, so it is only there after
+    the first response has been read from the connection.
+    """
+    sock = getattr(conn, "sock", None)
+    session = getattr(sock, "session", None)
+    if session is not None:
+        _SESSIONS[conn._tunnel_host or conn.host] = session
+
+
+class _HttpStatusError(Exception):
+    def __init__(self, status: int, body: str) -> None:
+        super().__init__(f"HTTP {status}")
+        self.status = status
+        self.body = body
+
+
+def _proxy_for(scheme: str, host: str) -> tuple[str, int] | None:
+    try:
+        if urllib.request.proxy_bypass(host):
+            return None
+        raw = urllib.request.getproxies().get(scheme)
+    except Exception:
+        return None
+    if not raw:
+        return None
+    u = urllib.parse.urlsplit(raw if "://" in raw else f"http://{raw}")
+    if not u.hostname:
+        return None
+    return u.hostname, u.port or 80
+
+
+def _open(scheme: str, host: str, port: int, timeout_s: float) -> Any:
+    cls = _HttpsConnection if scheme == "https" else http.client.HTTPConnection
+    routes = getattr(_local, "routes", None)
+    if routes is None:
+        routes = _local.routes = {}
+    proxy = _proxy_for(scheme, host)
+    with _CONNECT_GATE:
+        if proxy is not None and routes.get(host) != "direct" and routes.get(host) != "proxy":
+            conn = cls(host, port, timeout=_CONNECT_TIMEOUT_S)
+            try:
+                conn.connect()
+                routes[host] = "direct"
+                conn.timeout = timeout_s
+                conn.sock.settimeout(timeout_s)
+                conn.wsfiles_absolute_target = False
+                return conn
+            except OSError:
+                routes[host] = "proxy"
+                conn.close()
+        if proxy is None or routes.get(host) == "direct":
+            conn = cls(host, port, timeout=timeout_s)
+            conn.wsfiles_absolute_target = False
+        else:
+            conn = cls(proxy[0], proxy[1], timeout=timeout_s)
+            if scheme == "https":
+                conn.set_tunnel(host, port)
+            conn.wsfiles_absolute_target = scheme == "http"
+        conn.connect()
+    return conn
+
+
+def _connection(scheme: str, host: str, port: int, timeout_s: float) -> Any:
+    key = (scheme, host, port)
+    conns = getattr(_local, "conns", None)
+    if conns is None:
+        conns = _local.conns = {}
+    conn = conns.get(key)
+    if conn is None:
+        conn = conns[key] = _open(scheme, host, port, timeout_s)
+    return key, conn
+
+
+def _drop_connection(key: tuple) -> None:
+    conns = getattr(_local, "conns", None)
+    conn = conns.pop(key, None) if conns else None
+    if conn is not None:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def _request(method: str, url: str, timeout_s: float, body: Any = None, headers: dict | None = None) -> Any:
+    """Send one request on the thread's pooled connection; returns the response.
+
+    The caller must read the response to the end before issuing another
+    request on the same thread. Anything but a 2xx raises ``_HttpStatusError``
+    with the body already consumed: a redirect is not followed, because a PUT
+    answered with one stored nothing and the signature would not survive the
+    new location. Any transport failure closes the connection so the retry
+    starts clean.
+    """
+    u = urllib.parse.urlsplit(url)
+    scheme = u.scheme or "https"
+    host = u.hostname or ""
+    port = u.port or (443 if scheme == "https" else 80)
+    key, conn = _connection(scheme, host, port, timeout_s)
+    target = url if conn.wsfiles_absolute_target else (u.path or "/") + (f"?{u.query}" if u.query else "")
+    try:
+        conn.request(method, target, body=body, headers=headers or {})
+        resp = conn.getresponse()
+    except BaseException:
+        _drop_connection(key)
+        raise
+    if scheme == "https":
+        _remember_session(conn)
+    if not 200 <= resp.status < 300:
+        text = _read_error_body(resp)
+        _drop_connection(key)
+        raise _HttpStatusError(resp.status, text)
+    resp.wsfiles_conn_key = key
+    return resp
+
+
+def _drop_response_connection(resp: Any) -> None:
+    """Discard the connection behind a response whose body read failed.
+
+    Left in the pool, its unread body makes the next request on the thread
+    fail with ``CannotSendRequest``, which reads as unreachable and burns an
+    attempt on a transient read error.
+    """
+    key = getattr(resp, "wsfiles_conn_key", None)
+    if key is not None:
+        _drop_connection(key)
+
+
+def _timed(fn: Any, *args: Any) -> dict[str, Any]:
+    t0 = time.monotonic()
+    res = fn(*args)
+    res["ms"] = int((time.monotonic() - t0) * 1000)
+    return res
+
+
+# ---------------------------------------------------------------------------
+# push
+# ---------------------------------------------------------------------------
+
+
+class _BoundedBody:
+    """A file wrapper that stops at ``limit`` and remembers if more was there.
+
+    ``http.client`` streams a file object to EOF whatever Content-Length it
+    was handed, so a file appended to during its own PUT puts the tail on the
+    wire behind the declared body: the store keeps the prefix, which still
+    matches the signed digest, and the tail arrives at the head of the next
+    request on that pooled connection.
+    """
+
+    def __init__(self, fh: Any, limit: int) -> None:
+        self._fh = fh
+        self._left = limit
+        self.overrun = False
+
+    def read(self, size: int = -1) -> bytes:
+        if self._left <= 0:
+            # One byte past the declared body decides; it is never sent.
+            self.overrun = self.overrun or bool(self._fh.read(1))
+            return b""
+        want = self._left if size is None or size < 0 else min(size, self._left)
+        data = self._fh.read(want)
+        self._left -= len(data)
+        return data
+
+
+def _size_of(path: str) -> int:
+    """The file's current size, or -1 when it can no longer be stat'd."""
+    try:
+        return os.stat(path).st_size
+    except OSError:
+        return -1
+
+
+def _push_one(root: str, item: dict[str, Any], timeout_s: float) -> dict[str, Any]:
+    final = _resolve_under_root(root, item.get("path", ""))
+    if final is None:
+        return _result("failed", error="path escapes root")
+    expected_size = int(item["size"])
+    try:
+        if os.stat(final).st_size != expected_size:
+            return _result("changed", error="size changed before upload")
+    except OSError as exc:
+        return _result("failed", error=str(exc))
+
+    headers = dict(item.get("headers") or {})
+    headers["Content-Length"] = str(expected_size)
+    last: dict[str, Any] | None = None
+    for attempt in range(_MAX_ATTEMPTS):
+        if attempt:
+            time.sleep(_BACKOFF_S[min(attempt - 1, len(_BACKOFF_S) - 1)])
+        try:
+            with open(final, "rb") as fh:
+                body = _BoundedBody(fh, expected_size)
+                resp = _request("PUT", item["url"], timeout_s, body=body, headers=headers)
+                try:
+                    resp.read()
+                except BaseException:
+                    _drop_response_connection(resp)
+                    raise
+                # The store verifies the bytes it was framed to read, so a
+                # file that grew during its own PUT is stored, and matches,
+                # as the prefix it was scanned as. Only the sandbox can see
+                # that the file is no longer those bytes.
+                if body.overrun or _size_of(final) != expected_size:
+                    return _result(
+                        "changed", resp.status, "size changed during upload"
+                    )
+                return _result("ok", resp.status)
+        except _HttpStatusError as exc:
+            if exc.status == 400 and "BadDigest" in exc.body:
+                return _result("changed", exc.status, "BadDigest")
+            if exc.status == 403 and "SignatureDoesNotMatch" in exc.body:
+                return _result("changed", exc.status, "SignatureDoesNotMatch")
+            last = _result("failed", exc.status, f"HTTP {exc.status}")
+            if exc.status < 500:
+                return last
+        except Exception as exc:
+            if not _is_connection_error(exc):
+                return _result("failed", error=f"{type(exc).__name__}: {exc}")
+            last = _result("unreachable", error=f"{type(exc).__name__}: {exc}")
+    return last or _result("failed", error="exhausted retries")
+
+
+def push(spec: dict[str, Any]) -> dict[str, Any]:
+    root = os.path.abspath(spec["root"])
+    timeout_s = float(spec.get("timeout_s") or 300)
+    items = spec.get("items") or []
+    concurrency = max(1, int(spec.get("concurrency") or _PUSH_CONCURRENCY))
+    results: dict[str, dict[str, Any]] = {}
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        for item, res in zip(items, pool.map(lambda i: _timed(_push_one, root, i, timeout_s), items)):
+            results[item["sha256"]] = res
+            # A pack chunk is a one-shot artifact, but only the store having it
+            # makes the local copy expendable: an unreachable store sends the
+            # server down the relay path, which reads the chunk back out of the
+            # sandbox. What neither path took is left where it is, and the next
+            # pack op's stale sweep removes it from a directory the scan
+            # excludes, so it never becomes a user's file.
+            if item.get("unlink") and res.get("status") == "ok":
+                final = _resolve_under_root(root, item.get("path", ""))
+                if final:
+                    _unlink_quiet(final)
+    return {"results": results, "handshakes": dict(_HANDSHAKES)}
+
+
+# ---------------------------------------------------------------------------
+# pull
+# ---------------------------------------------------------------------------
+
+
+def _download_to_temp(url: str, parent: str, timeout_s: float) -> tuple[str, str, int, int]:
+    """GET ``url`` into a temp file beside the target; returns (temp, sha256, bytes, http)."""
+    tmp = tempfile.NamedTemporaryFile(dir=parent, prefix=_TEMP_PREFIX, delete=False)
+    try:
+        h = hashlib.sha256()
+        n = 0
+        resp = _request("GET", url, timeout_s)
+        try:
+            for chunk in iter(lambda: resp.read(_CHUNK), b""):
+                h.update(chunk)
+                n += len(chunk)
+                tmp.write(chunk)
+        except BaseException:
+            _drop_response_connection(resp)
+            raise
+        status = resp.status
+        tmp.close()
+        return tmp.name, h.hexdigest(), n, status
+    except BaseException:
+        tmp.close()
+        _unlink_quiet(tmp.name)
+        raise
+
+
+def _unlink_quiet(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _populated_directory(final: str) -> bool:
+    """True when a populated directory holds the path a file or symlink needs.
+
+    An empty one yields, but only at placement (``_yield_empty_directory``):
+    every fresh sandbox seeds ``data``, ``results`` and ``work`` before the
+    restore runs, and a manifest that names one of them as a symlink or file
+    must win over the seed, or it fails on every recreation and the next
+    backup records the seed as the user's choice. Removing it before the
+    bytes are verified would leave nothing at the path when the transfer
+    fails, and nothing recreates a seed mid-session."""
+    if not os.path.isdir(final) or os.path.islink(final):
+        return False
+    return bool(os.listdir(final))
+
+
+def _yield_empty_directory(final: str) -> None:
+    """Remove the empty directory at ``final`` right before the verified bytes land."""
+    if os.path.isdir(final) and not os.path.islink(final):
+        os.rmdir(final)
+
+
+def _pull_file(root: str, item: dict[str, Any], timeout_s: float) -> dict[str, Any]:
+    final = _resolve_under_root(root, item.get("path", ""))
+    if final is None:
+        return _result("failed", error="path escapes root")
+    if _populated_directory(final):
+        return _result("failed", error="target is a populated directory")
+    url = item.get("url")
+    expected_sha = item.get("sha256")
+    expected_size = item.get("size")
+    if item.get("file"):
+        return _place_staged(root, final, item)
+    if not url:
+        return _result("failed", error="missing url")
+
+    last: dict[str, Any] | None = None
+    for attempt in range(_MAX_ATTEMPTS):
+        if attempt:
+            time.sleep(_BACKOFF_S[min(attempt - 1, len(_BACKOFF_S) - 1)])
+        try:
+            tmp, digest, n, status = _download_to_temp(url, root, timeout_s)
+        except _HttpStatusError as exc:
+            last = _result("failed", exc.status, f"HTTP {exc.status}")
+            if exc.status < 500:
+                return last
+            continue
+        except Exception as exc:
+            if not _is_connection_error(exc):
+                return _result("failed", error=f"{type(exc).__name__}: {exc}")
+            last = _result("unreachable", error=f"{type(exc).__name__}: {exc}")
+            continue
+
+        if (expected_sha is not None and digest != expected_sha) or (
+            expected_size is not None and n != int(expected_size)
+        ):
+            _unlink_quiet(tmp)
+            return _result("mismatch", status, f"got sha256={digest} bytes={n}")
+        try:
+            _yield_empty_directory(final)
+            os.replace(tmp, final)
+            mode = item.get("mode")
+            if mode is not None:
+                os.chmod(final, int(mode))
+            mtime_ns = item.get("mtime_ns")
+            if mtime_ns is not None:
+                os.utime(final, ns=(int(mtime_ns), int(mtime_ns)))
+        except OSError as exc:
+            _unlink_quiet(tmp)
+            return _result("failed", status, str(exc))
+        return _result("ok", status)
+    return last or _result("failed", error="exhausted retries")
+
+
+def _sweep_orphan_staging(root: str, items: list[dict[str, Any]]) -> None:
+    """Remove root-level transient entries no item of this op claims.
+
+    A relay upload the file API cut short, or a download the runtime died
+    in, leaves its partial bytes under the prefix, and the scan skips it
+    there, so nothing else would ever see them. Restores are serialized per
+    workspace, so any entry this op does not claim is a leftover of an
+    earlier one.
+    """
+    claimed = {os.path.basename(i["file"]) for i in items if i.get("file")}
+    for name in os.listdir(root):
+        if not name.startswith(_TEMP_PREFIX) or name in claimed:
+            continue
+        path = os.path.join(root, name)
+        if os.path.isdir(path) and not os.path.islink(path):
+            _rmtree_quiet(path)
+        else:
+            _unlink_quiet(path)
+
+
+def _place_staged(root: str, final: str, item: dict[str, Any]) -> dict[str, Any]:
+    """Move a file the server uploaded to a staging name into place.
+
+    The staged copy is verified against the manifest before it becomes the
+    file: an upload cut short by a full disk would otherwise be the file's
+    next content at the next backup. The staged copy is removed either way.
+    """
+    staged = _resolve_under_root(root, item["file"])
+    if staged is None:
+        return _result("failed", error="file escapes root")
+    try:
+        digest, _, n = _hash_file(staged)
+    except OSError as exc:
+        return _result("failed", error=str(exc))
+    expected_sha, expected_size = item.get("sha256"), item.get("size")
+    if (expected_sha is not None and digest != expected_sha) or (
+        expected_size is not None and n != int(expected_size)
+    ):
+        _unlink_quiet(staged)
+        return _result("mismatch", None, f"got sha256={digest} bytes={n}")
+    try:
+        _yield_empty_directory(final)
+        os.replace(staged, final)
+        mode = item.get("mode")
+        if mode is not None:
+            os.chmod(final, int(mode))
+        mtime_ns = item.get("mtime_ns")
+        if mtime_ns is not None:
+            os.utime(final, ns=(int(mtime_ns), int(mtime_ns)))
+    except OSError as exc:
+        _unlink_quiet(staged)
+        return _result("failed", error=str(exc))
+    return _result("ok")
+
+
+def _reopen_dir(path: str) -> None:
+    """Give the owner write and search on a directory a previous restore closed.
+
+    Directory modes are the last thing a restore applies, so a retry after a
+    partial one finds its parents already read-only; step 4 closes them again.
+    """
+    st = os.stat(path)
+    if st.st_mode & 0o300 != 0o300:
+        os.chmod(path, stat.S_IMODE(st.st_mode) | 0o300)
+
+
+def _pull_symlink(root: str, item: dict[str, Any]) -> dict[str, Any]:
+    final = _resolve_under_root(root, item.get("path", ""))
+    if final is None:
+        return _result("failed", error="path escapes root")
+    target = item.get("symlink_target")
+    if not target:
+        return _result("failed", error="missing symlink_target")
+    try:
+        if os.path.islink(final) or os.path.isfile(final):
+            os.unlink(final)
+        elif _populated_directory(final):
+            return _result("failed", error="target is a populated directory")
+        else:
+            _yield_empty_directory(final)
+        os.symlink(target, final)
+    except OSError as exc:
+        return _result("failed", error=str(exc))
+    mtime_ns = item.get("mtime_ns")
+    if mtime_ns is not None:
+        try:
+            os.utime(final, ns=(int(mtime_ns), int(mtime_ns)), follow_symlinks=False)
+        except (NotImplementedError, OSError):
+            pass
+    return _result("ok")
+
+
+def _extract_member(root: str, chunk: Any, member: dict[str, Any], http_status: int | None) -> dict[str, Any]:
+    """Slice one member out of an open pack chunk and place it like a pulled file."""
+    final = _resolve_under_root(root, member.get("path", ""))
+    if final is None:
+        return _result("failed", error="path escapes root")
+    if _populated_directory(final):
+        return _result("failed", error="target is a populated directory")
+    size = int(member.get("size") or 0)
+    try:
+        os.makedirs(os.path.dirname(final), exist_ok=True)
+        chunk.seek(int(member.get("offset") or 0))
+        data = chunk.read(size)
+    except OSError as exc:
+        return _result("failed", http_status, str(exc))
+    if len(data) != size:
+        return _result("mismatch", http_status, f"short read from pack: got bytes={len(data)}")
+    expected_sha = member.get("sha256")
+    if expected_sha is not None:
+        digest = hashlib.sha256(data).hexdigest()
+        if digest != expected_sha:
+            return _result("mismatch", http_status, f"got sha256={digest}")
+    tmp = tempfile.NamedTemporaryFile(dir=root, prefix=_TEMP_PREFIX, delete=False)
+    try:
+        tmp.write(data)
+        tmp.close()
+        _yield_empty_directory(final)
+        os.replace(tmp.name, final)
+        mode = member.get("mode")
+        if mode is not None:
+            os.chmod(final, int(mode))
+        mtime_ns = member.get("mtime_ns")
+        if mtime_ns is not None:
+            os.utime(final, ns=(int(mtime_ns), int(mtime_ns)))
+    except OSError as exc:
+        tmp.close()
+        _unlink_quiet(tmp.name)
+        return _result("failed", http_status, str(exc))
+    return _result("ok", http_status)
+
+
+def _pull_pack(root: str, item: dict[str, Any], timeout_s: float) -> dict[str, dict[str, Any]]:
+    """Download one pack chunk, then slice every member out of it.
+
+    Members fail together when the chunk cannot be fetched and one at a time
+    when their own bytes do not verify; the caller only ever sees member paths.
+    A chunk already in the sandbox (``file``, relative to the root) is
+    verified and consumed in place: the relay path uploads it whole so the
+    members still get this extractor's names, modes and mtimes.
+    """
+    members = item.get("members") or []
+    url = item.get("url")
+    expected_sha = item.get("sha256")
+
+    def fail_all(res: dict[str, Any]) -> dict[str, dict[str, Any]]:
+        return {m.get("path", ""): dict(res) for m in members}
+
+    local = item.get("file")
+    if local:
+        tmp = _resolve_under_root(root, local)
+        if tmp is None:
+            return fail_all(_result("failed", error="file escapes root"))
+        try:
+            digest, _, n = _hash_file(tmp)
+        except OSError as exc:
+            return fail_all(_result("failed", error=str(exc)))
+        if expected_sha is not None and digest != expected_sha:
+            _unlink_quiet(tmp)
+            return fail_all(_result("mismatch", None, f"got sha256={digest} bytes={n}"))
+        return _extract_all(root, tmp, members, None)
+    if not url:
+        return fail_all(_result("failed", error="missing url"))
+    # The chunk lands under the pack directory, which the scan excludes, so a
+    # restore that dies mid-download can never leave a partial chunk where
+    # the next backup would record it as a user's file.
+    scratch = os.path.join(root, _PACK_DIR)
+    try:
+        os.makedirs(scratch, exist_ok=True)
+    except OSError as exc:
+        return fail_all(_result("failed", error=str(exc)))
+    last: dict[str, Any] | None = None
+    tmp = None
+    status: int | None = None
+    for attempt in range(_MAX_ATTEMPTS):
+        if attempt:
+            time.sleep(_BACKOFF_S[min(attempt - 1, len(_BACKOFF_S) - 1)])
+        try:
+            tmp, digest, n, status = _download_to_temp(url, scratch, timeout_s)
+        except _HttpStatusError as exc:
+            last = _result("failed", exc.status, f"HTTP {exc.status}")
+            if exc.status < 500:
+                return fail_all(last)
+            continue
+        except Exception as exc:
+            if not _is_connection_error(exc):
+                return fail_all(_result("failed", error=f"{type(exc).__name__}: {exc}"))
+            last = _result("unreachable", error=f"{type(exc).__name__}: {exc}")
+            continue
+        if expected_sha is not None and digest != expected_sha:
+            _unlink_quiet(tmp)
+            return fail_all(_result("mismatch", status, f"got sha256={digest} bytes={n}"))
+        break
+    else:
+        return fail_all(last or _result("failed", error="exhausted retries"))
+
+    return _extract_all(root, tmp, members, status)
+
+
+def _extract_all(
+    root: str, chunk_path: str, members: list[dict[str, Any]], status: int | None
+) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    try:
+        with open(chunk_path, "rb") as chunk:
+            for member in members:
+                out[member.get("path", "")] = _extract_member(root, chunk, member, status)
+    finally:
+        _unlink_quiet(chunk_path)
+    return out
+
+
+def _timed_pack(root: str, item: dict[str, Any], timeout_s: float) -> dict[str, dict[str, Any]]:
+    t0 = time.monotonic()
+    out = _pull_pack(root, item, timeout_s)
+    ms = int((time.monotonic() - t0) * 1000)
+    for res in out.values():
+        res["ms"] = ms
+    return out
+
+
+def pull(spec: dict[str, Any]) -> dict[str, Any]:
+    """Materialize items; with ``defer_dir_modes`` the directories stay open.
+
+    The server sets that when more files follow in a later op, so directory
+    modes and mtimes are applied exactly once, by the op that places the last
+    file; a read-only directory closed early would reject its own children.
+    """
+    root = os.path.abspath(spec["root"])
+    timeout_s = float(spec.get("timeout_s") or 300)
+    items = spec.get("items") or []
+    concurrency = max(1, int(spec.get("concurrency") or _PULL_CONCURRENCY))
+    defer_dir_modes = bool(spec.get("defer_dir_modes"))
+    results: dict[str, dict[str, Any]] = {}
+    _sweep_orphan_staging(root, items)
+
+    files: list[dict[str, Any]] = []
+    packs: list[dict[str, Any]] = []
+    symlinks: list[dict[str, Any]] = []
+    dirs: list[tuple[dict[str, Any], str]] = []
+
+    # Step 1: parents first, then dir items, so a file lands in a directory
+    # that already exists. Dir modes wait for step 4: a read-only directory
+    # restored read-only first would reject its own children.
+    for item in items:
+        if item.get("kind") == "pack":
+            packs.append(item)
+            continue
+        path = item.get("path", "")
+        final = _resolve_under_root(root, path)
+        if final is None:
+            results[path] = _result("failed", error="path escapes root")
+            continue
+        kind = item.get("kind", "file")
+        try:
+            os.makedirs(os.path.dirname(final), exist_ok=True)
+            if kind == "dir":
+                os.makedirs(final, exist_ok=True)
+                _reopen_dir(final)
+                dirs.append((item, final))
+            elif kind == "symlink":
+                symlinks.append(item)
+            elif kind == "file":
+                files.append(item)
+            else:
+                results[path] = _result("failed", error=f"unknown kind {kind!r}")
+        except OSError as exc:
+            results[path] = _result("failed", error=str(exc))
+
+    # Step 2: packs and files, in parallel. Packs are submitted first: each
+    # is one download that fans out into many members, so it is the tail.
+    if files or packs:
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            pack_futures = [pool.submit(_timed_pack, root, p, timeout_s) for p in packs]
+            for item, res in zip(files, pool.map(lambda i: _timed(_pull_file, root, i, timeout_s), files)):
+                results[item["path"]] = res
+            for fut in pack_futures:
+                results.update(fut.result())
+
+    # Step 3: symlinks after files, so a link never shadows a file being written.
+    for item in symlinks:
+        results[item["path"]] = _pull_symlink(root, item)
+
+    # Step 4: dir modes and mtimes last, deepest first; writing children
+    # above would disturb the mtimes, and a parent's mode may forbid writes.
+    for item, final in sorted(dirs, key=lambda d: d[1], reverse=True):
+        if defer_dir_modes:
+            results[item["path"]] = _result("ok")
+            continue
+        mode = item.get("mode")
+        mtime_ns = item.get("mtime_ns")
+        try:
+            if mode is not None:
+                os.chmod(final, int(mode))
+            if mtime_ns is not None:
+                os.utime(final, ns=(int(mtime_ns), int(mtime_ns)))
+            results[item["path"]] = _result("ok")
+        except OSError as exc:
+            results[item["path"]] = _result("failed", error=str(exc))
+
+    return {"results": results, "handshakes": dict(_HANDSHAKES)}
+
+
+# ---------------------------------------------------------------------------
+# pack
+# ---------------------------------------------------------------------------
+
+
+def pack(spec: dict[str, Any]) -> dict[str, Any]:
+    """Concatenate ``members`` (path, sha256, size) into chunk files under ``out_dir``.
+
+    Deterministic: members are taken in sorted path order and a chunk closes
+    only at a member boundary once the next member would exceed ``max_bytes``,
+    so the same member set always yields the same chunk bytes and digests. A
+    member whose bytes no longer match what the scan reported is dropped and
+    listed under ``changed`` rather than written wrong; the previous chunk
+    files are wiped first so a stale one can never be pushed.
+    """
+    root = os.path.abspath(spec["root"])
+    base = _resolve_under_root(root, spec.get("out_dir") or _PACK_DIR)
+    if base is None:
+        raise ValueError("out_dir escapes root")
+    max_bytes = int(spec.get("max_bytes") or 32 * 1024 * 1024)
+    members = sorted(spec.get("members") or [], key=lambda m: m["path"])
+
+    # Two syncs of one workspace can overlap (a manual backup during a
+    # scheduled one), so each op owns a directory of its own and only ever
+    # removes what nothing can still be pushing: anything untouched for
+    # longer than a transfer is allowed to take.
+    os.makedirs(base, exist_ok=True)
+    _sweep_stale(base, _PACK_STALE_S)
+    out_dir = tempfile.mkdtemp(prefix="op-", dir=base)
+
+    chunks: list[dict[str, Any]] = []
+    changed: list[str] = []
+    current: dict[str, Any] | None = None
+
+    def open_chunk() -> dict[str, Any]:
+        tmp = tempfile.NamedTemporaryFile(dir=out_dir, prefix="chunk-tmp-", delete=False)
+        return {"file": tmp, "hash": hashlib.sha256(), "size": 0, "members": []}
+
+    def close_chunk() -> None:
+        # A chunk is opened only immediately before its first member is
+        # written, so one that exists always has at least one.
+        nonlocal current
+        if current is None:
+            return
+        current["file"].close()
+        digest = current["hash"].hexdigest()
+        final = os.path.join(out_dir, f"chunk-{digest}")
+        os.replace(current["file"].name, final)
+        chunks.append(
+            {
+                "path": os.path.relpath(final, root),
+                "sha256": digest,
+                "size": current["size"],
+                "members": current["members"],
+            }
+        )
+        current = None
+
+    for member in members:
+        rel = member["path"]
+        expected_size = int(member["size"])
+        expected_sha = member.get("sha256")
+        abs_path = _resolve_under_root(root, rel)
+        if abs_path is None:
+            changed.append(rel)
+            continue
+        # Small by contract, so the whole member is read before anything is
+        # written: a member that fails to verify must leave no bytes behind.
+        try:
+            with open(abs_path, "rb") as f:
+                data = f.read(expected_size + 1)
+        except OSError:
+            changed.append(rel)
+            continue
+        if len(data) != expected_size or (expected_sha is not None and hashlib.sha256(data).hexdigest() != expected_sha):
+            changed.append(rel)
+            continue
+        if current is not None and current["members"] and current["size"] + expected_size > max_bytes:
+            close_chunk()
+        if current is None:
+            current = open_chunk()
+        current["file"].write(data)
+        current["hash"].update(data)
+        current["members"].append(
+            {
+                "path": rel,
+                "offset": current["size"],
+                "size": expected_size,
+                "sha256": expected_sha or hashlib.sha256(data).hexdigest(),
+            }
+        )
+        current["size"] += expected_size
+    close_chunk()
+    if not chunks:
+        _rmtree_quiet(out_dir)
+    return {"chunks": chunks, "changed": changed}
+
+
+def _sweep_stale(base: str, max_age_s: float) -> None:
+    cutoff = time.time() - max_age_s
+    for name in os.listdir(base):
+        path = os.path.join(base, name)
+        try:
+            st = os.lstat(path)
+        except OSError:
+            continue
+        if st.st_mtime > cutoff:
+            continue
+        if stat.S_ISDIR(st.st_mode):
+            _rmtree_quiet(path)
+        else:
+            _unlink_quiet(path)
+
+
+def _rmtree_quiet(path: str) -> None:
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def unlink(spec: dict[str, Any]) -> dict[str, Any]:
+    """Remove files under root; used to drop chunks the server relayed itself."""
+    root = os.path.abspath(spec["root"])
+    removed = 0
+    for rel in spec.get("paths") or []:
+        path = _resolve_under_root(root, rel)
+        if path is None or not os.path.isfile(path):
+            continue
+        _unlink_quiet(path)
+        removed += 1
+    return {"removed": removed}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+_OPS = {"scan": scan, "push": push, "pull": pull, "pack": pack, "unlink": unlink}
+
+
+RESULT_MARKER = "WSFILES_RESULT "
+_USAGE = "usage: wsfiles_transfer.py <scan|push|pull|pack|unlink> (--spec-b64 <base64 json> | <in.json>)\n"
+
+
+def _load_spec(argv: list[str]) -> dict[str, Any]:
+    if argv[2] == "--spec-b64":
+        raw = base64.b64decode(argv[3])
+    else:
+        with open(argv[2], "rb") as f:
+            raw = f.read()
+        # The spec file is a one-shot exchange; nothing else reads it.
+        _unlink_quiet(argv[2])
+    spec = json.loads(raw.decode("utf-8"))
+    if not isinstance(spec, dict) or not isinstance(spec.get("root"), str):
+        raise ValueError("input must be a JSON object with a string 'root'")
+    return spec
+
+
+def _main(argv: list[str]) -> int:
+    """Run one op and print its result as the last stdout line.
+
+    The result travels back on stdout behind ``RESULT_MARKER`` so the caller
+    needs no second round trip to collect it; the spec arrives inline when
+    it fits an argument and as a file otherwise.
+    """
+    # The flag and its value are one unit, so a bare ``--spec-b64`` is a
+    # truncated four-argument form rather than a valid three-argument one.
+    inline = argv[2:3] == ["--spec-b64"]
+    if len(argv) not in (3, 4) or argv[1] not in _OPS or inline != (len(argv) == 4):
+        sys.stderr.write(_USAGE)
+        return 2
+    try:
+        spec = _load_spec(argv)
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"invalid input: {exc}\n")
+        return 2
+    try:
+        out = _OPS[argv[1]](spec)
+    except Exception as exc:
+        out = {"error": f"{type(exc).__name__}: {exc}"}
+    sys.stdout.write("\n" + RESULT_MARKER + json.dumps(out, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv))

--- a/src/server/app/public.py
+++ b/src/server/app/public.py
@@ -461,6 +461,7 @@ async def read_shared_file(
 
     from src.server.database.workspace import get_workspace as db_get_workspace
     from src.server.services.persistence.file import FilePersistenceService
+    from src.server.services.persistence.resolve import resolve_file_text_or_none
     from src.server.services.workspace_manager import WorkspaceManager
 
     workspace = await db_get_workspace(workspace_id)
@@ -483,21 +484,31 @@ async def read_shared_file(
         if file_record.get("is_binary"):
             raise HTTPException(status_code=415, detail="Cannot read binary file as text.")
 
-        text_content = file_record.get("content_text", "")
-        text_content = get_redactor().redact(text_content, vault_secrets=vault_secrets)
-        lines = text_content.splitlines()
-        content = "\n".join(lines[offset:offset + limit])
-        mime = file_record.get("mime_type") or "text/plain"
+        # `.get("content_text", "")` would hand redact() a None on a blob-backed
+        # row, since the key exists with a NULL value.
+        text_content = await resolve_file_text_or_none(
+            file_record,
+            user_id=workspace["user_id"],
+            context=f"reading shared file in workspace {workspace_id}",
+        )
+        # None is the resolver's uniform "absent" for a storage failure as
+        # much as for a missing row; a warm sandbox below may still hold
+        # the file, and the 404 at the end covers both when it does not.
+        if text_content is not None:
+            text_content = get_redactor().redact(text_content, vault_secrets=vault_secrets)
+            lines = text_content.splitlines()
+            content = "\n".join(lines[offset:offset + limit])
+            mime = file_record.get("mime_type") or "text/plain"
 
-        return {
-            "path": normalized_path,
-            "offset": offset,
-            "limit": limit,
-            "content": content,
-            "mime": mime,
-            "truncated": len(lines) > offset + limit,
-            "source": "database",
-        }
+            return {
+                "path": normalized_path,
+                "offset": offset,
+                "limit": limit,
+                "content": content,
+                "mime": mime,
+                "truncated": len(lines) > offset + limit,
+                "source": "database",
+            }
 
     # Try live sandbox only when it's ALREADY warm in this worker — see
     # list_shared_files: gate on the in-memory has_ready_session() and read the
@@ -573,6 +584,7 @@ async def download_shared_file(
 
     from src.server.database.workspace import get_workspace as db_get_workspace
     from src.server.services.persistence.file import FilePersistenceService
+    from src.server.services.persistence.resolve import resolve_file_bytes_or_none
     from src.server.services.workspace_manager import WorkspaceManager
 
     workspace = await db_get_workspace(workspace_id)
@@ -592,26 +604,28 @@ async def download_shared_file(
         FilePersistenceService.get_file_content(workspace_id, normalized_path),
     )
     if file_record:
-        if file_record.get("is_binary") and file_record.get("content_binary"):
-            content = file_record["content_binary"]
-            if isinstance(content, memoryview):
-                content = bytes(content)
-        elif file_record.get("content_text") is not None:
-            content = file_record["content_text"].encode("utf-8")
-        else:
-            raise HTTPException(status_code=404, detail="File content not available")
-
-        filename = file_record.get("file_name", "download")
-        mime = file_record.get("mime_type") or "application/octet-stream"
-
-        if _is_text_content_type(mime) or _is_utf8(content):
-            content = get_redactor().redact_bytes(content, vault_secrets=vault_secrets)
-
-        return StreamingResponse(
-            iter([content]),
-            media_type=mime,
-            headers={"Content-Disposition": content_disposition(filename)},
+        content = await resolve_file_bytes_or_none(
+            file_record,
+            user_id=workspace["user_id"],
+            context=f"downloading shared file in workspace {workspace_id}",
         )
+        # None is the resolver's uniform "absent" for a storage failure as
+        # much as for a missing row; a warm sandbox below may still hold the
+        # file. When it does not, the 404 at the end has the same status and
+        # body as an absent path: the caller holds only a share token, so
+        # "content not available" would confirm the workspace and path exist.
+        if content is not None:
+            filename = file_record.get("file_name", "download")
+            mime = file_record.get("mime_type") or "application/octet-stream"
+
+            if _is_text_content_type(mime) or _is_utf8(content):
+                content = get_redactor().redact_bytes(content, vault_secrets=vault_secrets)
+
+            return StreamingResponse(
+                iter([content]),
+                media_type=mime,
+                headers={"Content-Disposition": content_disposition(filename)},
+            )
 
     # Try live sandbox only when it's ALREADY warm in this worker — see
     # list_shared_files: gate on the in-memory has_ready_session() and read the

--- a/src/server/app/setup.py
+++ b/src/server/app/setup.py
@@ -609,6 +609,14 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Failed to start ProvenanceGCService: {e}")
 
+    # Start WorkspaceFileGCService (condemn-then-reap of unreferenced file blobs)
+    try:
+        from src.server.services.workspace_file_gc import WorkspaceFileGCService
+
+        await WorkspaceFileGCService.get_instance().start()
+    except Exception as e:
+        logger.warning(f"Failed to start WorkspaceFileGCService: {e}")
+
     # Confirm the runtime credit gate can reach its lease service, and on
     # terms its refresher can work with. Both failures it catches are silent
     # at request time.
@@ -673,6 +681,13 @@ async def lifespan(app: FastAPI):
         await ProvenanceGCService.get_instance().stop()
     except Exception as e:
         logger.warning(f"Error shutting down ProvenanceGCService: {e}")
+
+    try:
+        from src.server.services.workspace_file_gc import WorkspaceFileGCService
+
+        await WorkspaceFileGCService.get_instance().stop()
+    except Exception as e:
+        logger.warning(f"Error shutting down WorkspaceFileGCService: {e}")
 
     # 0.2. Shutdown NewsRefreshService
     try:

--- a/src/server/app/workspace_files/_shared.py
+++ b/src/server/app/workspace_files/_shared.py
@@ -23,6 +23,10 @@ from ptc_agent.core.paths import (
     USER_PROFILE_WATCHLIST_FILE,
 )
 from src.server.services.workspace_manager import WorkspaceManager
+from src.server.services.persistence.resolve import (
+    FileBytesUnavailable,
+    resolve_file_bytes,
+)
 from src.server.services import user_data_io
 from src.server.utils.error_sanitization import (
     sandbox_unreachable_detail,
@@ -31,6 +35,43 @@ from src.server.utils.error_sanitization import (
 from src.observability import safe_record, workspace_fs_bytes
 
 logger = logging.getLogger(__name__)
+
+
+async def http_file_bytes(file_record: dict[str, Any], *, user_id: str) -> bytes:
+    """Resolve a persisted file's bytes for a route that authenticated its caller.
+
+    ``user_id`` is the workspace owner's (the storage namespace), which the
+    caller already holds from the ownership check.
+
+    503 when the bytes exist but object storage can't serve them right now, 404
+    when the row carries no content at all. The caller is already authorized for
+    this workspace, so the distinction leaks nothing to them — and a storage
+    outage must not be reported as "your file is gone". Routes whose only
+    credential is the URL take the opposite policy: see
+    ``resolve_file_bytes_or_none``.
+
+    The underlying error is logged rather than returned; its message names the
+    object key, which the client has no business seeing.
+    """
+    try:
+        content = await resolve_file_bytes(file_record, user_id=user_id)
+    except FileBytesUnavailable as e:
+        logger.warning(f"Blob unavailable for {file_record.get('file_path')!r}: {e}")
+        raise HTTPException(
+            status_code=503, detail="File content temporarily unavailable"
+        ) from None
+    if content is None:
+        raise HTTPException(status_code=404, detail="File content not available")
+    return content
+
+
+async def http_file_text(file_record: dict[str, Any], *, user_id: str) -> str:
+    """:func:`http_file_bytes`, decoded. Caller must 415 binary rows first.
+
+    ``replace`` is a guard, not a decoding strategy; see ``resolve_file_text``.
+    """
+    data = await http_file_bytes(file_record, user_id=user_id)
+    return data.decode("utf-8", errors="replace")
 
 
 def _record_fs_bytes(op: str, size: int | None) -> None:

--- a/src/server/app/workspace_files/crud.py
+++ b/src/server/app/workspace_files/crud.py
@@ -48,6 +48,8 @@ from ._shared import (
     _requested_system_ok,
     _serialize_user_profile_file,
     _to_client_path,
+    http_file_bytes,
+    http_file_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -255,7 +257,10 @@ async def read_workspace_file(
                 detail="Cannot read binary file as text. Use GET /files/download instead.",
             )
 
-        text_content = file_record.get("content_text", "")
+        # Never `.get("content_text", "")` — the key exists with a NULL value on
+        # a blob-backed row, so the default never fires and redact() would be
+        # handed None.
+        text_content = await http_file_text(file_record, user_id=workspace["user_id"])
         text_content = get_redactor().redact(text_content, vault_secrets=vault_secrets)
         if unlimited:
             content = text_content
@@ -473,14 +478,7 @@ async def download_workspace_file(
         if not file_record:
             raise HTTPException(status_code=404, detail="File not found")
 
-        if file_record.get("is_binary") and file_record.get("content_binary"):
-            content = file_record["content_binary"]
-            if isinstance(content, memoryview):
-                content = bytes(content)
-        elif file_record.get("content_text") is not None:
-            content = file_record["content_text"].encode("utf-8")
-        else:
-            raise HTTPException(status_code=404, detail="File content not available")
+        content = await http_file_bytes(file_record, user_id=workspace["user_id"])
 
         filename = file_record.get("file_name", "download")
         mime = file_record.get("mime_type") or "application/octet-stream"
@@ -617,6 +615,7 @@ async def backup_workspace_files(
         "skipped": result["skipped"],
         "deleted": result["deleted"],
         "errors": result["errors"],
+        "oversized": result.get("oversized", 0),
         "total_size": result["total_size"],
     }
 
@@ -648,7 +647,13 @@ async def get_backup_status(
         get_workspace_total_size,
     )
 
-    db_meta = await get_file_metadata_for_sync(workspace_id)
+    # The sync metadata carries directory and symlink rows too; this status
+    # is about files, and the running branch below only ever sees files.
+    db_meta = {
+        path: meta
+        for path, meta in (await get_file_metadata_for_sync(workspace_id)).items()
+        if meta.get("kind", "file") == "file"
+    }
 
     # If sandbox is stopped, everything in DB is "backed_up", nothing else
     if workspace.get("status") in ("stopped", "stopping", "starting"):
@@ -675,9 +680,11 @@ async def get_backup_status(
             "total_backed_up_size": total_size,
         }
 
-    # Run find to get current sandbox file metadata
+    # The sandbox lists itself; known rows let it skip re-hashing.
     try:
-        sandbox_meta = await FilePersistenceService.list_sandbox_files(sandbox)
+        sandbox_meta = await FilePersistenceService.list_sandbox_files(
+            sandbox, prior=FilePersistenceService.prior_from_meta(db_meta)
+        )
     except Exception:
         total_size = await get_workspace_total_size(workspace_id)
         return {

--- a/src/server/app/workspace_files/serve.py
+++ b/src/server/app/workspace_files/serve.py
@@ -17,6 +17,7 @@ from fastapi.responses import Response
 from src.server.database.workspace import get_workspace as db_get_workspace
 from src.server.services.workspace_manager import WorkspaceManager
 from src.server.services.persistence.file import FilePersistenceService
+from src.server.services.persistence.resolve import resolve_file_bytes_or_none
 from src.server.utils.secret_redactor import get_redactor, get_vault_secrets_for_redaction
 from src.utils.mime import resolve_content_type
 
@@ -161,7 +162,7 @@ def _has_traversal(path: str) -> bool:
 
 
 async def _db_fallback_bytes(
-    workspace_id: str, normalized_path: str, extension_mime: str
+    workspace: dict[str, Any], workspace_id: str, normalized_path: str, extension_mime: str
 ) -> tuple[bytes, str] | None:
     """Read a file's bytes from the persisted DB record (no sandbox I/O)."""
     file_record = await FilePersistenceService.get_file_content(
@@ -169,13 +170,12 @@ async def _db_fallback_bytes(
     )
     if not file_record:
         return None
-    if file_record.get("is_binary") and file_record.get("content_binary") is not None:
-        content = file_record["content_binary"]
-        if isinstance(content, memoryview):
-            content = bytes(content)
-    elif file_record.get("content_text") is not None:
-        content = file_record["content_text"].encode("utf-8")
-    else:
+    content = await resolve_file_bytes_or_none(
+        file_record,
+        user_id=workspace["user_id"],
+        context=f"serving {normalized_path} for workspace {workspace_id}",
+    )
+    if content is None:
         return None
     # Extension is the authority for known web types; fall back to the
     # DB-stored mime only when the extension is unrecognized.
@@ -215,7 +215,9 @@ async def _resolve_serve_bytes(
     )
     sandbox = getattr(session, "sandbox", None) if session else None
     if sandbox is None:
-        return await _db_fallback_bytes(workspace_id, normalized_path, extension_mime)
+        return await _db_fallback_bytes(
+            workspace, workspace_id, normalized_path, extension_mime
+        )
     candidate, error = sandbox.validate_and_normalize_path(normalized_path)
     if error:
         return None
@@ -232,7 +234,9 @@ async def _resolve_serve_bytes(
             f"Sandbox read failed for workspace {workspace_id}; "
             f"serving the persisted copy instead: {single_line(str(e))}"
         )
-        return await _db_fallback_bytes(workspace_id, normalized_path, extension_mime)
+        return await _db_fallback_bytes(
+            workspace, workspace_id, normalized_path, extension_mime
+        )
     if content is None:
         return None
     client_path = _to_client_path(sandbox, candidate)

--- a/src/server/database/blob_keys.py
+++ b/src/server/database/blob_keys.py
@@ -1,0 +1,113 @@
+"""Key format, size cap and registry SQL for workspace file blobs. Import-free by design.
+
+Split out of :mod:`workspace_file_blobs` so the operator scripts under
+``scripts/ops/`` can share these definitions rather than keep a second copy in
+sync by hand. That module imports ``database.pool`` -> ``src.config.env`` ->
+``load_dotenv()``, which would silently retarget a mutating script at whatever
+``.env`` happens to be on disk. Nothing here imports anything but ``re``, so
+both sides can agree on one definition.
+"""
+
+from __future__ import annotations
+
+import re
+
+BLOB_KEY_PREFIX = "blobs/"
+
+# One blob backs files with different names and MIME types, so any per-file
+# content type would be write-order-dependent and wrong for some referrer.
+# Serving derives Content-Type from the file's extension instead.
+BLOB_CONTENT_TYPE = "application/octet-stream"
+
+# Per-object cap, passed explicitly to the storage facade so its shared
+# STORAGE_MAX_UPLOAD_SIZE default (10MB, sized for avatars and charts) can't
+# reject a file the sync path already accepted. ``FilePersistenceService``
+# derives MAX_FILE_SIZE from this: a file the sync path accepts must be storable.
+MAX_BLOB_BYTES = 100 * 1024 * 1024
+
+# Garbage-collection windows, shared with scripts/ops/report_orphan_blobs.py.
+# A blob is condemned after GC_GRACE_DAYS with no reference and no writer
+# touch, and its object is deleted GC_CONDEMNED_GRACE_HOURS after that. Any
+# sync that saw the row as live before condemnation has long since committed
+# or failed by the time the object goes.
+GC_GRACE_DAYS = 7
+GC_CONDEMNED_GRACE_HOURS = 24
+
+# A real SHA-256 hexdigest. The object key is derived from the digest, so
+# anything that isn't a clean digest must never reach the store as a key.
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+
+# A user id as the store sees it: one path segment, no separators, no dots
+# leading it. ``workspaces.user_id`` is free text up to 255 characters, so
+# the shape is checked here rather than assumed.
+_USER_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._@+-]{0,254}\Z")
+
+
+class BlobError(Exception):
+    """Base class for workspace file blob failures."""
+
+
+def blob_key(user_id: str, sha256: str) -> str:
+    """Return the object key for one user's copy of a digest.
+
+    Keys are scoped per user so a presigned URL, and any sandbox holding
+    one, can only ever name objects under its own user; identical bytes
+    held by two users are two objects. Both segments are validated, since
+    the key is built from them and nothing else.
+    """
+    if not user_id or not _USER_ID_RE.match(user_id):
+        msg = f"Refusing to build a blob key for a malformed user id: {user_id!r}"
+        raise BlobError(msg)
+    if not sha256 or not _SHA256_RE.match(sha256):
+        msg = f"Refusing to build a blob key for a non-digest: {sha256!r}"
+        raise BlobError(msg)
+    return f"{BLOB_KEY_PREFIX}{user_id}/{sha256}"
+
+
+# --- registry SQL -------------------------------------------------------------
+#
+# The statements a writer and the sweep have to agree on, character for
+# character. The backfill script runs the same protocol as the app; a second
+# hand-copy of any of these is how the two silently diverge.
+
+# Registry upsert shared by every writer. Reviving a condemned row is the
+# writer's half of the protocol: its upload precedes this statement, so a
+# revived row always has an object behind it again.
+REGISTER_SQL = """
+    INSERT INTO workspace_file_blobs (user_id, sha256, byte_len)
+    VALUES (%s, %s, %s)
+    ON CONFLICT (user_id, sha256) DO UPDATE
+        SET condemned_at = NULL,
+            last_referenced_at = NOW()
+"""
+
+# A writer's claim on a condemned row, ordered before its upload. Restamping
+# condemned_at takes the row out of the reap's grace predicate for another
+# GC_CONDEMNED_GRACE_HOURS; if the reap already holds the row lock this
+# blocks, then matches nothing, and the writer inserts fresh after uploading.
+CLAIM_SQL = """
+    UPDATE workspace_file_blobs
+       SET condemned_at = NOW()
+     WHERE user_id = %s AND sha256 = ANY(%s) AND condemned_at IS NOT NULL
+"""
+
+# Every column a manifest row can reference a blob through: its own object, or
+# the pack chunk it is a member of. Written against a ``workspace_file_blobs
+# b``; the condemn pass, the reap re-check and the orphan report must agree on
+# it exactly. A row references a registry entry only through a workspace of
+# the same user, since that user's object is the one the row's bytes are in.
+# Two EXISTS rather than one OR so each side can use its partial index.
+REFERENCED_SQL = (
+    "(EXISTS (SELECT 1 FROM workspace_files f"
+    " JOIN workspaces w ON w.workspace_id = f.workspace_id"
+    " WHERE f.blob_sha256 = b.sha256 AND w.user_id = b.user_id)"
+    " OR EXISTS (SELECT 1 FROM workspace_files f"
+    " JOIN workspaces w ON w.workspace_id = f.workspace_id"
+    " WHERE f.pack_sha256 = b.sha256 AND w.user_id = b.user_id))"
+)
+
+# The manifest side of the same relation: an unaliased ``workspace_files``
+# predicate for a row whose bytes live in object storage. It enumerates the
+# same two pointer columns as REFERENCED_SQL, so a third one has to land in
+# both.
+BLOB_BACKED_SQL = "(blob_sha256 IS NOT NULL OR pack_sha256 IS NOT NULL)"

--- a/src/server/database/session_lock.py
+++ b/src/server/database/session_lock.py
@@ -1,0 +1,50 @@
+"""Release a session-level advisory lock so it never outlives its holder."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+async def await_settled(task: asyncio.Future) -> Any:
+    """Await ``task`` to completion through every cancellation delivery.
+
+    An AnyIO scope re-delivers a cancellation at every await, so one shield
+    is not enough for work that must finish once started. The cancellation
+    is re-raised once the task has settled; otherwise its result is returned.
+    """
+    cancelled = False
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancelled = True
+    if cancelled:
+        if not task.cancelled():
+            task.exception()  # retrieved, so the loop does not warn
+        raise asyncio.CancelledError()
+    return task.result()
+
+
+async def _unlock_or_close(conn, key: str) -> None:
+    try:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT pg_advisory_unlock(hashtextextended(%s, 0))", (key,)
+            )
+    except BaseException:
+        await conn.close()
+        raise
+
+
+async def release_session_lock(conn, key: str) -> None:
+    """Release the session lock, or close the session so the lock dies with it.
+
+    The release runs as its own task and is awaited until it finishes no
+    matter how often cancellation is delivered: a cancelled holder would
+    otherwise cancel the unlock itself and hand the pool a connection that
+    still holds the lock. When the release cannot be confirmed the
+    connection is closed, which the server treats as a release and the pool
+    as a slot to replace.
+    """
+    await await_settled(asyncio.ensure_future(_unlock_or_close(conn, key)))

--- a/src/server/database/workspace.py
+++ b/src/server/database/workspace.py
@@ -702,6 +702,83 @@ async def set_workspace_always_on(
     return await _set_workspace_scalar(workspace_id, "is_always_on", enabled, conn=conn)
 
 
+ANY_SANDBOX: Any = object()
+"""Skip the identity guard on the completeness flag, for a runtime with no id."""
+
+
+async def set_files_restore_incomplete(
+    workspace_id: str,
+    incomplete: bool,
+    *,
+    conn=None,
+    sandbox_id: Any = ANY_SANDBOX,
+) -> bool:
+    """Record whether the sandbox is missing files the manifest still lists.
+
+    ``sandbox_id`` is the sandbox the row is expected to name, ``None``
+    included, and the write lands only while it does. A restore runs on a
+    provisional sandbox before the identity CAS picks a winner: a raise names
+    the sandbox that CAS expects to replace and a clear names the sandbox it
+    vouches for, so neither can land on a row another provisioner has since
+    bound. Returns whether the write landed.
+
+    Deliberately not routed through ``_set_workspace_scalar``: that helper's
+    allowlist is for workspace settings a user chooses, this is persistence
+    bookkeeping, and it bumps ``updated_at`` — which orders the workspace
+    gallery, so a failed restore would silently reshuffle the user's list.
+    """
+    guarded = sandbox_id is not ANY_SANDBOX
+    guard = "AND sandbox_id IS NOT DISTINCT FROM %s" if guarded else ""
+    params: tuple = (datetime.now(timezone.utc) if incomplete else None, workspace_id)
+    if guarded:
+        params += (sandbox_id,)
+    async with _ws_cursor(conn) as cur:
+        await cur.execute(
+            f"""
+            UPDATE workspaces
+            SET files_restore_incomplete_at = %s
+            WHERE workspace_id = %s {guard}
+            """,
+            params,
+        )
+        return cur.rowcount > 0
+
+
+async def files_restore_incomplete(workspace_id: str, *, conn=None) -> bool:
+    """Whether a restore is known to have left files unrecovered.
+
+    Raises on a read failure rather than defaulting — the caller gates a
+    destructive operation on this answer, so it must not be able to mistake
+    "could not tell" for "everything is fine".
+    """
+    async with _ws_cursor(conn) as cur:
+        await cur.execute(
+            "SELECT files_restore_incomplete_at FROM workspaces "
+            "WHERE workspace_id = %s",
+            (workspace_id,),
+        )
+        row = await cur.fetchone()
+    return bool(row and row["files_restore_incomplete_at"] is not None)
+
+
+async def workspace_owner(workspace_id: str, conn=None) -> str:
+    """The user whose object-storage namespace holds this workspace's bytes.
+
+    Raises when the workspace does not exist: every caller is about to build
+    a storage key from the answer, and a default would put bytes under a
+    namespace nobody owns.
+    """
+    async with _ws_cursor(conn) as cur:
+        await cur.execute(
+            "SELECT user_id FROM workspaces WHERE workspace_id = %s",
+            (workspace_id,),
+        )
+        row = await cur.fetchone()
+    if not row:
+        raise LookupError(f"Workspace {workspace_id} does not exist")
+    return row["user_id"]
+
+
 async def update_workspace_activity(
     workspace_id: str,
     conn=None,

--- a/src/server/database/workspace_file.py
+++ b/src/server/database/workspace_file.py
@@ -6,15 +6,45 @@ and PostgreSQL for offline access and disaster recovery.
 """
 
 import logging
-from datetime import datetime
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
+from psycopg.errors import LockNotAvailable
 from psycopg.rows import dict_row
 
 from src.server.database.pool import get_db_connection
+from src.server.database.session_lock import release_session_lock
 from src.server.utils.pg_sanitize import strip_pg_nul_str
 
 logger = logging.getLogger(__name__)
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+# Namespace prefix for the per-workspace manifest-sync lock, so the key space
+# is this module's alone.
+_SYNC_LOCK_NS = "WSFILES_SYNC"
+# Longer than any healthy sync, so a waiter only gives up when the holder is
+# wedged; a bounded wait keeps a stuck holder from pinning every later sync's
+# pool slot behind it.
+SYNC_LOCK_WAIT = "120s"
+
+
+class WorkspaceSyncBusy(Exception):
+    """Another sync held the workspace lock for the whole wait."""
+
+
+def datetime_to_micros(value: datetime | None) -> int | None:
+    """Exact integer microseconds since the epoch, or None."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return (value - _EPOCH) // timedelta(microseconds=1)
+
+
+def micros_to_datetime(micros: int) -> datetime:
+    return _EPOCH + timedelta(microseconds=micros)
 
 
 # =============================================================================
@@ -37,8 +67,10 @@ async def bulk_upsert_files(
     Args:
         workspace_id: Workspace UUID
         files: List of dicts with keys: file_path, file_name, file_size,
-               content_hash, content_text, content_binary, mime_type,
-               is_binary, permissions, sandbox_modified_at
+               content_hash, content_text, content_binary, blob_sha256,
+               pack_sha256, pack_offset, mime_type, is_binary, permissions,
+               sandbox_modified_at, kind ('file' default, 'dir', 'symlink'),
+               symlink_target
         conn: Optional database connection to reuse
 
     Returns:
@@ -50,20 +82,26 @@ async def bulk_upsert_files(
     sql = """
         INSERT INTO workspace_files (
             workspace_id, file_path, file_name, file_size, content_hash,
-            content_text, content_binary, mime_type, is_binary, permissions,
-            sandbox_modified_at
+            content_text, content_binary, blob_sha256, pack_sha256, pack_offset,
+            mime_type, is_binary, permissions, sandbox_modified_at, kind,
+            symlink_target
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (workspace_id, file_path) DO UPDATE SET
             file_name = EXCLUDED.file_name,
             file_size = EXCLUDED.file_size,
             content_hash = EXCLUDED.content_hash,
             content_text = EXCLUDED.content_text,
             content_binary = EXCLUDED.content_binary,
+            blob_sha256 = EXCLUDED.blob_sha256,
+            pack_sha256 = EXCLUDED.pack_sha256,
+            pack_offset = EXCLUDED.pack_offset,
             mime_type = EXCLUDED.mime_type,
             is_binary = EXCLUDED.is_binary,
             permissions = EXCLUDED.permissions,
             sandbox_modified_at = EXCLUDED.sandbox_modified_at,
+            kind = EXCLUDED.kind,
+            symlink_target = EXCLUDED.symlink_target,
             updated_at = NOW()
     """
 
@@ -80,10 +118,15 @@ async def bulk_upsert_files(
             f.get("content_hash"),
             strip_pg_nul_str(f.get("content_text")),
             f.get("content_binary"),
+            f.get("blob_sha256"),
+            f.get("pack_sha256"),
+            f.get("pack_offset"),
             strip_pg_nul_str(f.get("mime_type")),
             f.get("is_binary", False),
             strip_pg_nul_str(f.get("permissions")),
             f.get("sandbox_modified_at"),
+            f.get("kind", "file"),
+            strip_pg_nul_str(f.get("symlink_target")),
         )
         for f in files
     ]
@@ -120,46 +163,11 @@ async def bulk_upsert_files(
         raise
 
 
-async def upsert_file(
-    workspace_id: str,
-    file_path: str,
-    file_name: str,
-    file_size: int,
-    content_hash: Optional[str] = None,
-    content_text: Optional[str] = None,
-    content_binary: Optional[bytes] = None,
-    mime_type: Optional[str] = None,
-    is_binary: bool = False,
-    permissions: Optional[str] = None,
-    sandbox_modified_at: Optional[datetime] = None,
-    *,
-    conn=None,
-) -> None:
-    """Insert or update a single workspace file. Delegates to bulk_upsert_files."""
-    await bulk_upsert_files(
-        workspace_id,
-        [
-            {
-                "file_path": file_path,
-                "file_name": file_name,
-                "file_size": file_size,
-                "content_hash": content_hash,
-                "content_text": content_text,
-                "content_binary": content_binary,
-                "mime_type": mime_type,
-                "is_binary": is_binary,
-                "permissions": permissions,
-                "sandbox_modified_at": sandbox_modified_at,
-            }
-        ],
-        conn=conn,
-    )
-
-
 async def get_files_for_workspace(
     workspace_id: str,
     *,
     include_content: bool = False,
+    all_kinds: bool = False,
     conn=None,
 ) -> List[Dict[str, Any]]:
     """
@@ -168,9 +176,15 @@ async def get_files_for_workspace(
     By default returns metadata only (no content_text/content_binary) for
     efficient listing. Set include_content=True to include file contents.
 
+    Only ``kind = 'file'`` rows are returned unless ``all_kinds`` is set:
+    directory and symlink rows exist for restore, and every other reader
+    (file tree, serving, redaction) is written for files. Restore is the one
+    caller that asks for everything.
+
     Args:
         workspace_id: Workspace UUID
         include_content: Whether to include content_text and content_binary
+        all_kinds: Include directory and symlink rows
         conn: Optional database connection to reuse
 
     Returns:
@@ -181,22 +195,26 @@ async def get_files_for_workspace(
             columns = """
                 workspace_file_id, workspace_id, file_path, file_name,
                 file_size, content_hash, content_text, content_binary,
-                mime_type, is_binary, permissions, sandbox_modified_at,
-                created_at, updated_at
+                blob_sha256, pack_sha256, pack_offset, mime_type, is_binary, permissions,
+                sandbox_modified_at, created_at, updated_at,
+                kind, symlink_target
             """
         else:
             columns = """
                 workspace_file_id, workspace_id, file_path, file_name,
                 file_size, content_hash, mime_type, is_binary, permissions,
-                sandbox_modified_at, created_at, updated_at
+                sandbox_modified_at, created_at, updated_at,
+                kind, symlink_target
             """
+
+        kind_filter = "" if all_kinds else "AND kind = 'file'"
 
         async def _execute(cur):
             await cur.execute(
                 f"""
                 SELECT {columns}
                 FROM workspace_files
-                WHERE workspace_id = %s
+                WHERE workspace_id = %s {kind_filter}
                 ORDER BY file_path ASC
                 """,
                 (workspace_id,),
@@ -241,14 +259,16 @@ async def get_file(
             columns = """
                 workspace_file_id, workspace_id, file_path, file_name,
                 file_size, content_hash, content_text, content_binary,
-                mime_type, is_binary, permissions, sandbox_modified_at,
-                created_at, updated_at
+                blob_sha256, pack_sha256, pack_offset, mime_type, is_binary, permissions,
+                sandbox_modified_at, created_at, updated_at,
+                kind, symlink_target
             """
         else:
             columns = """
                 workspace_file_id, workspace_id, file_path, file_name,
                 file_size, content_hash, mime_type, is_binary, permissions,
-                sandbox_modified_at, created_at, updated_at
+                sandbox_modified_at, created_at, updated_at,
+                kind, symlink_target
             """
 
         async def _execute(cur):
@@ -256,7 +276,7 @@ async def get_file(
                 f"""
                 SELECT {columns}
                 FROM workspace_files
-                WHERE workspace_id = %s AND file_path = %s
+                WHERE workspace_id = %s AND file_path = %s AND kind = 'file'
                 """,
                 (workspace_id, file_path),
             )
@@ -281,51 +301,6 @@ async def get_file(
         raise
 
 
-async def get_file_hashes(
-    workspace_id: str,
-    *,
-    conn=None,
-) -> Dict[str, str]:
-    """
-    Get content hashes for all files in a workspace.
-
-    Useful for diffing local sandbox state against stored state to determine
-    which files need to be synced.
-
-    Args:
-        workspace_id: Workspace UUID
-        conn: Optional database connection to reuse
-
-    Returns:
-        Dict mapping file_path to content_hash
-    """
-    try:
-
-        async def _execute(cur):
-            await cur.execute(
-                """
-                SELECT file_path, content_hash
-                FROM workspace_files
-                WHERE workspace_id = %s
-                """,
-                (workspace_id,),
-            )
-            results = await cur.fetchall()
-            return {row["file_path"]: row["content_hash"] for row in results}
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                return await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    return await _execute(cur)
-
-    except Exception as e:
-        logger.error(f"Error getting file hashes for workspace {workspace_id}: {e}")
-        raise
-
-
 async def get_file_metadata_for_sync(
     workspace_id: str,
     *,
@@ -334,32 +309,53 @@ async def get_file_metadata_for_sync(
     """
     Get file metadata for incremental sync comparison.
 
-    Returns dict mapping file_path to {content_hash, file_size, mtime_epoch}.
-    Used to pre-filter unchanged files before downloading.
+    Returns dict mapping file_path to {content_hash, file_size, mtime_epoch,
+    mtime_ns, kind, permissions, symlink_target, blob_sha256, is_binary,
+    mime_type}. Every kind is
+    included: the sync diff has to see directory and symlink rows to know
+    whether they still exist.
+
+    ``mtime_ns`` is derived from the stored microsecond timestamp, so it
+    equals the nanosecond value the sandbox reports only when the file's mtime
+    was itself set from this row (restore does that) or the filesystem keeps
+    no finer precision. Either way an exact match means unchanged.
     """
     try:
 
         async def _execute(cur):
             await cur.execute(
                 """
-                SELECT file_path, content_hash, file_size,
-                       EXTRACT(EPOCH FROM sandbox_modified_at) AS mtime_epoch
+                SELECT file_path, content_hash, file_size, kind, permissions,
+                       symlink_target, blob_sha256, pack_sha256, pack_offset,
+                       is_binary, mime_type, sandbox_modified_at
                 FROM workspace_files
                 WHERE workspace_id = %s
                 """,
                 (workspace_id,),
             )
             results = await cur.fetchall()
-            return {
-                row["file_path"]: {
+            out = {}
+            for row in results:
+                modified = row["sandbox_modified_at"]
+                # Integer microseconds straight off the datetime: a float
+                # epoch drops the last digit on about one row in twenty,
+                # which read as "changed" and rewrote the row every sync.
+                micros = datetime_to_micros(modified)
+                out[row["file_path"]] = {
                     "content_hash": row["content_hash"],
                     "file_size": row["file_size"],
-                    "mtime_epoch": float(row["mtime_epoch"])
-                    if row["mtime_epoch"] is not None
-                    else None,
+                    "mtime_epoch": micros / 1_000_000 if micros is not None else None,
+                    "mtime_ns": micros * 1000 if micros is not None else None,
+                    "kind": row["kind"],
+                    "permissions": row["permissions"],
+                    "symlink_target": row["symlink_target"],
+                    "blob_sha256": row["blob_sha256"],
+                    "pack_sha256": row["pack_sha256"],
+                    "pack_offset": row["pack_offset"],
+                    "is_binary": row["is_binary"],
+                    "mime_type": row["mime_type"],
                 }
-                for row in results
-            }
+            return out
 
         if conn:
             async with conn.cursor(row_factory=dict_row) as cur:
@@ -374,18 +370,18 @@ async def get_file_metadata_for_sync(
         raise
 
 
-async def bulk_update_file_mtimes(
+async def bulk_update_file_stamps(
     workspace_id: str,
     updates: List[tuple],
     *,
     conn=None,
 ) -> int:
     """
-    Bulk update sandbox_modified_at for multiple files.
+    Bulk update the mtime and mode of files whose bytes did not change.
 
     Args:
         workspace_id: Workspace UUID
-        updates: List of (file_path, sandbox_modified_at) tuples
+        updates: List of (file_path, sandbox_modified_at, permissions) tuples
         conn: Optional database connection to reuse
 
     Returns:
@@ -396,83 +392,120 @@ async def bulk_update_file_mtimes(
 
     sql = """
         UPDATE workspace_files
-        SET sandbox_modified_at = %s, updated_at = NOW()
+        SET sandbox_modified_at = %s, permissions = %s, updated_at = NOW()
         WHERE workspace_id = %s AND file_path = %s
     """
 
     params_list = [
-        (mtime, workspace_id, fpath) for fpath, mtime in updates
+        (mtime, permissions, workspace_id, fpath)
+        for fpath, mtime, permissions in updates
     ]
 
-    try:
+    async def _execute(c):
+        async with c.transaction():
+            async with c.cursor() as cur:
+                await cur.executemany(sql, params_list)
 
-        async def _execute(c):
-            async with c.transaction():
-                async with c.cursor() as cur:
-                    await cur.executemany(sql, params_list)
+    if conn:
+        await _execute(conn)
+    else:
+        async with get_db_connection() as c:
+            await _execute(c)
 
-        if conn:
-            await _execute(conn)
-        else:
-            async with get_db_connection() as c:
-                await _execute(c)
-
-        logger.debug(
-            f"Bulk updated mtimes for {len(updates)} files in workspace {workspace_id}"
-        )
-        return len(updates)
-
-    except Exception as e:
-        logger.warning(
-            f"Error bulk updating mtimes for workspace {workspace_id}: {e}"
-        )
-        return 0
-
-
-async def update_file_mtime(
-    workspace_id: str,
-    file_path: str,
-    sandbox_modified_at: datetime,
-) -> None:
-    """Update only the sandbox_modified_at for a file. Delegates to bulk_update_file_mtimes."""
-    await bulk_update_file_mtimes(
-        workspace_id, [(file_path, sandbox_modified_at)]
+    logger.debug(
+        f"Bulk updated mtimes for {len(updates)} files in workspace {workspace_id}"
     )
+    return len(updates)
+
+
+async def manifest_clock(*, conn=None) -> datetime:
+    """The database's own ``now()``: the reference every ``updated_at`` uses."""
+    async with get_db_connection(conn) as c:
+        async with c.cursor() as cur:
+            await cur.execute("SELECT now()")
+            row = await cur.fetchone()
+    return row[0]
+
+
+@asynccontextmanager
+async def workspace_sync_lock(workspace_id: str):
+    """Serialize manifest syncs for one workspace, and yield the session holding it.
+
+    Session-level rather than transaction-level because a sync is not one
+    statement: it reads the manifest, walks the sandbox, moves bytes, and only
+    then writes. Two overlapping syncs that each read before either wrote let
+    the older pack's unconditional upsert land last, so the fence has to span
+    the read and the write together. The connection is yielded because the
+    sync's own reads and writes belong on this session rather than on a second
+    pool slot checked out underneath it.
+    """
+    key = f"{_SYNC_LOCK_NS}:{workspace_id}"
+    async with get_db_connection() as conn:
+        try:
+            # SET LOCAL scopes the timeout to this transaction; the session
+            # lock itself outlives the commit.
+            async with conn.transaction():
+                async with conn.cursor() as cur:
+                    await cur.execute(f"SET LOCAL lock_timeout = '{SYNC_LOCK_WAIT}'")
+                    await cur.execute(
+                        "SELECT pg_advisory_lock(hashtextextended(%s, 0))", (key,)
+                    )
+        except LockNotAvailable as e:
+            raise WorkspaceSyncBusy(
+                f"workspace {workspace_id} sync lock held for over {SYNC_LOCK_WAIT}"
+            ) from e
+        except BaseException:
+            # A cancellation or failure while the grant may already have
+            # landed: the transaction rolls back but a session lock does
+            # not, so the session is released the way a held one is rather
+            # than handed to the pool with the lock still on it.
+            await release_session_lock(conn, key)
+            raise
+        try:
+            yield conn
+        finally:
+            await release_session_lock(conn, key)
 
 
 async def delete_removed_files(
     workspace_id: str,
     active_paths: set,
     *,
+    untouched_since: datetime,
     conn=None,
 ) -> int:
     """
     Delete files that are no longer present in the sandbox.
 
     Removes all workspace_files rows whose file_path is NOT in active_paths.
-    If active_paths is empty, deletes all files (equivalent to delete_all_files).
+
+    ``untouched_since`` fences the prune to rows nobody has written since the
+    caller's scan began: two syncs may overlap (a post-turn backup and a stop,
+    say), and the older scan must not delete a row the newer one just added.
+    It is required rather than optional because an unfenced prune against an
+    empty ``active_paths`` erases the whole manifest.
 
     Args:
         workspace_id: Workspace UUID
         active_paths: Set of file paths that still exist in the sandbox
+        untouched_since: Only delete rows with ``updated_at`` before this
         conn: Optional database connection to reuse
 
     Returns:
         Number of deleted rows
     """
     try:
-        if not active_paths:
-            return await delete_all_files(workspace_id, conn=conn)
-
         paths_list = list(active_paths)
 
         async def _execute(cur):
             await cur.execute(
                 """
                 DELETE FROM workspace_files
-                WHERE workspace_id = %s AND NOT (file_path = ANY(%s))
+                WHERE workspace_id = %s
+                  AND NOT (file_path = ANY(%s::text[]))
+                  AND (%s::timestamptz IS NULL OR updated_at < %s::timestamptz)
                 """,
-                (workspace_id, paths_list),
+                (workspace_id, paths_list, untouched_since, untouched_since),
             )
             return cur.rowcount
 
@@ -493,48 +526,30 @@ async def delete_removed_files(
         raise
 
 
-async def delete_all_files(
-    workspace_id: str,
-    *,
-    conn=None,
+async def delete_file_rows(
+    workspace_id: str, paths: list[str], *, conn=None
 ) -> int:
-    """
-    Delete all files for a workspace.
+    """Delete the named manifest rows. Unlike ``delete_removed_files`` this
+    is unfenced: the caller has positive evidence each path is gone."""
+    if not paths:
+        return 0
 
-    Args:
-        workspace_id: Workspace UUID
-        conn: Optional database connection to reuse
+    async def _execute(cur):
+        await cur.execute(
+            """
+            DELETE FROM workspace_files
+            WHERE workspace_id = %s AND file_path = ANY(%s::text[])
+            """,
+            (workspace_id, paths),
+        )
+        return cur.rowcount
 
-    Returns:
-        Number of deleted rows
-    """
-    try:
-
-        async def _execute(cur):
-            await cur.execute(
-                """
-                DELETE FROM workspace_files
-                WHERE workspace_id = %s
-                """,
-                (workspace_id,),
-            )
-            return cur.rowcount
-
-        if conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                deleted = await _execute(cur)
-        else:
-            async with get_db_connection() as conn:
-                async with conn.cursor(row_factory=dict_row) as cur:
-                    deleted = await _execute(cur)
-
-        if deleted:
-            logger.info(f"Deleted all {deleted} files for workspace {workspace_id}")
-        return deleted
-
-    except Exception as e:
-        logger.error(f"Error deleting all files for workspace {workspace_id}: {e}")
-        raise
+    if conn:
+        async with conn.cursor() as cur:
+            return await _execute(cur)
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            return await _execute(cur)
 
 
 async def copy_workspace_files(
@@ -549,6 +564,11 @@ async def copy_workspace_files(
     Inserts fresh rows for dest_id mirroring every file under source_id.
     Primary keys and created_at/updated_at use their DB defaults (new uuid,
     NOW()); all content columns are carried over.
+
+    ``blob_sha256`` is copied rather than dereferenced: the fork points at the
+    same content-addressed objects, so forking a large workspace no longer
+    duplicates its TOASTed bytes. Shared pointers are also why per-workspace
+    object deletion is unsafe by construction.
 
     Args:
         source_id: Workspace UUID to copy files from
@@ -565,13 +585,15 @@ async def copy_workspace_files(
                 """
                 INSERT INTO workspace_files (
                     workspace_id, file_path, file_name, file_size,
-                    content_hash, content_text, content_binary, mime_type,
-                    is_binary, permissions, sandbox_modified_at
+                    content_hash, content_text, content_binary, blob_sha256,
+                    pack_sha256, pack_offset, mime_type, is_binary, permissions,
+                    sandbox_modified_at, kind, symlink_target
                 )
                 SELECT
                     %s, file_path, file_name, file_size,
-                    content_hash, content_text, content_binary, mime_type,
-                    is_binary, permissions, sandbox_modified_at
+                    content_hash, content_text, content_binary, blob_sha256,
+                    pack_sha256, pack_offset, mime_type, is_binary, permissions,
+                    sandbox_modified_at, kind, symlink_target
                 FROM workspace_files
                 WHERE workspace_id = %s
                 """,

--- a/src/server/database/workspace_file_blobs.py
+++ b/src/server/database/workspace_file_blobs.py
@@ -1,0 +1,405 @@
+"""Content-addressed store for workspace file bytes.
+
+A workspace file keeps its manifest row in ``workspace_files`` and its bytes
+in object storage under ``blobs/{user_id}/{sha256}``; ``workspace_file_blobs``
+is the registry of ``(user_id, sha256)`` pairs that have been written. Content
+addressing dedups identical files across a user's workspaces, and lets a
+forked workspace share bytes rather than copy TOASTed BYTEA. The user is part
+of the key, so a presigned URL can only name that user's objects and a
+registry hit is always a pointer into bytes the same user uploaded.
+
+The key format, the size cap and the registry statements live in
+:mod:`src.server.database.blob_keys`, which is import-free so ``scripts/ops/``
+can run the same protocol.
+
+Deletion is the one irrecoverable operation here, and the reference to a
+blob lands seconds after its upload in a separate transaction, so a sweep
+cannot simply delete what nothing references. The registry carries a
+protocol instead. Writers touch ``last_referenced_at`` before they upload
+(``registered_blobs``); a row nothing references and nothing has touched for
+``GC_GRACE_DAYS`` is condemned (``condemn_orphan_blobs``), which makes it
+invisible to that touch. A writer that still wants the digest claims the
+condemned row by restamping ``condemned_at``, uploads, and only then revives
+it (``register_blobs`` / ``store_blob``), so a live row always has an object.
+``GC_CONDEMNED_GRACE_HOURS`` after condemnation the object is deleted under
+the row's lock (``reap_condemned_blobs``), and the lock is taken with the
+grace predicate: a claim that lands first pushes the row out of the
+predicate, and a claim that lands second queues behind the lock and finds no
+row, so the writer inserts a fresh one after its upload. No manifest row can
+point at a deleted object.
+
+The residual the ordering accepts: an upload that lands and is then abandoned
+before its row is written, because the process was cancelled or the register
+failed, leaves an object no sweep can see, since every pass enumerates the
+registry rather than the bucket. The next sync of the same content re-uploads
+the same key and registers it, so it is reclaimable for as long as the content
+survives; a digest that never recurs is not. That is the price of the
+direction, and the direction is the safe one, since the alternative deletes
+objects a concurrent writer may already have committed a manifest row against.
+
+DEPLOYMENT REQUIREMENT — the ``blobs/`` prefix must not be anonymously
+readable. The bucket this facade writes to may also be fronted by a public URL
+base (``STORAGE_PUBLIC_URL_BASE``) for avatars and chart images. Where that
+base serves arbitrary keys, a content-addressed key is guessable for any file
+whose bytes an attacker can reconstruct, so the digest is obscurity rather
+than access control. Deny ``blobs/`` on the public base, or point blob storage
+at a bucket that has none, before enabling this in a hosted deployment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+
+from src.server.database.blob_keys import (
+    BLOB_CONTENT_TYPE,
+    CLAIM_SQL,
+    GC_CONDEMNED_GRACE_HOURS,
+    GC_GRACE_DAYS,
+    MAX_BLOB_BYTES,
+    REFERENCED_SQL,
+    REGISTER_SQL,
+    BlobError,
+    blob_key,
+)
+from src.server.database.pool import get_db_connection
+from src.server.database.session_lock import await_settled, release_session_lock
+from src.utils.storage import (
+    delete_object as _storage_delete_object,
+    get_bytes as _storage_get_bytes,
+    get_bytes_range as _storage_get_bytes_range,
+    upload_bytes as _storage_upload_bytes,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "BlobError",
+    "BlobFetchError",
+    "BlobUploadError",
+    "GC_CONDEMNED_GRACE_HOURS",
+    "GC_GRACE_DAYS",
+    "GC_REAP_BATCH",
+    "blob_key",
+    "condemn_orphan_blobs",
+    "fetch_blob",
+    "fetch_blob_range",
+    "reap_condemned_blobs",
+    "register_blobs",
+    "registered_blobs",
+    "store_blob",
+    "sweep_blob_garbage",
+]
+
+# Objects deleted per sweep cycle. Bounds the store calls a cycle makes; the
+# report script shows the backlog if churn ever outruns it.
+GC_REAP_BATCH = 500
+
+_GC_LOCK_KEY = "workspace_file_blobs:gc"
+
+# The writer's touch: restamps last_referenced_at so the sweep leaves the row
+# alone until the manifest row referencing it has landed, and restamps
+# condemned_at on a condemned row (the claim) so the caller's re-upload is
+# ordered before any reap of it.
+_TOUCH_SQL = """
+    UPDATE workspace_file_blobs
+       SET last_referenced_at = NOW(),
+           condemned_at = CASE WHEN condemned_at IS NULL THEN NULL ELSE NOW() END
+     WHERE user_id = %s AND sha256 = ANY(%s)
+    RETURNING sha256, condemned_at IS NULL AS live
+"""
+
+
+class BlobUploadError(BlobError):
+    """Raised when a blob could not be written to object storage."""
+
+
+class BlobFetchError(BlobError):
+    """Raised when a blob's bytes could not be read back."""
+
+
+async def store_blob(user_id: str, sha256: str, data: bytes) -> None:
+    """Write ``data`` to object storage under the user's digest key and register it.
+
+    The object lands before the registry row, so a registered blob always has
+    bytes behind it. This is the relay path's writer; callers skip it for
+    digests ``registered_blobs`` already reports, since a registry row is
+    proof the object exists with verified content. The claim comes first so
+    a concurrent reap cannot delete the object between the upload and the
+    row.
+    """
+    key = blob_key(user_id, sha256)
+    try:
+        async with get_db_connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(CLAIM_SQL, (user_id, [sha256]))
+    except Exception as e:
+        msg = f"Blob claim failed for {key}"
+        raise BlobUploadError(msg) from e
+    uploaded = await asyncio.to_thread(
+        _storage_upload_bytes,
+        key,
+        data,
+        BLOB_CONTENT_TYPE,
+        max_size=MAX_BLOB_BYTES,
+    )
+    if not uploaded:
+        msg = f"Blob upload failed for {key} ({len(data)} bytes)"
+        raise BlobUploadError(msg)
+
+    try:
+        async with get_db_connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(REGISTER_SQL, (user_id, sha256, len(data)))
+    except Exception as e:
+        # The object is already durable; leaving it behind is correct. It is a
+        # content-addressed key another of this user's syncs may have committed
+        # a manifest row against, so deleting it here could strand that row.
+        msg = f"Blob registry insert failed for {key}"
+        raise BlobUploadError(msg) from e
+
+
+async def registered_blobs(user_id: str, sha256s: list[str]) -> set[str]:
+    """Which of these digests the user may skip uploading.
+
+    A live registry row under the user is proof the bytes are there: it is
+    written only after a checksum-bound upload to that user's key succeeded,
+    or after this process hashed the bytes itself. Another user's row for the
+    same digest is a different object and never a hit, so a caller that
+    merely names a digest is told nothing about who else holds the content.
+
+    The check is also the touch that keeps the sweep off the row: a digest
+    named here cannot be condemned for another ``GC_GRACE_DAYS``, long enough
+    for the manifest row that references it to land. A condemned row is never
+    a hit but is claimed in the same statement, so the caller's upload is
+    ordered before any reap of it; ``register_blobs`` then revives it.
+    """
+    if not sha256s:
+        return set()
+    digests = list(set(sha256s))
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(_TOUCH_SQL, (user_id, digests))
+            return {row[0] for row in await cur.fetchall() if row[1]}
+
+
+async def register_blobs(user_id: str, entries: list[tuple[str, int]]) -> None:
+    """Record ``(sha256, byte_len)`` pairs whose objects are known to exist
+    under the user, reviving any the sweep had condemned in the meantime."""
+    if not entries:
+        return
+    async with get_db_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.executemany(
+                REGISTER_SQL, [(user_id, sha, n) for sha, n in entries]
+            )
+
+
+async def fetch_blob(user_id: str, sha256: str) -> bytes:
+    """Read a blob's bytes back, verifying they still hash to their key.
+
+    The digest check is free relative to the download and turns silent
+    corruption (or a mis-keyed object) into a loud error rather than a file
+    that restores wrong.
+    """
+    key = blob_key(user_id, sha256)
+    data = await asyncio.to_thread(_storage_get_bytes, key)
+    # `is None` deliberately: sha256(b"") is a valid blob and b"" is falsy.
+    if data is None:
+        msg = f"Blob {key} could not be read from object storage"
+        raise BlobFetchError(msg)
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != sha256:
+        msg = f"Blob {key} content hash mismatch (got {actual})"
+        raise BlobFetchError(msg)
+    return data
+
+
+async def fetch_blob_range(
+    user_id: str,
+    sha256: str,
+    offset: int,
+    length: int,
+    *,
+    expected_sha256: str | None = None,
+) -> bytes:
+    """Read one member's bytes out of a pack chunk, verifying them.
+
+    A member row carries the file's own digest as ``content_hash``; checking
+    the slice against it catches a wrong offset or a mis-keyed chunk as
+    loudly as :func:`fetch_blob` catches a corrupt object.
+    """
+    key = blob_key(user_id, sha256)
+    data = await asyncio.to_thread(_storage_get_bytes_range, key, offset, length)
+    if data is None:
+        msg = f"Pack {key} could not be read from object storage"
+        raise BlobFetchError(msg)
+    if len(data) != length:
+        msg = f"Pack {key} range {offset}+{length} returned {len(data)} bytes"
+        raise BlobFetchError(msg)
+    if expected_sha256 is not None:
+        actual = hashlib.sha256(data).hexdigest()
+        if actual != expected_sha256:
+            msg = f"Pack {key} member at {offset} hash mismatch (got {actual})"
+            raise BlobFetchError(msg)
+    return data
+
+
+# --- garbage collection ------------------------------------------------------
+
+
+async def condemn_orphan_blobs(grace_days: int = GC_GRACE_DAYS, *, conn=None) -> int:
+    """Pass 1: mark rows nothing references and nothing has touched in ``grace_days``.
+
+    A concurrent touch and this UPDATE serialize on the row: whichever runs
+    second re-evaluates its WHERE against the other's result, so a touched
+    row is never condemned and a condemned row is never returned as live.
+    """
+    async with get_db_connection(conn) as c:
+        async with c.cursor() as cur:
+            await cur.execute(
+                f"""
+                UPDATE workspace_file_blobs b
+                   SET condemned_at = NOW()
+                 WHERE b.condemned_at IS NULL
+                   AND b.last_referenced_at < NOW() - make_interval(days => %s)
+                   AND NOT {REFERENCED_SQL}
+                """,
+                (grace_days,),
+            )
+            return cur.rowcount
+
+
+async def _reap_one(
+    conn, user_id: str, sha256: str, condemned_grace_hours: int
+) -> bool:
+    """Delete one condemned blob's object and row in one transaction.
+
+    ``FOR UPDATE`` with the grace predicate is what closes the race with a
+    writer. A claim that landed first restamped ``condemned_at`` and the row
+    no longer matches; a claim that lands later blocks behind the lock, then
+    matches nothing, and the writer uploads before inserting a fresh row. A
+    store failure raises, which rolls the transaction back and leaves the row
+    condemned for the next cycle.
+    """
+    async with conn.transaction():
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                SELECT 1 FROM workspace_file_blobs
+                 WHERE user_id = %s AND sha256 = %s
+                   AND condemned_at < NOW() - make_interval(hours => %s)
+                   FOR UPDATE
+                """,
+                (user_id, sha256, condemned_grace_hours),
+            )
+            if await cur.fetchone() is None:
+                return False  # revived, or reaped by another cycle
+            await cur.execute(
+                "SELECT 1 FROM workspace_file_blobs b "
+                f"WHERE b.user_id = %s AND b.sha256 = %s AND {REFERENCED_SQL}",
+                (user_id, sha256),
+            )
+            if await cur.fetchone() is not None:
+                # A reference appeared after condemnation. Fork copies only
+                # referenced rows so this should not happen; heal rather than
+                # delete an object a manifest row points at.
+                await cur.execute(
+                    "UPDATE workspace_file_blobs SET condemned_at = NULL, "
+                    "last_referenced_at = NOW() WHERE user_id = %s AND sha256 = %s",
+                    (user_id, sha256),
+                )
+                return False
+            key = blob_key(user_id, sha256)
+            # Awaited to completion however often the sweep is cancelled at
+            # shutdown. The thread cannot be interrupted, and this
+            # transaction's row lock is the only thing stopping a writer from
+            # claiming, uploading and reviving the digest while it runs: a
+            # rollback would release the lock and the thread would then
+            # delete that writer's fresh object.
+            deleted = await await_settled(
+                asyncio.ensure_future(asyncio.to_thread(_storage_delete_object, key))
+            )
+            if not deleted:
+                msg = f"Object delete failed for {key}"
+                raise BlobError(msg)
+            await cur.execute(
+                "DELETE FROM workspace_file_blobs WHERE user_id = %s AND sha256 = %s",
+                (user_id, sha256),
+            )
+            return True
+
+
+async def reap_condemned_blobs(
+    condemned_grace_hours: int = GC_CONDEMNED_GRACE_HOURS,
+    limit: int = GC_REAP_BATCH,
+    *,
+    conn=None,
+) -> tuple[int, int]:
+    """Pass 2: delete objects condemned longer than the grace, oldest first.
+
+    Returns ``(deleted, failed)``. One transaction per row so a single store
+    failure costs one row, not the batch.
+    """
+    async with get_db_connection(conn) as c:
+        async with c.cursor() as cur:
+            await cur.execute(
+                """
+                SELECT user_id, sha256 FROM workspace_file_blobs
+                 WHERE condemned_at < NOW() - make_interval(hours => %s)
+                 ORDER BY condemned_at
+                 LIMIT %s
+                """,
+                (condemned_grace_hours, limit),
+            )
+            candidates = [(row[0], row[1]) for row in await cur.fetchall()]
+        deleted = failed = 0
+        for user_id, sha256 in candidates:
+            try:
+                if await _reap_one(c, user_id, sha256, condemned_grace_hours):
+                    deleted += 1
+            except Exception as e:
+                failed += 1
+                logger.warning(
+                    f"Blob reap of {sha256} for user {user_id} failed, will retry: {e}"
+                )
+        return deleted, failed
+
+
+async def sweep_blob_garbage(
+    *,
+    grace_days: int = GC_GRACE_DAYS,
+    condemned_grace_hours: int = GC_CONDEMNED_GRACE_HOURS,
+    limit: int = GC_REAP_BATCH,
+) -> dict[str, int] | None:
+    """One condemn-then-reap cycle under a session advisory lock.
+
+    Returns the cycle's counts, or ``None`` when another process holds the
+    lock. The lock is session-scoped rather than transaction-scoped because
+    the reap runs one transaction per row; it is released before the
+    connection goes back to the pool.
+    """
+    async with get_db_connection() as conn:
+        try:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT pg_try_advisory_lock(hashtextextended(%s, 0))",
+                    (_GC_LOCK_KEY,),
+                )
+                row = await cur.fetchone()
+        except BaseException:
+            # The grant may already have landed: a session lock survives a
+            # cancelled fetch, so release it rather than pool a locked session.
+            await release_session_lock(conn, _GC_LOCK_KEY)
+            raise
+        if not (row and row[0]):
+            return None
+        try:
+            condemned = await condemn_orphan_blobs(grace_days, conn=conn)
+            deleted, failed = await reap_condemned_blobs(
+                condemned_grace_hours, limit, conn=conn
+            )
+        finally:
+            await release_session_lock(conn, _GC_LOCK_KEY)
+    return {"condemned": condemned, "deleted": deleted, "failed": failed}

--- a/src/server/services/persistence/_rows.py
+++ b/src/server/services/persistence/_rows.py
@@ -1,0 +1,220 @@
+"""Pure helpers shared by the backup and restore paths.
+
+Manifest row shape and the field conversions that feed it in both
+directions, plus the sandbox transfer mode both paths branch on. Nothing
+here touches the database, the sandbox or object storage.
+"""
+
+import codecs
+import mimetypes
+import os
+from datetime import datetime
+from typing import Any
+
+from src.server.database.workspace_file import micros_to_datetime
+from src.server.services.persistence.transfer import ScanEntry
+from src.utils.storage import get_blob_transfer_mode
+
+# Extensions treated as binary before any bytes are read, for rows whose
+# content this process never sees (the sandbox sniffs the rest).
+_BINARY_EXTENSIONS = frozenset(
+    {
+        ".pdf",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".bmp",
+        ".ico",
+        ".tiff",
+        ".zip",
+        ".tar",
+        ".gz",
+        ".bz2",
+        ".7z",
+        ".rar",
+        ".exe",
+        ".dll",
+        ".so",
+        ".dylib",
+        ".mp3",
+        ".mp4",
+        ".wav",
+        ".avi",
+        ".mov",
+        ".mkv",
+        ".doc",
+        ".docx",
+        ".xls",
+        ".xlsx",
+        ".ppt",
+        ".pptx",
+        ".sqlite",
+        ".db",
+        ".pickle",
+        ".pkl",
+    }
+)
+
+
+def _ns_to_datetime(mtime_ns: int) -> datetime:
+    # Epoch-zero and pre-1970 mtimes are legitimate (``touch -d @0`` is a
+    # common "mark as stale" idiom); treating them as absent makes the row
+    # look changed on every sync and restores the file with a fresh mtime.
+    return micros_to_datetime(mtime_ns // 1000)
+
+
+def _mode_string(mode: int | None) -> str | None:
+    # Zero is a real mode (a file made unreadable on purpose), so only an
+    # absent value reads as "no mode recorded".
+    return None if mode is None else f"{mode:04o}"
+
+
+def _entry_mode_string(entry: ScanEntry) -> str | None:
+    # A symlink's mode is never applied on restore, so none is recorded.
+    return None if entry.kind == "symlink" else _mode_string(entry.mode)
+
+
+def _mode_int(permissions: str | None, kind: str) -> int:
+    if permissions:
+        try:
+            return int(permissions, 8)
+        except ValueError:
+            pass
+    return 0o755 if kind == "dir" else 0o644
+
+
+_UTF8_SLICE = 1 << 20
+
+
+def _is_binary_extension(file_path: str) -> bool:
+    """Check if file extension indicates binary content."""
+    _, ext = os.path.splitext(file_path)
+    return ext.lower() in _BINARY_EXTENSIONS
+
+
+def _detect_is_binary(file_path: str, content: bytes) -> bool:
+    """Detect whether file content is binary."""
+    if _is_binary_extension(file_path):
+        return True
+    # A NUL anywhere, not only in a leading window: text goes to a column
+    # that cannot hold one, so a NUL further in is dropped on the way to
+    # the row and the stored bytes stop hashing to the row's own digest.
+    # Restore verifies that digest, and a file that fails it is never placed.
+    if b"\x00" in content:
+        return True
+    # The whole content decides, in slices so no full-size str is built: a
+    # blob row is never re-read on the way out, so a bad sequence after the
+    # first pages would otherwise be served as text with replacement marks.
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    view = memoryview(content)
+    try:
+        for start in range(0, len(view), _UTF8_SLICE):
+            decoder.decode(view[start : start + _UTF8_SLICE])
+        decoder.decode(b"", final=True)
+        return False
+    except UnicodeDecodeError:
+        return True
+
+
+def _transfer_mode(sandbox: Any) -> str:
+    # PTCSandbox holds the whole CoreConfig; the provider name is on its
+    # sandbox section. Anything else (a mock, a foreign runtime) reads as
+    # an unknown provider and relays.
+    config = getattr(sandbox, "config", None)
+    section = getattr(config, "sandbox", None)
+    provider = getattr(section, "provider", None)
+    if not isinstance(provider, str):
+        provider = None
+    return get_blob_transfer_mode(provider)
+
+
+def _row_base(entry: ScanEntry) -> dict[str, Any]:
+    return {
+        "file_path": entry.path,
+        "file_name": os.path.basename(entry.path),
+        "file_size": entry.size if entry.kind == "file" else 0,
+        "permissions": _entry_mode_string(entry),
+        "sandbox_modified_at": _ns_to_datetime(entry.mtime_ns),
+        "kind": entry.kind,
+        "symlink_target": entry.symlink_target,
+        "content_hash": entry.sha256 if entry.kind == "file" else None,
+        "content_text": None,
+        "content_binary": None,
+        "blob_sha256": None,
+        "pack_sha256": None,
+        "pack_offset": None,
+        "mime_type": None,
+        "is_binary": False,
+    }
+
+
+def _blob_row(
+    entry: ScanEntry, *, is_binary: bool | None = None
+) -> dict[str, Any]:
+    row = _row_base(entry)
+    mime, _ = mimetypes.guess_type(entry.path)
+    if is_binary is None:
+        # The scan sniffs content the way the relay path does; the
+        # extension list is the other half of that rule.
+        sniffed = entry.is_binary
+        is_binary = _is_binary_extension(entry.path) or bool(sniffed)
+    row.update(
+        {
+            "blob_sha256": entry.sha256,
+            "mime_type": mime,
+            "is_binary": is_binary,
+        }
+    )
+    return row
+
+
+def _pack_row(
+    entry: ScanEntry,
+    pack_sha256: str,
+    pack_offset: int,
+    *,
+    is_binary: bool | None = None,
+) -> dict[str, Any]:
+    row = _blob_row(entry, is_binary=is_binary)
+    row.update(
+        {
+            "blob_sha256": None,
+            "pack_sha256": pack_sha256,
+            "pack_offset": int(pack_offset),
+        }
+    )
+    return row
+
+
+def _stamp_matches(db: dict[str, Any], entry: ScanEntry) -> bool:
+    """True when a manifest row's mode and mtime already describe this entry.
+
+    The comparison is truncated to microseconds because the column is a
+    TIMESTAMPTZ: the nanoseconds the scan reports cannot survive the round
+    trip, so a full-precision compare would read every row as moved.
+    """
+    return (
+        db.get("mtime_ns") is not None
+        and db["mtime_ns"] // 1000 == entry.mtime_ns // 1000
+        and db.get("permissions") == _entry_mode_string(entry)
+    )
+
+
+def _content_matches(db: dict[str, Any] | None, entry: ScanEntry) -> bool:
+    """True when a manifest row's bytes are the ones this entry holds."""
+    return bool(
+        db
+        and db.get("kind", "file") == "file"
+        and db.get("content_hash") == entry.sha256
+        and db.get("file_size") == entry.size
+    )
+
+
+def _has_inline_bytes(row: dict[str, Any]) -> bool:
+    """True when a row carries its own bytes, so nothing has to be fetched."""
+    return (
+        row.get("content_text") is not None
+        or row.get("content_binary") is not None
+    )

--- a/src/server/services/persistence/backup.py
+++ b/src/server/services/persistence/backup.py
@@ -1,0 +1,378 @@
+"""Snapshot a workspace's sandbox tree into the manifest.
+
+The sandbox walks and hashes its own tree; this side diffs the result
+against the manifest and moves only the bytes whose digest is not yet
+registered. Getting those bytes into storage is ``blobs``; deciding which
+ones move, and what the manifest then says, is here.
+"""
+
+import errno
+import logging
+import os
+from datetime import datetime
+from typing import Any
+
+from src.server.database.workspace_file import (
+    bulk_update_file_stamps,
+    bulk_upsert_files,
+    delete_file_rows,
+    delete_removed_files,
+    manifest_clock,
+    get_file_metadata_for_sync,
+    get_workspace_total_size,
+    workspace_sync_lock,
+)
+from src.server.database.workspace import files_restore_incomplete, workspace_owner
+from src.server.database.blob_keys import MAX_BLOB_BYTES
+from src.server.services.persistence._rows import (
+    _blob_row,
+    _content_matches,
+    _entry_mode_string,
+    _ns_to_datetime,
+    _row_base,
+    _stamp_matches,
+)
+from src.server.services.persistence.blobs import (
+    _persist_blobs,
+    _persist_inline,
+    _persist_packed,
+)
+from src.server.services.persistence.transfer import (
+    PACK_CUTOFF,
+    ScanEntry,
+    scan_workspace,
+)
+from src.utils.storage import is_storage_enabled
+
+# Same number as the per-blob storage cap, and derived from it rather than
+# restated: a file this path accepts must be storable.
+MAX_FILE_SIZE = MAX_BLOB_BYTES
+MAX_WORKSPACE_SIZE = 1024 * 1024 * 1024  # 1GB total per workspace
+
+logger = logging.getLogger(__name__)
+
+
+async def list_sandbox_files(
+    sandbox: Any, *, prior: dict[str, tuple[int, int, str]] | None = None
+) -> dict[str, dict[str, Any]]:
+    """Listing of regular files for the backup-status route.
+
+    ``prior`` (path -> (size, mtime_ns, sha256)) lets the scan reuse
+    hashes for unchanged files instead of re-reading the whole tree.
+    """
+    scan = await scan_workspace(
+        sandbox, prior or {}, max_file_bytes=MAX_FILE_SIZE
+    )
+    work_dir = sandbox.working_dir
+    return {
+        e.path: {
+            "abs_path": f"{work_dir}/{e.path}",
+            "file_name": os.path.basename(e.path),
+            "file_size": e.size,
+            "mtime": e.mtime_ns / 1e9,
+            "content_hash": e.sha256,
+        }
+        for e in scan.entries
+        if e.kind == "file"
+    }
+
+
+def prior_from_meta(
+    existing: dict[str, dict[str, Any]],
+) -> dict[str, tuple[int, int, str]]:
+    return {
+        path: (m["file_size"], m["mtime_ns"], m["content_hash"])
+        for path, m in existing.items()
+        if m.get("kind", "file") == "file"
+        and m.get("mtime_ns") is not None
+        and m.get("content_hash")
+    }
+
+
+def _has_ancestor_in(path: str, names: set[str]) -> bool:
+    cut = path.rfind("/")
+    while cut > 0:
+        if path[:cut] in names:
+            return True
+        cut = path.rfind("/", 0, cut)
+    return False
+
+
+async def sync_to_db(workspace_id: str, sandbox: Any) -> dict[str, Any]:
+    """
+    Snapshot workspace files from the sandbox into the manifest.
+
+    The sandbox walks and hashes its own tree; this side diffs the result
+    against the manifest and moves only the bytes whose digest is not yet
+    registered. Under ``direct`` transfer those bytes never pass through
+    this process.
+
+    Serialized per workspace across workers: the diff decides what to write
+    from a read taken before the scan, so two overlapping passes would let
+    the older one's upsert land last and reinstate what the newer pass had
+    already recorded.
+
+    Returns:
+        Sync result summary
+    """
+    try:
+        async with workspace_sync_lock(workspace_id) as conn:
+            return await _sync_locked(workspace_id, sandbox, conn)
+    except Exception as e:
+        logger.error(f"File sync failed for workspace {workspace_id}: {e}")
+        raise
+
+
+async def _sync_locked(
+    workspace_id: str, sandbox: Any, conn: Any
+) -> dict[str, Any]:
+    """One sync pass, holding this workspace's lock on ``conn``.
+
+    Every manifest read and write rides that same session: acquiring a
+    second pooled connection underneath a lock holder doubles the slots a
+    sync costs and can stall on the pool's own timeout.
+    """
+    result = {
+        "synced": 0, "skipped": 0, "deleted": 0, "errors": 0,
+        "oversized": 0, "total_size": 0,
+    }
+
+    # Taken before the scan, on the database's clock: rows written by
+    # anyone after this instant are newer than what this pass saw.
+    started_at = await manifest_clock(conn=conn)
+    existing = await get_file_metadata_for_sync(workspace_id, conn=conn)
+    scan = await scan_workspace(
+        sandbox,
+        prior_from_meta(existing),
+        max_file_bytes=MAX_FILE_SIZE,
+    )
+    result["oversized"] = len(scan.oversized)
+    for item in scan.oversized:
+        logger.warning(
+            f"Skipping {item.get('path')} in workspace {workspace_id}: "
+            f"{item.get('size')} bytes exceeds the {MAX_FILE_SIZE} "
+            f"per-file limit"
+        )
+    read_errors = 0
+    for item in scan.errors:
+        # ENOENT below the root is a file removed between the listing
+        # and the read: absent for the right reason, so it is neither
+        # data at risk nor a reason to withhold pruning. Anything else
+        # (EACCES, EIO, the root itself) is data at risk, and a strict
+        # backup must refuse to tear the sandbox down over it.
+        if item.get("errno") == errno.ENOENT and item.get("path") != ".":
+            logger.info(
+                f"{item.get('path')} in workspace {workspace_id} vanished "
+                f"during the scan; treating it as deleted"
+            )
+            continue
+        logger.warning(
+            f"Could not read {item.get('path')} in workspace "
+            f"{workspace_id}: {item.get('error')}"
+        )
+        result["errors"] += 1
+        read_errors += 1
+
+    # Pruning treats "in the manifest but not the sandbox" as a user
+    # deletion. That inference only holds if the sandbox actually has
+    # everything it should — a failed restore produces the identical
+    # signature. A read failure counts as incomplete: the cost of
+    # skipping a prune is a stale row, and the cost of the opposite
+    # guess is the only surviving record of a file.
+    try:
+        may_prune = not await files_restore_incomplete(workspace_id, conn=conn)
+    except Exception as e:
+        logger.warning(
+            f"Could not read the restore-completeness flag for workspace "
+            f"{workspace_id} ({e}); treating the sandbox as an incomplete "
+            f"mirror and skipping deletions this pass"
+        )
+        may_prune = False
+
+    if read_errors and may_prune:
+        # A path the scan could not read is absent from the listing
+        # for the wrong reason. The root itself failing looks like
+        # an emptied workspace, and pruning on that erases the file
+        # list; one unreadable directory is the same mistake in
+        # miniature. Stale rows are the cheaper error.
+        logger.warning(
+            f"Scan of workspace {workspace_id} hit {read_errors} read "
+            f"error(s); keeping every manifest row this pass"
+        )
+        may_prune = False
+
+    if not scan.entries:
+        logger.info(f"No files found for workspace {workspace_id}")
+        if not may_prune:
+            logger.warning(
+                f"Sandbox for workspace {workspace_id} listed no files and "
+                f"is a known-incomplete mirror; keeping every manifest row. "
+                f"A restore that failed for all files looks exactly like "
+                f"this, and pruning here would erase the whole file list."
+            )
+            return result
+        deleted = await delete_removed_files(
+            workspace_id, set(), untouched_since=started_at, conn=conn
+        )
+        result["deleted"] = deleted
+        return result
+
+    total_size = sum(e.size for e in scan.entries if e.kind == "file")
+    if total_size > MAX_WORKSPACE_SIZE:
+        logger.warning(
+            f"Workspace {workspace_id} total size ({total_size}) exceeds limit "
+            f"({MAX_WORKSPACE_SIZE}). Syncing anyway but this may be slow."
+        )
+
+    active_paths: set[str] = set()
+    rows: list[dict[str, Any]] = []
+    stamp_updates: list[tuple[str, datetime, str | None]] = []
+    needs_bytes: list[ScanEntry] = []
+    pack_members: list[ScanEntry] = []
+    blobs_on = is_storage_enabled()
+    # Object keys are scoped to the owner; read once for the whole pass.
+    user_id = await workspace_owner(workspace_id, conn=conn) if blobs_on else None
+
+    # While the mirror is known incomplete a stamp that moved on an
+    # unchanged entry may be the restore's own failed chmod or utime, and
+    # recording it would make the wrong mode the one the retry restores.
+    # The manifest stays the authority on metadata until a restore completes.
+    refresh_stamps = may_prune
+
+    # A directory that came back as a file or symlink still has its old
+    # children in the manifest, and the scan never lists them (it does not
+    # descend into either). They are not "absent for an unknown reason",
+    # which is what the prune gate protects: the parent's new kind proves
+    # they cannot exist, and a restore that keeps them makes the child
+    # create a directory where the symlink or file has to land. Keyed on
+    # the scan alone: a manifest written before directories had rows of
+    # their own holds the children with no parent row to compare against.
+    non_dir_paths: set[str] = set()
+
+    for entry in scan.entries:
+        active_paths.add(entry.path)
+        db = existing.get(entry.path)
+
+        if entry.kind != "dir":
+            non_dir_paths.add(entry.path)
+
+        if entry.kind != "file":
+            if (
+                db is not None
+                and db.get("kind") == entry.kind
+                and db.get("symlink_target") == entry.symlink_target
+                and (_stamp_matches(db, entry) or not refresh_stamps)
+            ):
+                result["skipped"] += 1
+            else:
+                rows.append(_row_base(entry))
+            continue
+
+        if entry.sha256 is None:
+            # The scan reports why in ``errors`` and already counted it.
+            continue
+
+        if blobs_on and entry.size <= PACK_CUTOFF:
+            # Small files are decided as a set, below: whether the
+            # pack they share needs rewriting depends on all of them.
+            pack_members.append(entry)
+            continue
+
+        if _content_matches(db, entry):
+            result["skipped"] += 1
+            if _stamp_matches(db, entry) or not refresh_stamps:
+                continue
+            if db.get("blob_sha256"):
+                # Pointer row: a metadata refresh costs no bytes.
+                rows.append(
+                    _blob_row(entry, is_binary=db.get("is_binary"))
+                )
+            else:
+                # Inline row: the stamps can be refreshed without
+                # rewriting content the row does not carry.
+                stamp_updates.append(
+                    (
+                        entry.path,
+                        _ns_to_datetime(entry.mtime_ns),
+                        _entry_mode_string(entry),
+                    )
+                )
+            continue
+
+        needs_bytes.append(entry)
+
+    if needs_bytes:
+        if blobs_on:
+            persisted, errors = await _persist_blobs(
+                user_id, workspace_id, sandbox, needs_bytes
+            )
+        else:
+            persisted, errors = await _persist_inline(
+                workspace_id, sandbox, needs_bytes
+            )
+        rows.extend(persisted)
+        result["errors"] += errors
+
+    if pack_members:
+        packed, errors, skipped = await _persist_packed(
+            user_id, workspace_id, sandbox, pack_members, existing, may_prune=may_prune
+        )
+        rows.extend(packed)
+        result["errors"] += errors
+        result["skipped"] += skipped
+
+    if stamp_updates:
+        # A mode or mtime change on unchanged bytes is persisted only here.
+        # Left uncounted, a failed write reads as a clean backup, and a strict
+        # caller would tear the sandbox down with the new stamps unrecorded.
+        try:
+            await bulk_update_file_stamps(workspace_id, stamp_updates, conn=conn)
+        except Exception as e:
+            logger.error(
+                f"Stamp update failed for {len(stamp_updates)} files in "
+                f"workspace {workspace_id}: {e}"
+            )
+            result["errors"] += len(stamp_updates)
+
+    if rows:
+        result["synced"] = await bulk_upsert_files(
+            workspace_id, rows, conn=conn
+        )
+
+    orphaned = [
+        p for p in existing
+        if p not in active_paths and _has_ancestor_in(p, non_dir_paths)
+    ]
+    if orphaned:
+        result["deleted"] += await delete_file_rows(
+            workspace_id, orphaned, conn=conn
+        )
+
+    if may_prune:
+        deleted = await delete_removed_files(
+            workspace_id, active_paths, untouched_since=started_at, conn=conn
+        )
+        result["deleted"] += deleted
+    else:
+        withheld = len(set(existing) - active_paths)
+        if withheld:
+            logger.warning(
+                f"Keeping {withheld} manifest row(s) for workspace "
+                f"{workspace_id} whose files are absent from the sandbox: "
+                f"it is a known-incomplete mirror, so a missing file means "
+                f"a failed restore, not a user deletion. The next workspace "
+                f"start retries the restore and pruning resumes."
+            )
+
+    result["total_size"] = await get_workspace_total_size(
+        workspace_id, conn=conn
+    )
+
+    logger.debug(
+        f"File sync completed for workspace {workspace_id}: "
+        f"synced={result['synced']}, skipped={result['skipped']}, "
+        f"deleted={result['deleted']}, errors={result['errors']}, "
+        f"hashed={scan.hashed}, reused={scan.reused}"
+    )
+
+    return result

--- a/src/server/services/persistence/blobs.py
+++ b/src/server/services/persistence/blobs.py
@@ -1,0 +1,451 @@
+"""Get a scanned entry's bytes into object storage, or into the row itself.
+
+Digests the registry already knows cost nothing. The rest go straight from
+the sandbox to the store under a presigned PUT, or through this process when
+that path is unavailable. Small files travel as members of shared chunks.
+"""
+
+import asyncio
+import hashlib
+import logging
+import mimetypes
+from dataclasses import dataclass
+from typing import Any
+
+from src.server.database.blob_keys import BLOB_CONTENT_TYPE, blob_key
+from src.server.database.workspace_file_blobs import (
+    BlobUploadError,
+    register_blobs,
+    registered_blobs,
+    store_blob,
+)
+from src.server.services.persistence._rows import (
+    _blob_row,
+    _content_matches,
+    _detect_is_binary,
+    _pack_row,
+    _row_base,
+    _stamp_matches,
+    _transfer_mode,
+)
+from src.server.services.persistence.transfer import (
+    pack_direct,
+    unlink_direct,
+    ScanEntry,
+    all_unreachable,
+    push_direct,
+    transfer_timeout_s,
+)
+from src.utils.storage import get_signed_upload_url
+
+# Files moved through this process (inline rows, or blobs when direct
+# transfer is unavailable). The sandbox's own download semaphore is the
+# tighter bound; this one keeps the gather from fanning out unboundedly.
+RELAY_CONCURRENCY = 8
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DirectPush:
+    """What the store made of one direct-upload pass, per digest."""
+
+    registered: set[str]
+    changed: set[str]
+    unreachable: set[str]
+
+
+async def _persist_blobs(
+    user_id: str,
+    workspace_id: str,
+    sandbox: Any,
+    entries: list[ScanEntry],
+    *,
+    unlink_after: bool = False,
+) -> tuple[list[dict[str, Any]], int]:
+    """Make sure every entry's digest has an object, then build its row.
+
+    Digests the registry already knows under the owner are done before any
+    byte moves. The rest go direct when the store and sandbox allow it, and
+    through this process otherwise. An entry whose digest still has no
+    object at the end is dropped from the batch and counted as an error:
+    its old row survives, and the next sync retries.
+    """
+    wanted = {e.sha256 for e in entries if e.sha256}
+    have = await registered_blobs(user_id, list(wanted))
+    need = wanted - have
+    mode = _transfer_mode(sandbox)
+    if unlink_after and have:
+        # A chunk the registry already holds is never pushed, so nothing
+        # downstream would remove it; it would sit until the age sweep.
+        await _unlink_chunks(
+            sandbox, [e.path for e in entries if e.sha256 in have], workspace_id
+        )
+
+    # The store answering at all makes a rejection final this pass, so only
+    # the digests it never reached fall through to the relay.
+    outcome = (
+        await _push_direct(
+            user_id, workspace_id, sandbox, entries, need, unlink_after=unlink_after
+        )
+        if need and mode == "direct"
+        else None
+    )
+    relay_need = need if outcome is None else outcome.unreachable
+    registered, changed = (
+        (set(), set()) if outcome is None else (outcome.registered, outcome.changed)
+    )
+    if relay_need:
+        relayed, relay_changed = await _relay_blobs(
+            user_id,
+            workspace_id,
+            sandbox,
+            entries,
+            relay_need,
+            unlink_after=unlink_after,
+        )
+        registered |= relayed
+        changed |= relay_changed
+
+    available = have | registered
+    rows: list[dict[str, Any]] = []
+    errors = 0
+    for entry in entries:
+        if entry.sha256 in available:
+            rows.append(_blob_row(entry))
+        else:
+            errors += 1
+            if entry.sha256 not in changed:
+                logger.error(
+                    f"Blob upload failed for {entry.path} "
+                    f"(workspace {workspace_id}, sha {entry.sha256}); "
+                    f"keeping the previous manifest row"
+                )
+    if changed:
+        logger.info(
+            f"{len(changed)} file(s) in workspace {workspace_id} changed "
+            f"during sync and will be picked up next pass"
+        )
+    return rows, errors
+
+
+async def _push_direct(
+    user_id: str,
+    workspace_id: str,
+    sandbox: Any,
+    entries: list[ScanEntry],
+    need: set[str],
+    *,
+    unlink_after: bool = False,
+) -> DirectPush | None:
+    """Presign one PUT per missing digest and let the sandbox upload.
+
+    ``None`` means the direct path was not usable at all (no presigning, or
+    the store unreachable from the sandbox); otherwise the digests the store
+    never answered for come back in ``unreachable``. Either way the caller
+    owns the fallback.
+    """
+    representative: dict[str, ScanEntry] = {}
+    for entry in entries:
+        if entry.sha256 in need and entry.sha256 not in representative:
+            representative[entry.sha256] = entry
+    total = sum(e.size for e in representative.values())
+    expires = transfer_timeout_s(total) + 60
+
+    # Signing is local work on a thread each; a large first backup has
+    # thousands of digests, and one at a time serializes what has no order.
+    signatures = await asyncio.gather(
+        *(
+            asyncio.to_thread(
+                get_signed_upload_url,
+                blob_key(user_id, sha),
+                sha256_hex=sha,
+                content_length=entry.size,
+                content_type=BLOB_CONTENT_TYPE,
+                expires_in=expires,
+            )
+            for sha, entry in representative.items()
+        )
+    )
+    items: list[dict[str, Any]] = []
+    for (sha, entry), signed in zip(representative.items(), signatures):
+        if signed is None:
+            logger.info(
+                f"Store cannot presign uploads; relaying {len(need)} "
+                f"blob(s) for workspace {workspace_id}"
+            )
+            return None
+        url, headers = signed
+        items.append(
+            {
+                "path": entry.path,
+                "sha256": sha,
+                "size": entry.size,
+                "url": url,
+                "headers": headers,
+                "unlink": unlink_after,
+            }
+        )
+
+    items.sort(key=lambda i: int(i.get("size") or 0), reverse=True)
+    results = await push_direct(sandbox, items)
+    if all_unreachable(results):
+        logger.warning(
+            f"Sandbox for workspace {workspace_id} could not reach object "
+            f"storage; relaying {len(items)} blob(s) through the server"
+        )
+        return None
+    unreachable = {
+        sha for sha, r in results.items() if r.get("status") == "unreachable"
+    }
+    if unreachable:
+        # The store answered for the rest, so this is a flaky egress path
+        # rather than a missing route, and the caller relays just these in
+        # the same pass instead of leaving them for the next sync.
+        logger.warning(
+            f"{len(unreachable)} of {len(items)} direct upload(s) for "
+            f"workspace {workspace_id} could not reach object storage; "
+            f"relaying those through the server"
+        )
+
+    ok = [
+        (sha, representative[sha].size)
+        for sha, r in results.items()
+        if r.get("status") == "ok" and sha in representative
+    ]
+    await register_blobs(user_id, ok)
+    for sha, r in results.items():
+        if r.get("status") not in ("ok", "changed", "unreachable"):
+            logger.warning(
+                f"Direct upload of {representative.get(sha).path if sha in representative else sha} "
+                f"for workspace {workspace_id} {r.get('status')}: "
+                f"http={r.get('http')} {r.get('error')}"
+            )
+    return DirectPush(
+        registered={sha for sha, _ in ok},
+        changed={
+            sha for sha, r in results.items() if r.get("status") == "changed"
+        },
+        unreachable=unreachable,
+    )
+
+
+async def _relay_blobs(
+    user_id: str,
+    workspace_id: str,
+    sandbox: Any,
+    entries: list[ScanEntry],
+    need: set[str],
+    *,
+    unlink_after: bool = False,
+) -> tuple[set[str], set[str]]:
+    """Copy missing digests through this process: download, hash, PUT."""
+    representative: dict[str, ScanEntry] = {}
+    for entry in entries:
+        if entry.sha256 in need and entry.sha256 not in representative:
+            representative[entry.sha256] = entry
+
+    registered: set[str] = set()
+    changed: set[str] = set()
+    sem = asyncio.Semaphore(RELAY_CONCURRENCY)
+
+    async def _one(sha: str, entry: ScanEntry) -> None:
+        async with sem:
+            try:
+                content = await sandbox.adownload_file_bytes(
+                    f"{sandbox.working_dir}/{entry.path}"
+                )
+                if content is None:
+                    changed.add(sha)
+                    return
+                # Length as well as digest: the scan stats a file before it
+                # hashes it, so a size the digest does not cover is a change.
+                if len(content) != entry.size or hashlib.sha256(content).hexdigest() != sha:
+                    changed.add(sha)
+                    return
+                await store_blob(user_id, sha, content)
+                registered.add(sha)
+            except BlobUploadError as e:
+                logger.error(
+                    f"Blob upload failed for {entry.path} "
+                    f"(workspace {workspace_id}, sha {sha}): {e}"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Error relaying {entry.path} for workspace "
+                    f"{workspace_id}: {e}"
+                )
+
+    await asyncio.gather(*(_one(s, e) for s, e in representative.items()))
+    if unlink_after:
+        await _unlink_chunks(sandbox, [e.path for e in entries], workspace_id)
+    return registered, changed
+
+
+async def _unlink_chunks(sandbox: Any, paths: list[str], workspace_id: str) -> None:
+    try:
+        await unlink_direct(sandbox, paths)
+    except Exception as e:
+        # Cosmetic: the next pack op sweeps what is left by age.
+        logger.info(f"Could not remove pack chunks for {workspace_id}: {e}")
+
+
+async def _persist_packed(
+    user_id: str,
+    workspace_id: str,
+    sandbox: Any,
+    members: list[ScanEntry],
+    existing: dict[str, dict[str, Any]],
+    *,
+    may_prune: bool = True,
+) -> tuple[list[dict[str, Any]], int, int]:
+    """Rows for every small file, via the pack set. Returns (rows, errors, skipped).
+
+    The pack set is rewritten whole whenever a member changed, appeared or
+    left, so a workspace never trails half-dead chunks and a restore stays
+    a handful of GETs. When nothing changed and every member already
+    points at a pack, the only work is a metadata refresh for rows whose
+    stamp moved. A file that only recently shrank below the cutoff, or
+    was stored per object before packs existed, reads as a set change
+    and is packed on this pass. A member that is absent from the sandbox
+    counts as having left only when this pass may prune its row: while
+    pruning is withheld the row stays and the file is expected back, so
+    repacking around it would repeat on every sync until the restore. The
+    same pass leaves a moved stamp unrecorded, for the reason ``sync_to_db``
+    gives: it may be the failed restore's own doing.
+    """
+    by_path = {e.path: e for e in members}
+
+    def packed_unchanged(e: ScanEntry) -> bool:
+        db = existing.get(e.path)
+        return _content_matches(db, e) and bool(db.get("pack_sha256"))
+
+    previously_packed = {
+        path
+        for path, m in existing.items()
+        if m.get("kind", "file") == "file" and m.get("pack_sha256")
+    }
+    left = previously_packed - set(by_path) if may_prune else set()
+    if not left and all(packed_unchanged(e) for e in members):
+        rows: list[dict[str, Any]] = []
+        for e in members:
+            db = existing[e.path]
+            if may_prune and not _stamp_matches(db, e):
+                rows.append(
+                    _pack_row(
+                        e, db["pack_sha256"], db["pack_offset"], is_binary=db.get("is_binary")
+                    )
+                )
+        return rows, 0, len(members)
+
+    out = await pack_direct(
+        sandbox,
+        [{"path": e.path, "sha256": e.sha256, "size": e.size} for e in members],
+    )
+    chunks = out["chunks"]
+    changed = set(out["changed"])
+    # A chunk is pushed exactly like a file: same presigning, same direct
+    # path with relay fallback, same registry. It just is not a file the
+    # user has, so it is removed from the sandbox once pushed.
+    chunk_entries = [
+        ScanEntry(
+            path=c["path"],
+            kind="file",
+            size=int(c["size"]),
+            mtime_ns=0,
+            mode=0,
+            sha256=c["sha256"],
+            symlink_target=None,
+            is_binary=True,
+        )
+        for c in chunks
+    ]
+    chunk_rows, _ = await _persist_blobs(
+        user_id, workspace_id, sandbox, chunk_entries, unlink_after=True
+    )
+    available = {r["blob_sha256"] for r in chunk_rows}
+
+    rows = []
+    errors = len(changed)
+    for c in chunks:
+        if c["sha256"] not in available:
+            # The old rows survive, still pointing at the previous chunk,
+            # which stays referenced and restorable; next sync retries.
+            errors += len(c["members"])
+            continue
+        for m in c["members"]:
+            e = by_path.get(m["path"])
+            if e is None:
+                continue
+            db = existing.get(e.path)
+            is_binary = db.get("is_binary") if _content_matches(db, e) else None
+            rows.append(_pack_row(e, c["sha256"], m["offset"], is_binary=is_binary))
+    if changed:
+        logger.info(
+            f"{len(changed)} small file(s) in workspace {workspace_id} changed "
+            f"during packing and will be picked up next pass"
+        )
+    logger.info(
+        f"Packed {len(rows)} file(s) into {len(chunks)} chunk(s) "
+        f"for workspace {workspace_id}"
+    )
+    return rows, errors, 0
+
+
+async def _persist_inline(
+    workspace_id: str, sandbox: Any, entries: list[ScanEntry]
+) -> tuple[list[dict[str, Any]], int]:
+    """No object store: bytes go into the manifest row itself."""
+    rows: list[dict[str, Any]] = []
+    errors = 0
+    sem = asyncio.Semaphore(RELAY_CONCURRENCY)
+
+    async def _one(entry: ScanEntry) -> dict[str, Any] | None:
+        async with sem:
+            try:
+                content = await sandbox.adownload_file_bytes(
+                    f"{sandbox.working_dir}/{entry.path}"
+                )
+                if content is None:
+                    return None
+                # The row describes the bytes it carries, so hash and size
+                # come from the download even if the scan saw an earlier
+                # version of the file.
+                content_hash = hashlib.sha256(content).hexdigest()
+                is_binary = _detect_is_binary(entry.path, content)
+                content_text = None
+                content_binary = None
+                if is_binary:
+                    content_binary = content
+                else:
+                    try:
+                        content_text = content.decode("utf-8")
+                    except UnicodeDecodeError:
+                        is_binary = True
+                        content_binary = content
+                row = _row_base(entry)
+                mime, _ = mimetypes.guess_type(entry.path)
+                row.update(
+                    {
+                        "file_size": len(content),
+                        "content_hash": content_hash,
+                        "content_text": content_text,
+                        "content_binary": content_binary,
+                        "mime_type": mime,
+                        "is_binary": is_binary,
+                    }
+                )
+                return row
+            except Exception as e:
+                logger.warning(
+                    f"Error downloading file {entry.path} "
+                    f"for workspace {workspace_id}: {e}"
+                )
+                return None
+
+    for payload in await asyncio.gather(*(_one(e) for e in entries)):
+        if payload is None:
+            errors += 1
+        else:
+            rows.append(payload)
+    return rows, errors

--- a/src/server/services/persistence/file.py
+++ b/src/server/services/persistence/file.py
@@ -1,677 +1,112 @@
 """
 File Persistence Service.
 
-Syncs workspace files between Daytona sandboxes and PostgreSQL.
+Keeps a workspace's manifest in step with the sandbox that holds the live
+files. The manifest is one Postgres row per path, with the bytes in object
+storage or, where there is none, in the row itself.
 
-- Snapshots files to DB on workspace stop/delete
-- Restores files to sandbox when sandbox is recreated
-- Serves file metadata/content from DB when sandbox is stopped
+- Snapshots the sandbox into the manifest on workspace stop/delete
+- Restores the manifest into a sandbox that was recreated
+- Serves file metadata and content from the manifest while the sandbox is down
+
+Each job has its own module: ``backup`` snapshots, ``restore`` restores,
+``blobs`` moves bytes into storage, ``resolve`` reads them back, and ``_rows``
+holds the row shape they share. This module is the facade over them.
 """
 
-import asyncio
-import hashlib
-import logging
-import mimetypes
-import os
-import shlex
-from datetime import datetime, timezone
 from typing import Any
 
-from ptc_agent.core.paths import BACKUP_EXCLUDE_AGENT_SUBDIRS, BACKUP_EXCLUDE_DIRS, ALWAYS_HIDDEN_DIR_NAMES, HIDDEN_DIR_NAMES
-from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
+from src.server.database.blob_keys import MAX_BLOB_BYTES
+from src.server.database.workspace import ANY_SANDBOX
 from src.server.database.workspace_file import (
-    bulk_update_file_mtimes,
-    bulk_upsert_files,
-    delete_removed_files,
     get_file as db_get_file,
-    get_file_metadata_for_sync,
     get_files_for_workspace,
-    get_workspace_total_size,
-    update_file_mtime,
+)
+from src.server.services.persistence import backup, restore
+from src.server.services.persistence.restore import (
+    RestoreGuardUnavailable as RestoreGuardUnavailable,
+    RestoreIdentityLost as RestoreIdentityLost,
+)
+from src.server.services.persistence.resolve import (
+    FileBytesUnavailable as FileBytesUnavailable,
+    resolve_file_bytes as resolve_file_bytes,
+    resolve_file_bytes_or_none as resolve_file_bytes_or_none,
+    resolve_file_text_or_none as resolve_file_text_or_none,
 )
 
-logger = logging.getLogger(__name__)
 
-# Known binary file extensions (reused from workspace_files.py)
-_BINARY_EXTENSIONS = frozenset(
-    {
-        ".pdf",
-        ".png",
-        ".jpg",
-        ".jpeg",
-        ".gif",
-        ".webp",
-        ".bmp",
-        ".ico",
-        ".tiff",
-        ".zip",
-        ".tar",
-        ".gz",
-        ".bz2",
-        ".7z",
-        ".rar",
-        ".exe",
-        ".dll",
-        ".so",
-        ".dylib",
-        ".mp3",
-        ".mp4",
-        ".wav",
-        ".avi",
-        ".mov",
-        ".mkv",
-        ".doc",
-        ".docx",
-        ".xls",
-        ".xlsx",
-        ".ppt",
-        ".pptx",
-        ".sqlite",
-        ".db",
-        ".pickle",
-        ".pkl",
-    }
-)
+async def get_file_tree(workspace_id: str) -> list[dict[str, Any]]:
+    """
+    Get file metadata from DB for offline UI browsing.
 
-def _sync_marker_path(work_dir: str) -> str:
-    """Return the sync marker file path for the given working directory."""
-    return f"{work_dir}/.file_sync_marker"
+    Returns flat list of file metadata (no content).
+    """
+    files = await get_files_for_workspace(workspace_id, include_content=False)
+    return [
+        {
+            "path": f["file_path"],
+            "name": f["file_name"],
+            "size": f["file_size"],
+            "mime_type": f.get("mime_type"),
+            "is_binary": f.get("is_binary", False),
+            "modified_at": f.get("sandbox_modified_at"),
+        }
+        for f in files
+    ]
 
 
-def _is_binary_extension(file_path: str) -> bool:
-    """Check if file extension indicates binary content."""
-    _, ext = os.path.splitext(file_path)
-    return ext.lower() in _BINARY_EXTENSIONS
+async def get_file_content(
+    workspace_id: str, file_path: str
+) -> dict[str, Any] | None:
+    """
+    Get file content from DB for offline access.
 
-
-def _detect_is_binary(file_path: str, content: bytes) -> bool:
-    """Detect whether file content is binary."""
-    if _is_binary_extension(file_path):
-        return True
-    if b"\x00" in content[:65536]:
-        return True
-    try:
-        content[:8192].decode("utf-8")
-        return False
-    except UnicodeDecodeError:
-        return True
+    Returns file record with content, or None if not found.
+    """
+    return await db_get_file(workspace_id, file_path, include_content=True)
 
 
 class FilePersistenceService:
     """Sync workspace files between Daytona sandbox and PostgreSQL."""
 
-    MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB per file
-    MAX_WORKSPACE_SIZE = 1024 * 1024 * 1024  # 1GB total per workspace
+    # Same number as the per-blob storage cap, and derived from it rather than
+    # restated: a file this path accepts must be storable.
+    MAX_FILE_SIZE = MAX_BLOB_BYTES
 
-    # Directories excluded from sync (relative to /home/workspace/).
-    # All patterns match at any depth via find's -not -path '*/{d}/*'.
-    EXCLUDE_DIRS = BACKUP_EXCLUDE_DIRS | HIDDEN_DIR_NAMES | ALWAYS_HIDDEN_DIR_NAMES
+    @staticmethod
+    async def sync_to_db(workspace_id: str, sandbox: Any) -> dict[str, Any]:
+        return await backup.sync_to_db(workspace_id, sandbox)
 
-    # File extensions to exclude
-    EXCLUDE_EXTENSIONS = {".pyc", ".pyo", ".so", ".dylib", ".o"}
+    @staticmethod
+    async def list_sandbox_files(
+        sandbox: Any, *, prior: dict[str, tuple[int, int, str]] | None = None
+    ) -> dict[str, dict[str, Any]]:
+        return await backup.list_sandbox_files(sandbox, prior=prior)
 
-    # Basenames to exclude
-    EXCLUDE_BASENAMES = {".DS_Store", "Thumbs.db", "__init__.py"}
+    @staticmethod
+    def prior_from_meta(
+        existing: dict[str, dict[str, Any]],
+    ) -> dict[str, tuple[int, int, str]]:
+        return backup.prior_from_meta(existing)
 
-    @classmethod
-    async def list_sandbox_files(cls, sandbox: Any) -> dict[str, dict[str, Any]]:
-        """List user files in sandbox with metadata.
-
-        Returns:
-            Dict mapping virtual_path to {abs_path, file_name, file_size, mtime}.
-            Empty dict if no files found.
-        """
-        work_dir = sandbox.working_dir
-        work_dir_prefix = work_dir + "/"
-        sync_marker = _sync_marker_path(work_dir)
-
-        exclude_flags = []
-        for d in cls.EXCLUDE_DIRS:
-            exclude_flags.append(f"-not -path '*/{d}/*'")
-        for subdir in BACKUP_EXCLUDE_AGENT_SUBDIRS:
-            exclude_flags.append(f"-not -path '*/{subdir}/*'")
-        for ext in cls.EXCLUDE_EXTENSIONS:
-            exclude_flags.append(f"-not -name '*{ext}'")
-        for name in cls.EXCLUDE_BASENAMES:
-            exclude_flags.append(f"-not -name '{name}'")
-
-        find_cmd = (
-            f"find {work_dir} -type f "
-            f"{' '.join(exclude_flags)} "
-            f"-printf '%s\\t%T@\\t%p\\n' 2>/dev/null"
-        )
-
-        find_result = await sandbox.execute_bash_command(find_cmd, timeout=30)
-        if not find_result.get("success"):
-            raise RuntimeError(
-                f"Failed to list sandbox files: {find_result.get('stderr', 'unknown error')}"
-            )
-        if not find_result.get("stdout", "").strip():
-            return {}
-
-        result: dict[str, dict[str, Any]] = {}
-        for line in find_result["stdout"].strip().split("\n"):
-            parts = line.split("\t", 2)
-            if len(parts) != 3:
-                continue
-
-            size_str, mtime_str, abs_path = parts
-            try:
-                file_size = int(size_str)
-            except ValueError:
-                continue
-
-            if file_size > cls.MAX_FILE_SIZE:
-                continue
-
-            virtual_path = abs_path
-            if virtual_path.startswith(work_dir_prefix):
-                virtual_path = virtual_path[len(work_dir_prefix):]
-            elif virtual_path == work_dir:
-                continue
-
-            if abs_path == sync_marker:
-                continue
-
-            try:
-                mtime = float(mtime_str)
-            except ValueError:
-                mtime = 0.0
-
-            result[virtual_path] = {
-                "abs_path": abs_path,
-                "file_name": os.path.basename(abs_path),
-                "file_size": file_size,
-                "mtime": mtime,
-            }
-
-        return result
-
-    @classmethod
-    async def _compute_sandbox_hashes(
-        cls, sandbox: Any, file_paths: list[str]
-    ) -> dict[str, str]:
-        """Compute SHA-256 hashes on the sandbox to avoid downloading unchanged files.
-
-        Args:
-            sandbox: Sandbox instance
-            file_paths: List of absolute paths on the sandbox
-
-        Returns:
-            Dict mapping abs_path to hex hash. Missing entries mean the file
-            could not be hashed (deleted, permission error, etc.).
-        """
-        if not file_paths:
-            return {}
-
-        batch_size = 200
-        batches = [
-            file_paths[i : i + batch_size]
-            for i in range(0, len(file_paths), batch_size)
-        ]
-
-        async def _run_batch(paths: list[str]) -> dict[str, str]:
-            quoted = " ".join(shlex.quote(p) for p in paths)
-            cmd = f"sha256sum {quoted} 2>/dev/null"
-            res = await sandbox.execute_bash_command(cmd, timeout=30)
-            result: dict[str, str] = {}
-            if not res.get("success") or not res.get("stdout", "").strip():
-                return result
-            for line in res["stdout"].strip().split("\n"):
-                parts = line.split(None, 1)
-                if len(parts) == 2:
-                    hex_hash, path = parts
-                    result[path] = hex_hash
-            return result
-
-        try:
-            batch_results = await asyncio.gather(
-                *[_run_batch(b) for b in batches], return_exceptions=True
-            )
-            merged: dict[str, str] = {}
-            for br in batch_results:
-                if isinstance(br, dict):
-                    merged.update(br)
-            return merged
-        except Exception as e:
-            logger.warning(f"Sandbox hash computation failed: {e}")
-            return {}
-
-    @classmethod
-    async def sync_to_db(cls, workspace_id: str, sandbox: Any) -> dict[str, Any]:
-        """
-        Snapshot workspace files from sandbox to PostgreSQL.
-
-        Args:
-            workspace_id: Workspace UUID
-            sandbox: Sandbox instance with file access methods
-
-        Returns:
-            Sync result summary
-        """
-        result = {"synced": 0, "skipped": 0, "deleted": 0, "errors": 0, "total_size": 0}
-
-        try:
-            # 1. List files in sandbox
-            sandbox_meta = await cls.list_sandbox_files(sandbox)
-
-            if not sandbox_meta:
-                logger.info(f"No files found for workspace {workspace_id}")
-                deleted = await delete_removed_files(workspace_id, set())
-                result["deleted"] = deleted
-                return result
-
-            sandbox_files = [
-                {"virtual_path": vp, **info} for vp, info in sandbox_meta.items()
-            ]
-            total_size = sum(f["file_size"] for f in sandbox_files)
-
-            # Check total workspace size limit
-            if total_size > cls.MAX_WORKSPACE_SIZE:
-                logger.warning(
-                    f"Workspace {workspace_id} total size ({total_size}) exceeds limit "
-                    f"({cls.MAX_WORKSPACE_SIZE}). Syncing anyway but this may be slow."
-                )
-
-            # 3. Get existing metadata from DB for incremental sync
-            existing_meta = await get_file_metadata_for_sync(workspace_id)
-            active_paths: set[str] = set()
-
-            # 4. Pre-filter: skip files where size + mtime are unchanged
-            changed_files: list[dict[str, Any]] = []
-            for file_info in sandbox_files:
-                virtual_path = file_info["virtual_path"]
-                active_paths.add(virtual_path)
-
-                db_meta = existing_meta.get(virtual_path)
-                if db_meta is not None:
-                    # Compare size and mtime — if both match, skip download
-                    size_match = db_meta["file_size"] == file_info["file_size"]
-                    mtime_match = (
-                        db_meta["mtime_epoch"] is not None
-                        and file_info["mtime"] > 0
-                        and abs(db_meta["mtime_epoch"] - file_info["mtime"]) < 1.0
-                    )
-                    if size_match and mtime_match:
-                        result["skipped"] += 1
-                        continue
-
-                changed_files.append(file_info)
-
-            # 5. Compute hashes on sandbox to avoid unnecessary downloads
-            sandbox_hashes = await cls._compute_sandbox_hashes(
-                sandbox, [f["abs_path"] for f in changed_files]
-            )
-
-            # 6. Split into mtime-only updates vs files needing download
-            mtime_updates: list[tuple[str, datetime]] = []
-            files_to_download: list[dict[str, Any]] = []
-
-            for file_info in changed_files:
-                virtual_path = file_info["virtual_path"]
-                sandbox_hash = sandbox_hashes.get(file_info["abs_path"])
-                db_meta = existing_meta.get(virtual_path)
-
-                if (
-                    sandbox_hash
-                    and db_meta is not None
-                    and db_meta["content_hash"] == sandbox_hash
-                ):
-                    # Content unchanged — just update mtime in DB
-                    if file_info["mtime"] > 0:
-                        mtime_updates.append(
-                            (
-                                virtual_path,
-                                datetime.fromtimestamp(
-                                    file_info["mtime"], tz=timezone.utc
-                                ),
-                            )
-                        )
-                    result["skipped"] += 1
-                else:
-                    files_to_download.append(file_info)
-
-            # 7. Bulk update mtimes for unchanged files
-            if mtime_updates:
-                await bulk_update_file_mtimes(workspace_id, mtime_updates)
-
-            # 8. Download files that actually changed, in parallel batches
-            upsert_payloads: list[dict[str, Any]] = []
-            download_batch_size = 10
-
-            async def _download_file(file_info: dict[str, Any]) -> dict[str, Any] | None:
-                virtual_path = file_info["virtual_path"]
-                try:
-                    content = await sandbox.adownload_file_bytes(file_info["abs_path"])
-                    if content is None:
-                        return None
-
-                    # Recompute hash from actual bytes (race safety)
-                    content_hash = hashlib.sha256(content).hexdigest()
-
-                    is_binary = _detect_is_binary(virtual_path, content)
-                    content_text = None
-                    content_binary = None
-                    if is_binary:
-                        content_binary = content
-                    else:
-                        try:
-                            content_text = content.decode("utf-8")
-                        except UnicodeDecodeError:
-                            is_binary = True
-                            content_binary = content
-
-                    mime, _ = mimetypes.guess_type(virtual_path)
-
-                    sandbox_modified_at = None
-                    if file_info["mtime"] > 0:
-                        sandbox_modified_at = datetime.fromtimestamp(
-                            file_info["mtime"], tz=timezone.utc
-                        )
-
-                    return {
-                        "file_path": virtual_path,
-                        "file_name": file_info["file_name"],
-                        "file_size": file_info["file_size"],
-                        "content_hash": content_hash,
-                        "content_text": content_text,
-                        "content_binary": content_binary,
-                        "mime_type": mime,
-                        "is_binary": is_binary,
-                        "permissions": None,
-                        "sandbox_modified_at": sandbox_modified_at,
-                    }
-                except Exception as e:
-                    logger.warning(
-                        f"Error downloading file {virtual_path} "
-                        f"for workspace {workspace_id}: {e}"
-                    )
-                    return None
-
-            for i in range(0, len(files_to_download), download_batch_size):
-                batch = files_to_download[i : i + download_batch_size]
-                batch_results = await asyncio.gather(
-                    *[_download_file(f) for f in batch],
-                    return_exceptions=False,
-                )
-                for payload in batch_results:
-                    if payload is not None:
-                        upsert_payloads.append(payload)
-                    else:
-                        result["errors"] += 1
-
-            # 9. Bulk upsert all downloaded files
-            if upsert_payloads:
-                count = await bulk_upsert_files(workspace_id, upsert_payloads)
-                result["synced"] = count
-
-            # 10. Delete files from DB that no longer exist in sandbox
-            deleted = await delete_removed_files(workspace_id, active_paths)
-            result["deleted"] = deleted
-
-            result["total_size"] = await get_workspace_total_size(workspace_id)
-
-            logger.debug(
-                f"File sync completed for workspace {workspace_id}: "
-                f"synced={result['synced']}, skipped={result['skipped']}, "
-                f"deleted={result['deleted']}, errors={result['errors']}"
-            )
-
-        except Exception as e:
-            logger.error(f"File sync failed for workspace {workspace_id}: {e}")
-            raise
-
-        return result
-
-    @classmethod
+    @staticmethod
     async def restore_to_sandbox(
-        cls, workspace_id: str, sandbox: Any
+        workspace_id: str, sandbox: Any, *, expected_sandbox_id: Any = ANY_SANDBOX
     ) -> dict[str, Any]:
-        """
-        Restore workspace files from DB to sandbox.
-
-        Pre-creates all unique parent directories in one bulk mkdir, then
-        uploads files concurrently through a semaphore-bounded worker pool
-        so the next upload starts the instant any slot frees up (rather
-        than waiting for the slowest file in a fixed-size batch).
-
-        Args:
-            workspace_id: Workspace UUID
-            sandbox: Sandbox instance
-
-        Returns:
-            Restore result summary
-        """
-        result = {"restored": 0, "errors": 0}
-
-        try:
-            files = await get_files_for_workspace(workspace_id, include_content=True)
-
-            if not files:
-                logger.info(f"No files to restore for workspace {workspace_id}")
-                return result
-
-            logger.info(f"Restoring {len(files)} files for workspace {workspace_id}")
-
-            # Bulk-create unique parent directories in one exec call so
-            # we skip ~N redundant round-trips inside the per-file path.
-            work_dir = sandbox.working_dir
-            unique_dirs = {
-                os.path.dirname(f"{work_dir}/{file_record['file_path']}")
-                for file_record in files
-            }
-            unique_dirs.discard("")
-            unique_dirs.discard(work_dir)
-            if unique_dirs:
-                await cls._bulk_create_directories(sandbox, unique_dirs)
-
-            # Worker-pool upload: semaphore bounds concurrency, but each
-            # task releases its slot as soon as it finishes — no batch
-            # waits for the slowest file.
-            sem = asyncio.Semaphore(16)
-
-            async def _upload(file_record: dict) -> tuple[str, bool | Exception]:
-                async with sem:
-                    try:
-                        ok = await cls._restore_file_content_only(sandbox, file_record)
-                        return (file_record["file_path"], ok)
-                    except Exception as e:
-                        return (file_record["file_path"], e)
-
-            outcomes = await asyncio.gather(*(_upload(f) for f in files))
-            for path, res in outcomes:
-                if isinstance(res, Exception):
-                    logger.warning(f"Failed to restore {path}: {res}")
-                    result["errors"] += 1
-                elif res:
-                    result["restored"] += 1
-                else:
-                    result["errors"] += 1
-
-            # Write sync marker
-            try:
-                work_dir = sandbox.working_dir
-                marker_content = datetime.now(timezone.utc).isoformat().encode("utf-8")
-                await sandbox.aupload_file_bytes(_sync_marker_path(work_dir), marker_content)
-            except Exception:
-                pass  # Non-critical
-
-            # Update DB mtimes to match restored files' new sandbox mtimes
-            if result["restored"] > 0:
-                try:
-                    sandbox_meta = await cls.list_sandbox_files(sandbox)
-                    for vpath, info in sandbox_meta.items():
-                        if info["mtime"] > 0:
-                            await update_file_mtime(
-                                workspace_id,
-                                vpath,
-                                datetime.fromtimestamp(
-                                    info["mtime"], tz=timezone.utc
-                                ),
-                            )
-                except Exception as e:
-                    logger.warning(
-                        f"Mtime sync after restore failed for {workspace_id}: {e}"
-                    )
-
-            logger.info(
-                f"File restore completed for workspace {workspace_id}: "
-                f"restored={result['restored']}, errors={result['errors']}"
-            )
-
-        except Exception as e:
-            logger.error(f"File restore failed for workspace {workspace_id}: {e}")
-            raise
-
-        return result
-
-    @classmethod
-    async def _restore_single_file(cls, sandbox: Any, file_record: dict) -> bool:
-        """Restore a single file to sandbox, creating its parent directory.
-
-        Kept for callers outside the bulk restore path (e.g. single-file
-        writes). Bulk restore uses ``_restore_file_content_only`` after a
-        single pre-pass that creates all unique parents at once.
-        """
-        work_dir = sandbox.working_dir
-        abs_path = f"{work_dir}/{file_record['file_path']}"
-
-        parent_dir = os.path.dirname(abs_path)
-        if parent_dir and parent_dir != work_dir:
-            await sandbox.acreate_directory(parent_dir)
-
-        return await cls._restore_file_content_only(sandbox, file_record)
-
-    @classmethod
-    async def _restore_file_content_only(
-        cls, sandbox: Any, file_record: dict
-    ) -> bool:
-        """Upload file content assuming parent directory already exists."""
-        work_dir = sandbox.working_dir
-        abs_path = f"{work_dir}/{file_record['file_path']}"
-
-        if file_record.get("is_binary") and file_record.get("content_binary"):
-            content = file_record["content_binary"]
-            if isinstance(content, memoryview):
-                content = bytes(content)
-        elif file_record.get("content_text") is not None:
-            content = file_record["content_text"].encode("utf-8")
-        else:
-            return False
-
-        return await sandbox.aupload_file_bytes(abs_path, content)
-
-    @classmethod
-    async def _bulk_create_directories(
-        cls, sandbox: Any, dirs: set[str]
-    ) -> None:
-        """Pre-create all unique parent directories before bulk upload.
-
-        Uses the sandbox's bulk API (single ``mkdir -p`` exec for all
-        paths). Falls back to parallel per-dir creates if the bulk call
-        fails (e.g. command-line length exceeded for huge workspaces).
-        ``mkdir -p`` is idempotent either way.
-        """
-        if not sandbox or not dirs:
-            return
-
-        try:
-            if await sandbox.acreate_directories(dirs):
-                return
-            reason = "bulk mkdir reported failure"
-        except SandboxGoneError:
-            # Nothing to fall back to: per-dir creates would fail identically.
-            raise
-        except Exception as exc:
-            # The bulk call is an optimization, and its documented failure mode
-            # — one mkdir line too long for the shell — now normalizes to a
-            # typed transient instead of a False return. Falling back is still
-            # the right answer for it; only a gone sandbox is unrecoverable.
-            reason = str(exc)
-
-        logger.debug(
-            f"Bulk mkdir unavailable or failed for {len(dirs)} dirs ({reason}); "
-            "falling back to parallel per-dir creates."
+        return await restore.restore_to_sandbox(
+            workspace_id, sandbox, expected_sandbox_id=expected_sandbox_id
         )
-        sem = asyncio.Semaphore(16)
 
-        async def _mkone(d: str) -> None:
-            async with sem:
-                await sandbox.acreate_directory(d)
+    @staticmethod
+    async def maybe_restore(workspace_id: str, sandbox: Any) -> None:
+        await restore.maybe_restore(workspace_id, sandbox)
 
-        await asyncio.gather(*(_mkone(d) for d in dirs), return_exceptions=True)
+    @staticmethod
+    async def get_file_tree(workspace_id: str) -> list[dict[str, Any]]:
+        return await get_file_tree(workspace_id)
 
-    @classmethod
-    async def maybe_restore(cls, workspace_id: str, sandbox: Any) -> None:
-        """
-        Restore files from DB if sandbox was recreated (files lost).
-
-        Checks for sync marker file. If absent, files were lost and need restore.
-        """
-        try:
-            work_dir = sandbox.working_dir
-            sync_marker = _sync_marker_path(work_dir)
-            marker = await sandbox.adownload_file_bytes(sync_marker)
-            if marker is not None:
-                # Marker exists — sandbox still has its files
-                return
-
-            # Check if we have any files in DB to restore
-            files = await get_files_for_workspace(workspace_id, include_content=False)
-            if not files:
-                # No files saved — write marker and skip
-                try:
-                    marker_content = (
-                        datetime.now(timezone.utc).isoformat().encode("utf-8")
-                    )
-                    await sandbox.aupload_file_bytes(sync_marker, marker_content)
-                except Exception:
-                    pass
-                return
-
-            logger.info(
-                f"Sync marker missing for workspace {workspace_id}. "
-                f"Restoring {len(files)} files from DB."
-            )
-            await cls.restore_to_sandbox(workspace_id, sandbox)
-
-        except (SandboxGoneError, SandboxTransientError):
-            # Let a sandbox condition reach the caller as itself. The marker
-            # probe answering with a failure means we never learned whether the
-            # files are there, and flattening that into a generic warning here
-            # reads downstream as "checked, nothing to do" — which is how a
-            # recreated sandbox stays empty with no attributable reason.
-            raise
-        except Exception as e:
-            logger.warning(f"Error in maybe_restore for workspace {workspace_id}: {e}")
-
-    @classmethod
-    async def get_file_tree(cls, workspace_id: str) -> list[dict[str, Any]]:
-        """
-        Get file metadata from DB for offline UI browsing.
-
-        Returns flat list of file metadata (no content).
-        """
-        files = await get_files_for_workspace(workspace_id, include_content=False)
-        return [
-            {
-                "path": f["file_path"],
-                "name": f["file_name"],
-                "size": f["file_size"],
-                "mime_type": f.get("mime_type"),
-                "is_binary": f.get("is_binary", False),
-                "modified_at": f.get("sandbox_modified_at"),
-            }
-            for f in files
-        ]
-
-    @classmethod
+    @staticmethod
     async def get_file_content(
-        cls, workspace_id: str, file_path: str
+        workspace_id: str, file_path: str
     ) -> dict[str, Any] | None:
-        """
-        Get file content from DB for offline access.
-
-        Returns file record with content, or None if not found.
-        """
-        return await db_get_file(workspace_id, file_path, include_content=True)
+        return await get_file_content(workspace_id, file_path)

--- a/src/server/services/persistence/resolve.py
+++ b/src/server/services/persistence/resolve.py
@@ -1,0 +1,104 @@
+"""The single byte-resolution ladder shared by every read path.
+
+Inline columns, then the blob a row names, then the pack member it points
+into. Restore and every serving route come through here.
+"""
+
+import logging
+
+from src.server.database.workspace_file_blobs import (
+    BlobError,
+    fetch_blob,
+    fetch_blob_range,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FileBytesUnavailable(Exception):
+    """A file's bytes live in object storage and could not be read right now.
+
+    Distinct from "no such file": the manifest row exists and names a blob, so
+    the correct answer is a transient failure, not a 404.
+    """
+
+
+async def resolve_file_bytes(file_record: dict, *, user_id: str) -> bytes | None:
+    """Return a file record's raw bytes, from inline columns or its blob.
+
+    The single byte-resolution ladder for every read path. Inline columns are
+    checked with ``is not None`` rather than truthiness: a row holding ``b""``
+    or ``""`` is populated, and truthiness would turn an empty file into a 404
+    (or, for a blob-backed row, into a pointless network fetch). Returns
+    ``None`` only when the file genuinely has no content anywhere; raises
+    :class:`FileBytesUnavailable` when a blob it names can't be read.
+
+    ``user_id`` is the workspace owner's, which names the object-storage
+    namespace the row's digest lives in; the row itself carries no user.
+    """
+    content_binary = file_record.get("content_binary")
+    if content_binary is not None:
+        return bytes(content_binary) if isinstance(content_binary, memoryview) else content_binary
+
+    content_text = file_record.get("content_text")
+    if content_text is not None:
+        return content_text.encode("utf-8")
+
+    blob_sha256 = file_record.get("blob_sha256")
+    if blob_sha256:
+        try:
+            return await fetch_blob(user_id, blob_sha256)
+        except BlobError as e:
+            raise FileBytesUnavailable(str(e)) from e
+
+    pack_sha256 = file_record.get("pack_sha256")
+    if pack_sha256:
+        try:
+            return await fetch_blob_range(
+                user_id,
+                pack_sha256,
+                int(file_record.get("pack_offset") or 0),
+                int(file_record.get("file_size") or 0),
+                expected_sha256=file_record.get("content_hash"),
+            )
+        except BlobError as e:
+            raise FileBytesUnavailable(str(e)) from e
+
+    return None
+
+
+async def resolve_file_bytes_or_none(
+    file_record: dict, *, user_id: str, context: str
+) -> bytes | None:
+    """Resolve bytes for a route whose only credential is the URL itself.
+
+    An unfetchable blob collapses to the same ``None`` as an absent file. These
+    routes (``wsfiles``, the share-token endpoints) authenticate nothing beyond
+    an opaque id in the path, so answering 503 for "storage is down" and 404
+    for "no such file" would confirm to a guesser that a workspace and path
+    exist. The uniform answer is a security property — it lives here, in one
+    named policy, rather than as a rule each route is trusted to remember.
+    """
+    try:
+        return await resolve_file_bytes(file_record, user_id=user_id)
+    except FileBytesUnavailable as e:
+        logger.warning(f"Blob unavailable {context}: {e}")
+        return None
+
+
+async def resolve_file_text_or_none(
+    file_record: dict, *, user_id: str, context: str
+) -> str | None:
+    """:func:`resolve_file_bytes_or_none`, decoded. Same uniform-absent policy.
+
+    ``replace`` is a guard, not a decoding strategy: the write path only leaves
+    ``is_binary`` false after a strict UTF-8 decode of the whole file, so a
+    caller that honours the flag never reaches a replacement character. One
+    that doesn't gets mojibake instead of an exception.
+    """
+    data = await resolve_file_bytes_or_none(
+        file_record, user_id=user_id, context=context
+    )
+    if data is None:
+        return None
+    return data.decode("utf-8", errors="replace")

--- a/src/server/services/persistence/restore.py
+++ b/src/server/services/persistence/restore.py
@@ -1,0 +1,645 @@
+"""Restore a workspace's manifest into a sandbox that lost its files.
+
+Blob-backed rows are pulled by the sandbox itself from presigned URLs when
+transfer is ``direct``; everything else is uploaded from this process.
+"""
+
+import asyncio
+import hashlib
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from ptc_agent.core.sandbox.runtime import SandboxGoneError, SandboxTransientError
+from src.server.database.workspace_file import (
+    WorkspaceSyncBusy,
+    datetime_to_micros,
+    get_files_for_workspace,
+    workspace_sync_lock,
+)
+from src.server.database.workspace import (
+    ANY_SANDBOX,
+    files_restore_incomplete,
+    set_files_restore_incomplete,
+    workspace_owner,
+)
+from src.server.database.blob_keys import blob_key
+from src.server.database.workspace_file_blobs import fetch_blob
+from src.server.services.persistence._rows import (
+    _has_inline_bytes,
+    _mode_int,
+    _transfer_mode,
+)
+from src.server.services.persistence.resolve import (
+    FileBytesUnavailable,
+    resolve_file_bytes,
+)
+from src.server.services.persistence.transfer import (
+    all_unreachable,
+    pull_direct,
+    transfer_timeout_s,
+)
+from src.utils.storage import get_signed_url
+
+# Relayed restore uploads in flight. Higher than RELAY_CONCURRENCY because an
+# upload costs this process nothing but a socket, where a relayed backup also
+# holds the file's bytes in memory while it hashes and stores them.
+RESTORE_UPLOAD_CONCURRENCY = 16
+
+logger = logging.getLogger(__name__)
+
+
+# Two separate facts, deliberately kept in separate places because they have
+# different lifetimes and different readers:
+#
+#   .file_sync_marker (sandbox filesystem)
+#       "this sandbox has been populated". Dies with the sandbox, which is
+#       exactly what makes it the right signal for `maybe_restore` — its
+#       absence is how a recreated sandbox announces itself.
+#
+#   workspaces.files_restore_incomplete_at (Postgres)
+#       "a restore left files unrecovered". Gates pruning in `sync_to_db`.
+#
+# The second is not a fact about the sandbox, so it does not belong in one. A
+# restore fails per file for reasons the sandbox is not party to — most often a
+# blob that object storage would not hand back — and in that case the sandbox is
+# healthy and would happily store a marker saying otherwise. Postgres is where
+# this project keeps cross-worker truth, the next sync may run on a worker that
+# never saw the failed restore, and keeping the flag beside the manifest means
+# the flag and the rows it protects fail together rather than independently.
+def _sync_marker_path(work_dir: str) -> str:
+    """Return the sync marker file path for the given working directory."""
+    return f"{work_dir}/.file_sync_marker"
+
+
+_FLAG_CLEAR_ATTEMPTS = 3
+_FLAG_CLEAR_BACKOFF_S = 0.2
+
+
+class RestoreGuardUnavailable(Exception):
+    """The completeness flag could not be raised, so no restore was attempted."""
+
+
+class RestoreIdentityLost(RestoreGuardUnavailable):
+    """The row no longer names the sandbox this restore expected to replace:
+    another provisioner bound first, so no restore was attempted."""
+
+
+def _identity_of(sandbox: Any) -> Any:
+    return getattr(sandbox, "sandbox_id", None) or ANY_SANDBOX
+
+
+async def _clear_restore_flag(workspace_id: str, sandbox: Any, *, conn=None) -> None:
+    """Clear the flag for this sandbox only: a restore into a provisional
+    sandbox that then loses the identity race must not vouch for the winner.
+    Before the bind the row names a different sandbox and the clear is a
+    no-op; the post-bind reconcile repeats it once the row names this one."""
+    await set_files_restore_incomplete(
+        workspace_id, False, conn=conn, sandbox_id=_identity_of(sandbox)
+    )
+
+
+async def restore_to_sandbox(
+    workspace_id: str, sandbox: Any, *, expected_sandbox_id: Any = ANY_SANDBOX
+) -> dict[str, Any]:
+    """
+    Restore workspace files from the manifest into the sandbox.
+
+    Blob-backed files are fetched by the sandbox itself from presigned
+    URLs when transfer is ``direct``; rows that still carry inline bytes
+    (or every file under ``relay``) are uploaded from here. Directories
+    and symlinks always go through the sandbox runtime, which needs no
+    network for them. Modes and mtimes are set from the manifest, so no
+    second pass is needed to learn what the sandbox now has.
+
+    Serialized with ``sync_to_db`` on the workspace's lock: a sync that
+    scanned the sandbox while a restore was still filling it, then read
+    the completeness flag after the restore cleared it, would prune every
+    row its stale scan had not seen arrive.
+
+    Returns:
+        Restore result summary
+    """
+    # Raised before the lock is even requested, cleared only once the whole
+    # restore came back clean. Both callers swallow every raise as a warning,
+    # a lock wait that times out included, and an unflagged sandbox is then
+    # an empty mirror of a full manifest, which the next sync prunes. Raising
+    # it after the timeout instead would let it land on top of a restore
+    # that another worker completed while this one waited: that worker
+    # clears the flag as its last step before releasing the lock, which is
+    # after any wait on that lock began, so a write made before the wait
+    # is always the older of the two.
+    # The raise names the sandbox the row is expected to hold, the same one
+    # the caller's identity CAS will expect to replace. A provisioner slow
+    # enough to reach this after another has bound and reconciled would
+    # otherwise leave a flag standing on the winner's sandbox that nothing
+    # clears until the next start, with pruning withheld all the while.
+    try:
+        landed = await set_files_restore_incomplete(
+            workspace_id, True, sandbox_id=expected_sandbox_id
+        )
+    except Exception as e:
+        # Without the guard an empty sandbox is indistinguishable from an
+        # emptied workspace, so no restore may begin: the caller has to abort
+        # provisioning rather than bind a sandbox the next backup would read
+        # as the user having deleted everything.
+        raise RestoreGuardUnavailable(workspace_id) from e
+    if not landed:
+        raise RestoreIdentityLost(workspace_id)
+    try:
+        async with workspace_sync_lock(workspace_id) as conn:
+            return await _restore_locked(workspace_id, sandbox, conn)
+    except WorkspaceSyncBusy:
+        logger.warning(f"File restore for workspace {workspace_id} timed out waiting for the sync lock")
+        raise
+    except Exception as e:
+        logger.error(f"File restore failed for workspace {workspace_id}: {e}")
+        raise
+
+
+async def _restore_locked(
+    workspace_id: str, sandbox: Any, conn: Any
+) -> dict[str, Any]:
+    result = {"restored": 0, "errors": 0}
+
+    rows = await get_files_for_workspace(
+        workspace_id, include_content=True, all_kinds=True, conn=conn
+    )
+
+    if not rows:
+        # An empty manifest is mirrored completely by any sandbox.
+        logger.info(f"No files to restore for workspace {workspace_id}")
+        await _clear_restore_flag(workspace_id, sandbox, conn=conn)
+        return result
+
+    logger.info(f"Restoring {len(rows)} entries for workspace {workspace_id}")
+
+    # Object keys are scoped to the owner; read once for the whole restore.
+    user_id = await workspace_owner(workspace_id, conn=conn)
+
+    mode = _transfer_mode(sandbox)
+    structural: list[dict[str, Any]] = []
+    direct: list[dict[str, Any]] = []
+    packs: dict[str, list[dict[str, Any]]] = {}
+    relay: list[dict[str, Any]] = []
+    total_bytes = 0
+
+    for row in rows:
+        if row.get("kind", "file") != "file":
+            structural.append(_pull_item(row, url=None))
+            continue
+        pointer = row.get("pack_sha256") or row.get("blob_sha256")
+        if mode == "direct" and not _has_inline_bytes(row) and pointer:
+            total_bytes += int(row.get("file_size") or 0)
+            if row.get("pack_sha256"):
+                packs.setdefault(row["pack_sha256"], []).append(row)
+            direct.append(row)
+        else:
+            relay.append(row)
+
+    if direct:
+        items, unsigned = await _signed_pull_items(
+            user_id, direct, packs, transfer_timeout_s(total_bytes) + 60
+        )
+        relay += unsigned
+        direct_paths: set[str] = set()
+        for i in items:
+            if i.get("kind") == "pack":
+                direct_paths.update(m["path"] for m in i["members"])
+            else:
+                direct_paths.add(i["path"])
+        # Directories stay open while a relay pass still has files to
+        # place under them; that pass closes them. A store the sandbox
+        # turns out not to reach reopens them on the same terms.
+        results = await pull_direct(
+            sandbox, structural + items, defer_dir_modes=bool(relay)
+        )
+        direct_results = {p: r for p, r in results.items() if p in direct_paths}
+        unreachable_paths = {
+            p for p, r in direct_results.items() if r.get("status") == "unreachable"
+        }
+        if unreachable_paths:
+            if all_unreachable(direct_results):
+                logger.warning(
+                    f"Sandbox for workspace {workspace_id} could not reach "
+                    f"object storage; restoring {len(items)} file(s) through "
+                    f"the server"
+                )
+            else:
+                logger.warning(
+                    f"{len(unreachable_paths)} of {len(items)} direct "
+                    f"download(s) for workspace {workspace_id} could not "
+                    f"reach object storage; restoring those through the server"
+                )
+            results = {p: r for p, r in results.items() if p not in unreachable_paths}
+        # The store would not sign it, or the sandbox could not reach it:
+        # both end in the same place, so they join the relay list together.
+        relay += [r for r in direct if r["file_path"] in unreachable_paths]
+        _tally_pull(workspace_id, results, result)
+    elif structural:
+        results = await pull_direct(
+            sandbox, structural, defer_dir_modes=bool(relay)
+        )
+        _tally_pull(workspace_id, results, result)
+
+    if relay:
+        dirs = [i for i in structural if i.get("kind") == "dir"]
+        await _restore_relay(user_id, workspace_id, sandbox, relay, result, dirs)
+
+    complete = result["errors"] == 0
+
+    # The marker only claims "this sandbox has been populated", so it
+    # goes in the sandbox and is withheld on a partial restore to make
+    # the next start retry. A sandbox failure here propagates: every
+    # file just restored through this same sandbox, so one failing now
+    # is a real condition, and swallowing it is what leaves a recreated
+    # sandbox looking populated with no attributable reason. False is
+    # the only outcome left to check — path validation rejected it.
+    if complete:
+        marker_written = await sandbox.aupload_file_bytes(
+            _sync_marker_path(sandbox.working_dir),
+            datetime.now(timezone.utc).isoformat().encode("utf-8"),
+        )
+        if not marker_written:
+            # Costs one redundant restore next start. Safe in the
+            # direction that matters: nothing is deleted on its account.
+            logger.warning(
+                f"Could not write the sync marker for workspace "
+                f"{workspace_id}; the next start will restore again"
+            )
+        # Last, on the lock connection: a worker whose wait on this lock
+        # timed out flagged the workspace before it began waiting, and
+        # this clear has to be the later write (see restore_to_sandbox).
+        await _clear_restore_flag(workspace_id, sandbox, conn=conn)
+    else:
+        logger.warning(
+            f"Restore for workspace {workspace_id} left {result['errors']} "
+            f"file(s) unrestored; the workspace stays flagged so the next "
+            f"start retries and sync leaves the manifest alone"
+        )
+
+    logger.info(
+        f"File restore completed for workspace {workspace_id}: "
+        f"restored={result['restored']}, errors={result['errors']}"
+    )
+
+    return result
+
+
+async def _signed_pull_items(
+    user_id: str,
+    direct: list[dict[str, Any]],
+    packs: dict[str, list[dict[str, Any]]],
+    expires: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Presign one URL per object and per chunk, largest item first.
+
+    Returns the items the sandbox can pull and the rows the store would not
+    sign, which the caller relays alongside anything the sandbox then fails
+    to reach.
+    """
+    items: list[dict[str, Any]] = []
+    unsigned: list[dict[str, Any]] = []
+    for row in direct:
+        if row.get("pack_sha256"):
+            continue
+        url = await asyncio.to_thread(
+            get_signed_url, blob_key(user_id, row["blob_sha256"]), expires
+        )
+        if url is None:
+            unsigned.append(row)
+            continue
+        items.append(_pull_item(row, url=url))
+    # One item per chunk; the runtime slices the members out.
+    for pack_sha256, members in packs.items():
+        url = await asyncio.to_thread(
+            get_signed_url, blob_key(user_id, pack_sha256), expires
+        )
+        if url is None:
+            unsigned.extend(members)
+            continue
+        items.append(
+            {
+                "kind": "pack",
+                "sha256": pack_sha256,
+                "size": sum(int(m.get("file_size") or 0) for m in members),
+                "url": url,
+                "members": [_pack_member_item(m) for m in members],
+            }
+        )
+    # Largest first: a big object that starts last is the tail.
+    items.sort(key=lambda i: int(i.get("size") or 0), reverse=True)
+    return items, unsigned
+
+
+def _pull_item(row: dict[str, Any], *, url: str | None) -> dict[str, Any]:
+    modified = row.get("sandbox_modified_at")
+    micros = datetime_to_micros(modified)
+    mtime_ns = micros * 1000 if micros is not None else None
+    return {
+        "path": row["file_path"],
+        "kind": row.get("kind", "file"),
+        "sha256": row.get("blob_sha256"),
+        "size": int(row.get("file_size") or 0),
+        "url": url,
+        "mode": _mode_int(row.get("permissions"), row.get("kind", "file")),
+        "mtime_ns": mtime_ns,
+        "symlink_target": row.get("symlink_target"),
+    }
+
+
+def _pack_member_item(row: dict[str, Any]) -> dict[str, Any]:
+    item = _pull_item(row, url=None)
+    return {
+        "path": item["path"],
+        "offset": int(row.get("pack_offset") or 0),
+        "size": item["size"],
+        "sha256": row.get("content_hash"),
+        "mode": item["mode"],
+        "mtime_ns": item["mtime_ns"],
+    }
+
+
+def _tally_pull(
+    workspace_id: str, results: dict[str, dict[str, Any]], result: dict[str, Any]
+) -> None:
+    for path, r in results.items():
+        if r.get("status") == "ok":
+            result["restored"] += 1
+        else:
+            result["errors"] += 1
+            logger.warning(
+                f"Failed to restore {path} for workspace {workspace_id}: "
+                f"{r.get('status')} http={r.get('http')} {r.get('error')}"
+            )
+
+
+async def _restore_relay(
+    user_id: str,
+    workspace_id: str,
+    sandbox: Any,
+    rows: list[dict[str, Any]],
+    result: dict[str, Any],
+    dirs: list[dict[str, Any]] | None = None,
+) -> None:
+    """Upload file rows from this process and let the runtime place them.
+
+    Nothing is uploaded to its final path. A plain file lands under a
+    scan-excluded staging name and a pack travels whole; one pull op then
+    verifies each against the manifest, moves it into place, and stamps
+    modes and mtimes. An upload cut short (a full disk) therefore fails
+    verification instead of becoming the file's next content at the next
+    backup. ``dirs`` are the structure pass's directory items, carried again
+    so their modes and mtimes are applied after the last file is in.
+    """
+    sem = asyncio.Semaphore(RESTORE_UPLOAD_CONCURRENCY)
+
+    async def _stage(row: dict) -> tuple[dict, tuple[str, str, int] | None]:
+        async with sem:
+            try:
+                return (row, await _stage_relayed_file(user_id, sandbox, row))
+            except Exception as e:
+                logger.warning(f"Failed to restore {row['file_path']}: {e}")
+                return (row, None)
+
+    # Packed rows travel as whole chunks, one at a time, and are sliced
+    # in the sandbox; see _relayed_pack_items.
+    packs: dict[str, list[dict[str, Any]]] = {}
+    plain: list[dict[str, Any]] = []
+    for r in rows:
+        if r.get("pack_sha256") and not _has_inline_bytes(r):
+            packs.setdefault(r["pack_sha256"], []).append(r)
+        else:
+            plain.append(r)
+
+    items: list[dict[str, Any]] = []
+    for row, staged in await asyncio.gather(*(_stage(r) for r in plain)):
+        if staged is None:
+            result["errors"] += 1
+            continue
+        name, digest, n = staged
+        if digest != row.get("content_hash"):
+            # The row's own digest no longer decides placement, so a row that
+            # cannot reproduce it would otherwise pass through unremarked.
+            logger.warning(
+                f"Row for {row['file_path']} in workspace {workspace_id} "
+                f"stores bytes that do not reproduce its own content_hash; "
+                f"restoring the bytes the row stores"
+            )
+        item = _pull_item(row, url=None)
+        item.update({"file": name, "sha256": digest, "size": n})
+        items.append(item)
+    if packs:
+        items += await _relayed_pack_items(user_id, workspace_id, sandbox, packs, result)
+    if not items and not dirs:
+        return
+
+    file_paths: set[str] = set()
+    for i in items:
+        if i.get("kind") == "pack":
+            file_paths.update(m["path"] for m in i["members"])
+        else:
+            file_paths.add(i["path"])
+    try:
+        outcomes = await pull_direct(sandbox, items + list(dirs or []))
+    except Exception as e:
+        logger.warning(
+            f"Could not place {len(file_paths)} relayed file(s) for workspace "
+            f"{workspace_id}: {e}"
+        )
+        result["errors"] += len(file_paths)
+        return
+    _tally_pull(
+        workspace_id, {p: r for p, r in outcomes.items() if p in file_paths}, result
+    )
+    for path, r in outcomes.items():
+        if path not in file_paths and r.get("status") != "ok":
+            # The directory itself was counted by the structure pass; a
+            # failed final mode or mtime is still a restore error, or the
+            # next backup records the wrong metadata as the user's.
+            result["errors"] += 1
+            logger.warning(
+                f"Could not stamp {path} for workspace {workspace_id}: "
+                f"{r.get('status')} {r.get('error')}"
+            )
+
+
+def _staging_name() -> str:
+    """A root-level name the scan skips and the sandbox file API accepts.
+
+    The pack directory would be the natural home, but the file API keeps
+    everything under ``_internal`` off limits; the ``.wsfiles-`` prefix is
+    excluded from the scan, so a restore that dies here leaves nothing the
+    next backup would record as a user's file.
+    """
+    return f".wsfiles-relay-{uuid.uuid4().hex}"
+
+
+async def _stage_relayed_file(
+    user_id: str, sandbox: Any, file_record: dict
+) -> tuple[str, str, int] | None:
+    """Upload one row's bytes; returns the staging name, their digest and length.
+
+    Byte resolution happens here rather than in the caller so blob fetches
+    run under the restore semaphore: concurrency is bounded for free.
+
+    The digest and length describe the bytes actually sent, not the row's
+    ``content_hash`` and ``file_size``. The check they feed asks whether the
+    upload arrived whole, which only a measurement of what was sent can
+    answer, and a row whose ``file_size`` came from a stat rather than from
+    the content can state a length its own bytes disagree with.
+    """
+    try:
+        content = await resolve_file_bytes(file_record, user_id=user_id)
+    except FileBytesUnavailable as e:
+        logger.warning(f"Cannot restore {file_record['file_path']}: {e}")
+        return None
+    if content is None:
+        return None
+    staged = _staging_name()
+    if not await sandbox.aupload_file_bytes(f"{sandbox.working_dir}/{staged}", content):
+        return None
+    return staged, hashlib.sha256(content).hexdigest(), len(content)
+
+
+async def _relayed_pack_items(
+    user_id: str,
+    workspace_id: str,
+    sandbox: Any,
+    packs: dict[str, list[dict[str, Any]]],
+    result: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Relay each chunk whole; returns the pull items that slice them in place.
+
+    Uploading members one by one costs a call per file and loses what
+    the runtime's extractor keeps: names the upload API cannot carry
+    (a trailing space, a newline), modes and mtimes. One upload per
+    chunk keeps the relay path at the direct path's fidelity, and memory
+    at one chunk at a time.
+    """
+    work_dir = sandbox.working_dir
+    items: list[dict[str, Any]] = []
+    for pack_sha256, members in packs.items():
+        rel = f".wsfiles-relay-{pack_sha256}"
+        try:
+            data = await fetch_blob(user_id, pack_sha256)
+            size = len(data)
+            ok = await sandbox.aupload_file_bytes(f"{work_dir}/{rel}", data)
+            del data
+        except Exception as e:
+            ok = False
+            logger.warning(f"Could not relay pack {pack_sha256} for workspace {workspace_id}: {e}")
+        if not ok:
+            result["errors"] += len(members)
+            continue
+        items.append(
+            {
+                "kind": "pack",
+                "file": rel,
+                "sha256": pack_sha256,
+                "size": size,
+                "members": [_pack_member_item(m) for m in members],
+            }
+        )
+    return items
+
+
+async def _reconcile_flag_beside_marker(workspace_id: str, sandbox: Any) -> None:
+    """Clear a flag left standing beside a marker, retrying a failed write.
+
+    This is the last chance on the provisioning path: a warm session is
+    never reconciled again, so a failure here withholds pruning until the
+    sandbox is next recreated, and that recreation restores files the user
+    had deleted. Each attempt checks out its own connection, so a failed
+    statement does not poison the next one."""
+    for attempt in range(1, _FLAG_CLEAR_ATTEMPTS + 1):
+        try:
+            if await files_restore_incomplete(workspace_id):
+                await _clear_restore_flag(workspace_id, sandbox)
+            return
+        except Exception as e:
+            if attempt == _FLAG_CLEAR_ATTEMPTS:
+                # Returning, not raising: the sandbox this runs on is
+                # complete and healthy, and the next cold start reconciles
+                # again from the same marker. Failing provisioning here
+                # would destroy it over a database that is briefly down.
+                logger.error(
+                    f"Could not clear the completeness flag for workspace "
+                    f"{workspace_id} after {attempt} attempts; pruning stays "
+                    f"withheld until the next restore: {e}"
+                )
+                return
+            await asyncio.sleep(_FLAG_CLEAR_BACKOFF_S * attempt)
+
+
+async def maybe_restore(workspace_id: str, sandbox: Any) -> None:
+    """
+    Restore files from DB if sandbox was recreated (files lost).
+
+    Checks for sync marker file. If absent, files were lost and need restore.
+    """
+    try:
+        work_dir = sandbox.working_dir
+        sync_marker = _sync_marker_path(work_dir)
+        marker = await sandbox.adownload_file_bytes(sync_marker)
+        if marker is not None:
+            # The marker is written only by a restore that came back clean
+            # and then clears the flag; a flag still standing beside it is
+            # a restore that died between those two writes, and left alone
+            # it would withhold pruning on every backup from here on.
+            await _reconcile_flag_beside_marker(workspace_id, sandbox)
+            return
+
+        # Every kind, not just ``kind='file'``: a workspace of directories
+        # and symlinks is not an empty one, and reading it as empty writes
+        # the marker and clears the flag, after which the next backup prunes
+        # the structural rows it never saw restored.
+        try:
+            files = await get_files_for_workspace(
+                workspace_id, include_content=False, all_kinds=True
+            )
+        except Exception as e:
+            # Not knowing the manifest is the same hazard as not raising the
+            # flag: the sandbox is empty, nothing marks it as unrestored,
+            # and the next backup reads the emptiness as deletions.
+            raise RestoreGuardUnavailable(
+                f"Could not read the manifest for workspace {workspace_id}: {e}"
+            ) from e
+        if not files:
+            # Nothing to restore, so the sandbox trivially matches the
+            # manifest — record it, or every start repeats this check.
+            # The flag goes first: it is the half that gates deletion, and
+            # an empty manifest has nothing left to protect either way,
+            # whereas a sandbox failure on the marker write belongs to the
+            # caller and is left to propagate.
+            await _clear_restore_flag(workspace_id, sandbox)
+            await sandbox.aupload_file_bytes(
+                sync_marker,
+                datetime.now(timezone.utc).isoformat().encode("utf-8"),
+            )
+            return
+
+        logger.info(
+            f"Sync marker missing for workspace {workspace_id}. "
+            f"Restoring {len(files)} files from DB."
+        )
+        await restore_to_sandbox(
+            workspace_id, sandbox, expected_sandbox_id=_identity_of(sandbox)
+        )
+
+    except RestoreGuardUnavailable:
+        # The caller aborts provisioning on this one; on the lazy-start and
+        # reconnect paths this is the only restore, and swallowing it here
+        # would publish an empty, unflagged sandbox for the next sync to
+        # read as an emptied workspace.
+        raise
+    except (SandboxGoneError, SandboxTransientError):
+        # Let a sandbox condition reach the caller as itself. The marker
+        # probe answering with a failure means we never learned whether the
+        # files are there, and flattening that into a generic warning here
+        # reads downstream as "checked, nothing to do" — which is how a
+        # recreated sandbox stays empty with no attributable reason.
+        raise
+    except Exception as e:
+        logger.warning(f"Error in maybe_restore for workspace {workspace_id}: {e}")

--- a/src/server/services/persistence/transfer.py
+++ b/src/server/services/persistence/transfer.py
@@ -1,0 +1,371 @@
+"""Drive the sandbox-side file transfer runtime.
+
+The runtime (``wsfiles_transfer_runtime.py``, shipped to
+``_internal/src/wsfiles_transfer.py``) walks, hashes and moves workspace
+files inside the sandbox. This module hands it a JSON spec, runs it, and
+reads the JSON it writes back. The server never holds file bytes on this
+path; it holds paths, digests and presigned URLs.
+
+The two JSON files travel through ``_internal/`` with the raw runtime calls
+rather than the agent-facing upload helpers: ``_internal`` is on the agent's
+denylist by design, and this exchange is the server's, not the agent's.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import shlex
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from ptc_agent.core.paths import (
+    ALWAYS_HIDDEN_DIR_NAMES,
+    BACKUP_EXCLUDE_AGENT_SUBDIRS,
+    BACKUP_EXCLUDE_DIRS,
+    HIDDEN_DIR_NAMES,
+)
+from ptc_agent.core.sandbox._shared import (
+    _TRANSFER_RUNTIME_SOURCE,
+    TRANSFER_RUNTIME_SANDBOX_NAME,
+)
+from ptc_agent.core.sandbox.wsfiles_transfer_runtime import RESULT_MARKER
+from ptc_agent.core.sandbox.retry import RetryPolicy
+
+logger = logging.getLogger(__name__)
+
+# Directory names pruned at any depth. ``__pycache__`` was only ever filtered
+# by its contents' names before.
+EXCLUDE_DIR_NAMES: frozenset[str] = (
+    BACKUP_EXCLUDE_DIRS | HIDDEN_DIR_NAMES | ALWAYS_HIDDEN_DIR_NAMES | {"__pycache__"}
+)
+# The skill reconciler's scratch space, which must never be restored on top
+# of a live reconcile. Matched by workspace-relative path: the same names
+# anywhere else (``work/model/.staging``) are the user's own directories.
+SKILLS_DIR = ".agents/skills"
+EXCLUDE_REL_DIRS: tuple[str, ...] = (
+    *BACKUP_EXCLUDE_AGENT_SUBDIRS,
+    f"{SKILLS_DIR}/.staging",
+)
+EXCLUDE_REL_DIR_PREFIXES: tuple[str, ...] = (f"{SKILLS_DIR}/.trash-",)
+# The reconciler's lock file, at its one path; a user's own
+# ``results/.skills-sync.flock`` is a file like any other.
+EXCLUDE_REL_FILES: tuple[str, ...] = (f"{SKILLS_DIR}/.skills-sync.flock",)
+EXCLUDE_SUFFIXES: frozenset[str] = frozenset({".pyc", ".pyo", ".so", ".dylib", ".o"})
+EXCLUDE_BASENAMES: frozenset[str] = frozenset({".DS_Store", "Thumbs.db", "__init__.py"})
+
+SYNC_MARKER_NAME = ".file_sync_marker"
+
+SCAN_TIMEOUT_S = 300
+# Transfer timeouts scale with bytes at a floor bandwidth so a large workspace
+# on a slow link is not cut off, while an idle exchange still ends.
+TRANSFER_FLOOR_BYTES_PER_S = 1024 * 1024
+TRANSFER_MIN_TIMEOUT_S = 300
+TRANSFER_MAX_TIMEOUT_S = 3600
+
+# The sandbox runs on a one-CPU quota, and the runtime's CPU per item grows
+# with its thread count (a 300-file pull: 1.0 s of CPU at 16 threads, 3.5 s
+# at 64) while the store answers in ~80 ms per GET and ~210 ms per PUT.
+# These are the measured knees; wider pools throttle, and the tail grows.
+PUSH_CONCURRENCY = 16
+PULL_CONCURRENCY = 32
+
+# Files at or below the cutoff travel as members of a pack: one object per
+# chunk of the workspace instead of one per file. The transfer cost is per
+# object, and the small files are most of the objects while being almost
+# none of the bytes. The chunk cap bounds what one small edit re-uploads and
+# what a restore holds in flight; chunks are written under PACK_DIR, which the
+# scan already excludes, and are removed once pushed.
+PACK_CUTOFF = 256 * 1024
+PACK_MAX_BYTES = 32 * 1024 * 1024
+PACK_DIR = "_internal/packs"
+
+
+class TransferRuntimeError(Exception):
+    """The runtime itself could not run or answer; not a per-item failure."""
+
+
+@dataclass(slots=True)
+class ScanEntry:
+    path: str
+    kind: str
+    size: int
+    mtime_ns: int
+    mode: int
+    sha256: str | None
+    symlink_target: str | None
+    is_binary: bool | None
+
+
+@dataclass(slots=True)
+class ScanResult:
+    entries: list[ScanEntry]
+    oversized: list[dict[str, Any]]
+    errors: list[dict[str, Any]]
+    hashed: int
+    reused: int
+
+
+def transfer_timeout_s(total_bytes: int) -> int:
+    scaled = TRANSFER_MIN_TIMEOUT_S + total_bytes // TRANSFER_FLOOR_BYTES_PER_S
+    return int(min(max(scaled, TRANSFER_MIN_TIMEOUT_S), TRANSFER_MAX_TIMEOUT_S))
+
+
+def exclusion_spec(max_file_bytes: int) -> dict[str, Any]:
+    return {
+        "exclude_dir_names": sorted(EXCLUDE_DIR_NAMES),
+        "exclude_rel_dirs": list(EXCLUDE_REL_DIRS),
+        "exclude_rel_dir_prefixes": list(EXCLUDE_REL_DIR_PREFIXES),
+        "exclude_rel_files": list(EXCLUDE_REL_FILES),
+        "exclude_basenames": sorted(EXCLUDE_BASENAMES),
+        # The sync marker and every transient file the runtime or the relay
+        # writes sit at the root; anywhere deeper the name is the user's own,
+        # and a basename exclusion would drop ``results/.file_sync_marker``
+        # from the scan and prune its row. The marker is one exact name: a
+        # root ``.file_sync_marker.bak`` is a user file too.
+        "exclude_root_basenames": [SYNC_MARKER_NAME],
+        "exclude_root_basename_prefixes": [".wsfiles-"],
+        "exclude_suffixes": sorted(EXCLUDE_SUFFIXES),
+        "max_file_bytes": max_file_bytes,
+    }
+
+
+def _script_path(sandbox: Any) -> str:
+    return f"{sandbox.working_dir}/_internal/src/{TRANSFER_RUNTIME_SANDBOX_NAME}"
+
+
+async def _upload_runtime(sandbox: Any) -> None:
+    """Ship the runtime to a sandbox that lacks it or runs a stale copy.
+
+    The asset sync delivers it on every fresh sandbox and on the first sync
+    after a deploy; a warm sandbox between those two moments still needs it.
+    """
+    script = _script_path(sandbox)
+    source = _TRANSFER_RUNTIME_SOURCE.read_bytes()
+    await sandbox._runtime_call(
+        sandbox.runtime.upload_file, source, script, retry_policy=RetryPolicy.SAFE
+    )
+    logger.info(f"Uploaded the file transfer runtime to {script}")
+
+
+# A single argv string tops out at 128 KiB on Linux; below this the spec rides
+# on the command line and the op is one round trip to the sandbox.
+INLINE_SPEC_LIMIT = 96 * 1024
+
+
+def _parse_result(stdout: str) -> dict[str, Any] | None:
+    """The runtime's result line, or None when no result was printed."""
+    for line in reversed((stdout or "").splitlines()):
+        if line.startswith(RESULT_MARKER):
+            return json.loads(line[len(RESULT_MARKER):])
+    return None
+
+
+def _slowest(out: dict[str, Any]) -> str:
+    """Suffix with the per-item latency spread, for the transfer timing line."""
+    results = out.get("results")
+    if not isinstance(results, dict) or not results:
+        return ""
+    timed = sorted(
+        ((r or {}).get("ms") or 0, key) for key, r in results.items() if (r or {}).get("ms")
+    )
+    if not timed:
+        return ""
+    q = lambda f: timed[min(len(timed) - 1, int(f * len(timed)))][0]  # noqa: E731
+    ms, key = timed[-1]
+    return f", per item p50={q(0.5)} p90={q(0.9)} p99={q(0.99)} max={ms} ms ({key})"
+
+
+async def run_transfer_op(
+    sandbox: Any, op: str, spec: dict[str, Any], *, timeout_s: int
+) -> dict[str, Any]:
+    """Run one runtime subcommand and return its output document.
+
+    One exec when the spec fits an argument, two when it has to be uploaded.
+    A sandbox without the runtime, or with one that predates this exchange,
+    exits 2 without a result line; the runtime is uploaded and the op rerun.
+    """
+    script = _script_path(sandbox)
+    runtime = sandbox.runtime
+    payload = json.dumps(spec, separators=(",", ":")).encode("utf-8")
+    encoded = base64.b64encode(payload).decode("ascii")
+    started = time.monotonic()
+    # One path for every attempt: the runtime removes the spec file once it
+    # has read it, and a rerun after a runtime upload reuses the name so a
+    # copy a stale runtime never read is taken by the one that replaces it.
+    in_path = f"{sandbox.working_dir}/_internal/.wsfiles/{op}-{uuid.uuid4().hex}.json"
+
+    async def _run() -> Any:
+        if len(encoded) <= INLINE_SPEC_LIMIT:
+            cmd = f"python3 {shlex.quote(script)} {op} --spec-b64 {encoded}"
+        else:
+            await sandbox._runtime_call(
+                runtime.upload_file, payload, in_path, retry_policy=RetryPolicy.SAFE
+            )
+            cmd = f"python3 {shlex.quote(script)} {op} {shlex.quote(in_path)}"
+        return await sandbox._runtime_call(
+            runtime.exec, cmd, timeout_s, retry_policy=RetryPolicy.SAFE
+        )
+
+    res = await _run()
+    out = _parse_result(res.stdout)
+    if out is None and res.exit_code == 2:
+        await _upload_runtime(sandbox)
+        res = await _run()
+        out = _parse_result(res.stdout)
+    if out is None:
+        tail = (res.stdout or "")[-2000:]
+        raise TransferRuntimeError(
+            f"wsfiles_transfer {op} exited {res.exit_code} without a result: {tail}"
+        )
+    if not isinstance(out, dict):
+        raise TransferRuntimeError(f"wsfiles_transfer {op} wrote a non-object")
+    if out.get("error"):
+        # The runtime caught its own crash and reported it instead of
+        # a result set; nothing below is trustworthy.
+        raise TransferRuntimeError(f"wsfiles_transfer {op} failed: {out['error']}")
+    hs = out.get("handshakes") or {}
+    hs_note = (
+        f", tls full={hs.get('full', 0)} resumed={hs.get('resumed', 0)}"
+        if isinstance(hs, dict) and hs
+        else ""
+    )
+    logger.info(
+        f"wsfiles_transfer {op}: {len(spec.get('items') or [])} item(s) in "
+        f"{time.monotonic() - started:.1f}s{_slowest(out)}{hs_note}"
+    )
+    return out
+
+
+async def scan_workspace(
+    sandbox: Any,
+    prior: dict[str, tuple[int, int, str]],
+    *,
+    max_file_bytes: int,
+) -> ScanResult:
+    """Walk and hash the workspace. ``prior`` lets unchanged files skip hashing."""
+    spec = exclusion_spec(max_file_bytes)
+    spec["root"] = sandbox.working_dir
+    spec["prior"] = {p: list(v) for p, v in prior.items()}
+    out = await run_transfer_op(sandbox, "scan", spec, timeout_s=SCAN_TIMEOUT_S)
+    # A runtime that predates the exact-name key reports the marker as a
+    # file; a manifest row for it would restore a "populated" claim into a
+    # sandbox before its files arrive, so the server drops it as well.
+    entries = [
+        ScanEntry(
+            path=e["path"],
+            kind=e["kind"],
+            size=int(e.get("size") or 0),
+            mtime_ns=int(e.get("mtime_ns") or 0),
+            mode=int(e.get("mode") or 0),
+            sha256=e.get("sha256"),
+            symlink_target=e.get("symlink_target"),
+            is_binary=e.get("is_binary"),
+        )
+        for e in out.get("entries", [])
+        if e["path"] != SYNC_MARKER_NAME
+    ]
+    return ScanResult(
+        entries=entries,
+        oversized=out.get("oversized", []),
+        errors=out.get("errors", []),
+        hashed=int(out.get("hashed") or 0),
+        reused=int(out.get("reused") or 0),
+    )
+
+
+async def push_direct(
+    sandbox: Any, items: list[dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    """Upload ``items`` (path, sha256, size, url, headers) from the sandbox.
+
+    Returns per-digest results: ``ok``, ``changed``, ``failed``, ``unreachable``.
+    """
+    if not items:
+        return {}
+    total = sum(int(i["size"]) for i in items)
+    spec = {
+        "root": sandbox.working_dir,
+        "concurrency": PUSH_CONCURRENCY,
+        "timeout_s": TRANSFER_MIN_TIMEOUT_S,
+        "items": items,
+    }
+    out = await run_transfer_op(
+        sandbox, "push", spec, timeout_s=transfer_timeout_s(total)
+    )
+    return out.get("results", {})
+
+
+async def pull_direct(
+    sandbox: Any, items: list[dict[str, Any]], *, defer_dir_modes: bool = False
+) -> dict[str, dict[str, Any]]:
+    """Materialize ``items`` in the sandbox. Returns per-path results.
+
+    ``defer_dir_modes`` leaves directories writable because a later op will
+    place more files under them; that op carries the directory items again
+    and applies their modes and mtimes once everything is in.
+    """
+    if not items:
+        return {}
+    total = sum(int(i.get("size") or 0) for i in items)
+    spec = {
+        "root": sandbox.working_dir,
+        "concurrency": PULL_CONCURRENCY,
+        "timeout_s": TRANSFER_MIN_TIMEOUT_S,
+        "items": items,
+    }
+    if defer_dir_modes:
+        spec["defer_dir_modes"] = True
+    out = await run_transfer_op(
+        sandbox, "pull", spec, timeout_s=transfer_timeout_s(total)
+    )
+    return out.get("results", {})
+
+
+async def pack_direct(
+    sandbox: Any, members: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Concatenate ``members`` (path, sha256, size) into chunk files in the sandbox.
+
+    Returns ``{"chunks": [{path, sha256, size, members: [{path, offset, size,
+    sha256}]}], "changed": [path, ...]}``. The chunks are then pushed like any
+    other file; ``changed`` lists members whose bytes no longer matched.
+    """
+    if not members:
+        return {"chunks": [], "changed": []}
+    total = sum(int(m.get("size") or 0) for m in members)
+    spec = {
+        "root": sandbox.working_dir,
+        "out_dir": PACK_DIR,
+        "max_bytes": PACK_MAX_BYTES,
+        "members": members,
+    }
+    out = await run_transfer_op(
+        sandbox, "pack", spec, timeout_s=transfer_timeout_s(total)
+    )
+    return {"chunks": out.get("chunks") or [], "changed": out.get("changed") or []}
+
+
+async def unlink_direct(sandbox: Any, paths: list[str]) -> int:
+    """Remove files under the working dir; returns how many were removed."""
+    if not paths:
+        return 0
+    out = await run_transfer_op(
+        sandbox, "unlink", {"root": sandbox.working_dir, "paths": paths}, timeout_s=60
+    )
+    return int(out.get("removed") or 0)
+
+
+def all_unreachable(results: dict[str, dict[str, Any]]) -> bool:
+    """True when every item failed at the connection level and none got an HTTP answer.
+
+    That signature means the sandbox has no route to the store, which the
+    relay path can still serve. Any 4xx or 5xx means the store was reached,
+    and falling back would only repeat a real rejection.
+    """
+    if not results:
+        return False
+    return all(r.get("status") == "unreachable" for r in results.values())

--- a/src/server/services/workspace_entitlements.py
+++ b/src/server/services/workspace_entitlements.py
@@ -564,7 +564,11 @@ class WorkspaceEntitlementsMixin:
                 #    copy should reflect the source's content).
                 async def _post_init(session: Session) -> None:
                     if session.sandbox:
-                        await self._restore_files(new_id, session.sandbox)
+                        # A fresh row: the bind expects no previous sandbox,
+                        # and so does the restore's flag.
+                        await self._restore_files(
+                            new_id, session.sandbox, expected_sandbox_id=None
+                        )
 
                 _session, new_workspace = await self._provision_sandbox_session(
                     new_id,

--- a/src/server/services/workspace_file_gc.py
+++ b/src/server/services/workspace_file_gc.py
@@ -1,0 +1,94 @@
+"""Periodic garbage collection for workspace file blobs.
+
+Schedules :func:`sweep_blob_garbage` on an interval and survives per-cycle
+failures. The protocol that makes deletion safe lives with the registry in
+:mod:`src.server.database.workspace_file_blobs`; this service only paces it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from src.server.database.workspace_file_blobs import sweep_blob_garbage
+from src.utils.storage import is_storage_enabled
+
+logger = logging.getLogger(__name__)
+
+# Four cycles a day at GC_REAP_BATCH objects each clears far more than any
+# plausible churn; a tighter cadence only adds store calls.
+_DEFAULT_INTERVAL_SECONDS = 6 * 3600
+
+
+class WorkspaceFileGCService:
+    """Singleton background sweeper for orphaned workspace file blobs."""
+
+    _instance: WorkspaceFileGCService | None = None
+
+    @classmethod
+    def get_instance(cls) -> WorkspaceFileGCService:
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def __init__(self, interval_seconds: int = _DEFAULT_INTERVAL_SECONDS) -> None:
+        self._interval = interval_seconds
+        self._shutdown_event = asyncio.Event()
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        """Launch the sweep loop; inert when no object store is configured."""
+        if self._task and not self._task.done():
+            return
+        if not is_storage_enabled():
+            logger.info("[WorkspaceFileGC] no object store configured; not started")
+            return
+        self._shutdown_event.clear()
+        self._task = asyncio.create_task(self._loop(), name="workspace_file_gc_sweep")
+        logger.info("[WorkspaceFileGC] started — sweep every %ds", self._interval)
+
+    async def stop(self) -> None:
+        """Cancel the sweep and wait, untimed, for it to unwind.
+
+        A reap in flight holds a row lock across an object delete it cannot
+        interrupt, and keeps the lock until the delete settles. Bounding this
+        await would deliver a second cancellation into that wait, rolling the
+        transaction back with the delete still running, which is the race the
+        shield in ``_reap_one`` exists to close.
+        """
+        self._shutdown_event.set()
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("[WorkspaceFileGC] stopped")
+
+    async def _loop(self) -> None:
+        """Sweep on start, then every interval; one failed cycle never kills the loop.
+
+        Sweeping first means a process that restarts more often than the
+        interval still sweeps; the grace periods keep a startup sweep from
+        touching anything recent.
+        """
+        while not self._shutdown_event.is_set():
+            try:
+                stats = await sweep_blob_garbage()
+                if stats is None:
+                    logger.debug("[WorkspaceFileGC] sweep skipped, lock held elsewhere")
+                elif any(stats.values()):
+                    logger.info(
+                        "[WorkspaceFileGC] condemned %d, deleted %d, failed %d",
+                        stats["condemned"],
+                        stats["deleted"],
+                        stats["failed"],
+                    )
+            except Exception:
+                logger.error("[WorkspaceFileGC] sweep cycle failed", exc_info=True)
+
+            try:
+                await asyncio.wait_for(self._shutdown_event.wait(), timeout=self._interval)
+                return
+            except asyncio.TimeoutError:
+                pass

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -55,7 +55,11 @@ from src.server.database.workspace import (
     update_workspace_activity,
     update_workspace_status,
 )
-from src.server.services.persistence.file import FilePersistenceService
+from src.server.services.persistence.file import (
+    FilePersistenceService,
+    RestoreGuardUnavailable,
+    RestoreIdentityLost,
+)
 from src.server.services.user_skills import sandbox_skill_sync_params
 from src.server.services.user_skills.reconcile import reconcile_workspace_skills
 from src.server.services.workspace_entitlements import WorkspaceEntitlementsMixin
@@ -1123,6 +1127,13 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             # can no longer be read as stale by a concurrent acquisition.
             self._sessions[workspace_id] = session
 
+            # post_init restored into a sandbox the row did not yet name, so
+            # its clear of the completeness flag could not land. Now that the
+            # row names this sandbox: a marker means the restore came back
+            # clean and the flag can go; no marker means it did not, and the
+            # restore runs again here, on the sandbox that actually won.
+            await self._maybe_restore_files(workspace_id, session.sandbox)
+
             if kick_discovery and resolved_mcp is not None:
                 self._kick_mcp_discovery(
                     workspace_id,
@@ -1175,9 +1186,15 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         always_on = await self._entitled_always_on(workspace or {}, user_id)
         auto_stop_minutes = 0 if always_on else None
 
+        previous_sandbox_id = (workspace or {}).get("sandbox_id")
+
         async def _post_init(session: Session) -> None:
             if session.sandbox:
-                await self._restore_files(workspace_id, session.sandbox)
+                await self._restore_files(
+                    workspace_id,
+                    session.sandbox,
+                    expected_sandbox_id=previous_sandbox_id,
+                )
 
         # ws_version=None forces a resolve (the session is brand new); discovery
         # is kicked in the background so recovered user servers re-hydrate.
@@ -1190,7 +1207,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
             kick_discovery=True,
             post_init=_post_init,
             core_config=core_config,
-            expected_previous_sandbox_id=(workspace or {}).get("sandbox_id"),
+            expected_previous_sandbox_id=previous_sandbox_id,
         )
         await update_workspace_activity(workspace_id)
         return session
@@ -1351,11 +1368,17 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 extra={"workspace_id": workspace_id, "sandbox_id": sandbox_id},
             )
 
-    async def _restore_files(self, workspace_id: str, sandbox: Any) -> None:
-        """Restore backed-up files from DB to sandbox. Non-blocking on failure."""
+    async def _restore_files(
+        self, workspace_id: str, sandbox: Any, *, expected_sandbox_id: Any
+    ) -> None:
+        """Restore backed-up files from DB to sandbox. Non-blocking on failure.
+
+        ``expected_sandbox_id`` is the sandbox the workspace row names while
+        the restore runs, the same value the identity CAS that follows expects
+        to replace; the restore's flag lands only while that still holds."""
         try:
             result = await FilePersistenceService.restore_to_sandbox(
-                workspace_id, sandbox
+                workspace_id, sandbox, expected_sandbox_id=expected_sandbox_id
             )
             errors = result.get("errors", 0) if isinstance(result, dict) else 0
             if errors:
@@ -1372,13 +1395,31 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 logger.info(
                     f"Restored {result['restored']} files to sandbox for {workspace_id}"
                 )
+        except RestoreIdentityLost:
+            # Another provisioner already bound this workspace; the identity
+            # CAS below would lose too. Unwinding here discards our sandbox
+            # before it is filled.
+            logger.info(
+                f"Skipping restore for {workspace_id}: another sandbox was "
+                f"bound while this one was being provisioned"
+            )
+            raise
+        except RestoreGuardUnavailable:
+            # Nothing was restored and nothing records that. Binding this
+            # sandbox would hand the next backup an empty mirror of a full
+            # manifest with pruning enabled; the provisioning unwind destroys
+            # it instead and the next start tries again.
+            raise
         except Exception as e:
             logger.warning(f"File restore failed for {workspace_id}: {e}")
 
     async def _maybe_restore_files(self, workspace_id: str, sandbox: Any) -> None:
-        """Restore files if sync marker is missing. Non-blocking on failure."""
+        """Restore files if sync marker is missing. Non-blocking on failure,
+        except when the completeness guard itself could not be raised."""
         try:
             await FilePersistenceService.maybe_restore(workspace_id, sandbox)
+        except RestoreGuardUnavailable:
+            raise
         except Exception as e:
             logger.warning(f"File restore check failed for {workspace_id}: {e}")
 

--- a/src/utils/storage/__init__.py
+++ b/src/utils/storage/__init__.py
@@ -30,23 +30,65 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
-def _load_storage_provider() -> str:
-    """Load storage provider from agent_config.yaml, with env var fallback."""
+def _load_storage_setting(name: str, env_var: str, default: str) -> str:
+    """One ``storage.<name>`` key from agent_config.yaml, else ``env_var``."""
     config_path = Path(__file__).parent.parent.parent.parent / "agent_config.yaml"
     if config_path.exists():
         try:
             with config_path.open() as f:
-                config = yaml.safe_load(f)
-            provider = config.get("storage", {}).get("provider")
-            if provider:
-                return provider.lower()
+                config = yaml.safe_load(f) or {}
+            value = (config.get("storage") or {}).get(name)
+            if value:
+                return str(value).lower()
         except (OSError, yaml.YAMLError) as e:
             logger.warning(f"Failed to load agent_config.yaml: {e}")
+    return os.getenv(env_var, default).lower()
 
-    return os.getenv("STORAGE_PROVIDER", "none").lower()
+
+STORAGE_PROVIDER = _load_storage_setting("provider", "STORAGE_PROVIDER", "none")
 
 
-STORAGE_PROVIDER = _load_storage_provider()
+def _configured_bucket(provider: str) -> str | None:
+    if provider == "oss":
+        return os.getenv("OSS_BUCKET_NAME")
+    return os.getenv("STORAGE_BUCKET_NAME") or os.getenv("S3_BUCKET_NAME")
+
+
+# A provider name alone is not a store. The checked-in config selects "s3"
+# while the bucket and credentials live in .env, so a deployment that never
+# filled those in would otherwise report storage as enabled and have every
+# upload fail; workspace file backups in particular would then persist
+# nothing instead of keeping their bytes inline.
+if STORAGE_PROVIDER != "none" and not _configured_bucket(STORAGE_PROVIDER):
+    logger.warning(
+        f"storage.provider is {STORAGE_PROVIDER!r} but no bucket is configured; "
+        f"treating storage as disabled"
+    )
+    STORAGE_PROVIDER = "none"
+
+#: How workspace file bytes travel between a sandbox and the store.
+#: ``direct``: the sandbox moves them over presigned URLs and the server
+#: handles metadata only. ``relay``: the server copies every byte through its
+#: own memory, the path a store without SHA-256-bound uploads (OSS, ``none``)
+#: or a sandbox without a route to the store still needs. ``auto`` picks
+#: ``direct`` for an S3-compatible store and a remote (Daytona) sandbox.
+BLOB_TRANSFER_MODE = _load_storage_setting("blob_transfer", "STORAGE_BLOB_TRANSFER", "auto")
+_BLOB_TRANSFER_MODES = ("auto", "direct", "relay")
+
+
+def get_blob_transfer_mode(sandbox_provider: str | None) -> str:
+    """Resolve ``auto`` against the provider pair; returns ``direct`` or ``relay``."""
+    mode = BLOB_TRANSFER_MODE
+    if mode not in _BLOB_TRANSFER_MODES:
+        logger.warning(
+            f"Unknown storage.blob_transfer {mode!r}; using auto"
+        )
+        mode = "auto"
+    if mode != "auto":
+        return mode
+    if STORAGE_PROVIDER in ("none", "oss"):
+        return "relay"
+    return "direct" if sandbox_provider == "daytona" else "relay"
 
 
 def is_storage_enabled() -> bool:
@@ -74,10 +116,18 @@ if STORAGE_PROVIDER == "none":
     def upload_base64(key: str, image_data: str, content_type: str | None = None) -> bool:
         return False
 
-    def upload_bytes(key: str, data: bytes, content_type: str | None = None) -> bool:
+    def upload_bytes(
+        key: str,
+        data: bytes,
+        content_type: str | None = None,
+        max_size: int | None = None,
+    ) -> bool:
         return False
 
     def get_bytes(key: str) -> bytes | None:
+        return None
+
+    def get_bytes_range(key: str, start: int, length: int) -> bytes | None:
         return None
 
     def does_object_exist(key: str) -> bool:
@@ -90,6 +140,16 @@ if STORAGE_PROVIDER == "none":
         return ""
 
     def get_signed_url(key: str, expires_in: int = 3600) -> str | None:
+        return None
+
+    def get_signed_upload_url(
+        key: str,
+        *,
+        sha256_hex: str,
+        content_length: int,
+        content_type: str,
+        expires_in: int = 900,
+    ) -> tuple[str, dict[str, str]] | None:
         return None
 
     def upload_image(file_path: str, prefix: str | None = None, custom_name: str | None = None) -> str | None:
@@ -119,9 +179,11 @@ if STORAGE_PROVIDER == "none":
 
 elif STORAGE_PROVIDER == "oss":
     from src.utils.storage.oss_uploader import (
+        get_signed_upload_url,
         delete_object,
         does_object_exist,
         get_bytes,
+        get_bytes_range,
         get_public_url,
         get_signed_url,
         sanitize_storage_key,
@@ -138,9 +200,11 @@ elif STORAGE_PROVIDER == "oss":
 else:
     # All S3-compatible providers: "s3", "r2", "cos", or any custom value
     from src.utils.storage.s3_compatible import (
+        get_signed_upload_url,
         delete_object,
         does_object_exist,
         get_bytes,
+        get_bytes_range,
         get_public_url,
         get_signed_url,
         sanitize_storage_key,
@@ -158,9 +222,12 @@ __all__ = [
     "delete_object",
     "does_object_exist",
     "get_bytes",
+    "get_bytes_range",
     "get_provider_id",
     "get_provider_name",
     "get_public_url",
+    "get_blob_transfer_mode",
+    "get_signed_upload_url",
     "get_signed_url",
     "is_storage_enabled",
     "sanitize_storage_key",

--- a/src/utils/storage/oss_uploader.py
+++ b/src/utils/storage/oss_uploader.py
@@ -186,13 +186,20 @@ def upload_base64(key: str, image_data: str, content_type: str | None = None) ->
         return False
 
 
-def upload_bytes(key: str, data: bytes, content_type: str | None = None) -> bool:
+def upload_bytes(
+    key: str,
+    data: bytes,
+    content_type: str | None = None,
+    max_size: int | None = None,
+) -> bool:
     """Upload raw bytes to OSS.
 
     Args:
         key: The object key (path) in OSS bucket
         data: Raw bytes to upload
         content_type: Optional MIME type. If not provided, auto-detected from key extension.
+        max_size: Per-call override of OSS_MAX_UPLOAD_SIZE, for callers whose
+            own domain cap is larger than the shared default.
 
     Returns:
         bool: True if upload successful, False otherwise
@@ -202,10 +209,9 @@ def upload_bytes(key: str, data: bytes, content_type: str | None = None) -> bool
         >>> upload_bytes("text/hello.txt", data)
         True
     """
-    if len(data) > OSSConfig.MAX_UPLOAD_SIZE:
-        logger.error(
-            f"Data too large: {len(data)} bytes > {OSSConfig.MAX_UPLOAD_SIZE} bytes limit"
-        )
+    cap = OSSConfig.MAX_UPLOAD_SIZE if max_size is None else max_size
+    if len(data) > cap:
+        logger.error(f"Data too large: {len(data)} bytes > {cap} bytes limit")
         return False
 
     # Auto-detect content type from key extension if not provided
@@ -231,6 +237,34 @@ def upload_bytes(key: str, data: bytes, content_type: str | None = None) -> bool
     except Exception:
         logger.exception(f"Unexpected error uploading {key}")
         return False
+
+
+def get_bytes_range(key: str, start: int, length: int) -> bytes | None:
+    """Download ``length`` bytes of an object from offset ``start``.
+
+    Same contract as the S3 ``get_bytes_range``: ``None`` on a missing object
+    or any failure, ``b""`` for a zero length without a request.
+    """
+    if length <= 0:
+        return b""
+    try:
+        client = get_oss_client()
+        result = client.get_object(oss.GetObjectRequest(
+            bucket=OSSConfig.BUCKET_NAME,
+            key=key,
+            range_header=f"bytes={start}-{start + length - 1}",
+        ))
+        body = getattr(result, "body", None)
+        if body is None:
+            return None
+        data = body.read()
+        return data if isinstance(data, bytes) else bytes(data)
+    except Exception as e:
+        if "NoSuchKey" in str(e):
+            logger.debug(f"Object not found: {key}")
+            return None
+        logger.exception(f"Ranged download failed for {key}: {e}")
+        return None
 
 
 def get_bytes(key: str) -> bytes | None:
@@ -349,6 +383,23 @@ def get_public_url(key: str) -> str:
         'https://${OSS_BUCKET_NAME}.${OSS_ENDPOINT}/images/photo.png'
     """
     return f"{OSSConfig.get_public_url_base()}/{key}"
+
+
+def get_signed_upload_url(
+    key: str,
+    *,
+    sha256_hex: str,
+    content_length: int,
+    content_type: str,
+    expires_in: int = 900,
+) -> tuple[str, dict[str, str]] | None:
+    """Unavailable on OSS: its presigner can bind Content-MD5 but not SHA-256.
+
+    An MD5 condition does not tie the key to the bytes under a content-
+    addressed key, so a direct upload here could not be trusted. Callers fall
+    back to uploading through the server.
+    """
+    return None
 
 
 def get_signed_url(key: str, expires_in: int = 3600) -> str | None:

--- a/src/utils/storage/s3_compatible.py
+++ b/src/utils/storage/s3_compatible.py
@@ -19,6 +19,7 @@ Environment Variables:
     STORAGE_MAX_UPLOAD_SIZE   - Max upload size in bytes (default: 10MB)
     STORAGE_CONNECT_TIMEOUT_S - boto3 connect timeout in seconds (default: 5)
     STORAGE_READ_TIMEOUT_S    - boto3 read timeout in seconds (default: 30)
+    STORAGE_MAX_POOL_CONNECTIONS - boto3 connection pool size (default: 32)
     STORAGE_ADDRESSING_STYLE  - Bucket addressing: virtual (default) | path | auto
 
 Endpoint / addressing:
@@ -37,6 +38,7 @@ bucket double-prefixes object keys under virtual addressing.
 import base64
 import logging
 import os
+import threading
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -91,6 +93,12 @@ class StorageConfig:
     CONNECT_TIMEOUT_S = int(os.getenv("STORAGE_CONNECT_TIMEOUT_S", "5"))
     READ_TIMEOUT_S = int(os.getenv("STORAGE_READ_TIMEOUT_S", "30"))
 
+    # botocore defaults this to 10, which workspace-file restore overruns: it
+    # fetches blobs under a semaphore of 16, so six of every sixteen requests
+    # got their connection discarded and paid a fresh TLS handshake. Sized
+    # above that concurrency with headroom for the concurrent sync path.
+    MAX_POOL_CONNECTIONS = int(os.getenv("STORAGE_MAX_POOL_CONNECTIONS", "32"))
+
     # boto3 bucket addressing. Defaults to "virtual" because most cloud
     # S3-compatible services require/prefer virtual-hosted addressing, whereas
     # boto3's own default ("path" for custom endpoints) double-prefixes keys
@@ -106,12 +114,20 @@ class StorageConfig:
         return f"https://{cls.BUCKET_NAME}.s3.{cls.REGION}.amazonaws.com"
 
 
-# Module-level cache. boto3 clients are thread-safe and the underlying
-# botocore connection pool reuses TLS sessions, so a single shared client
+# Module-level cache. Using a boto3 client from many threads is safe and the
+# underlying connection pool reuses TLS sessions, so a single shared client
 # eliminates the per-op handshake that previously dominated upload/download
 # latency under load. Lazy so import-time failures (missing creds in tests)
 # don't blow up modules that never actually use object storage.
+#
+# *Constructing* one is a different matter: botocore's session and loader are
+# not thread-safe, and every caller here arrives through asyncio.to_thread.
+# Workspace file restore fetches blobs under a semaphore of 16, so on a cold
+# process all 16 threads reach this at once. The lock makes construction
+# happen exactly once; the unlocked fast path keeps the steady state free.
 _CLIENT: Any | None = None
+_RANGE_CLIENT: Any | None = None
+_CLIENT_MU = threading.Lock()
 
 
 def _get_client() -> Any:
@@ -119,6 +135,32 @@ def _get_client() -> Any:
     global _CLIENT
     if _CLIENT is not None:
         return _CLIENT
+    with _CLIENT_MU:
+        if _CLIENT is not None:
+            return _CLIENT
+        _CLIENT = _build_client()
+    return _CLIENT
+
+
+def _get_range_client() -> Any:
+    """The client for ranged GETs, which must not validate response checksums.
+
+    An object uploaded with a full-object checksum comes back with that
+    checksum header on a ranged response too, and the SDK then checks the
+    partial body against it and fails every time. Callers reading a range
+    verify the bytes they get by their own means.
+    """
+    global _RANGE_CLIENT
+    if _RANGE_CLIENT is not None:
+        return _RANGE_CLIENT
+    with _CLIENT_MU:
+        if _RANGE_CLIENT is not None:
+            return _RANGE_CLIENT
+        _RANGE_CLIENT = _build_client(response_checksum_validation="when_required")
+    return _RANGE_CLIENT
+
+
+def _build_client(**config_overrides: Any) -> Any:
     kwargs: dict[str, Any] = {
         "aws_access_key_id": StorageConfig.ACCESS_KEY_ID,
         "aws_secret_access_key": StorageConfig.SECRET_ACCESS_KEY,
@@ -129,18 +171,21 @@ def _get_client() -> Any:
             retries={"max_attempts": 3, "mode": "standard"},
             connect_timeout=StorageConfig.CONNECT_TIMEOUT_S,
             read_timeout=StorageConfig.READ_TIMEOUT_S,
+            max_pool_connections=StorageConfig.MAX_POOL_CONNECTIONS,
+            **config_overrides,
         ),
     }
     if StorageConfig.ENDPOINT_URL:
         kwargs["endpoint_url"] = StorageConfig.ENDPOINT_URL
-    _CLIENT = boto3.client("s3", **kwargs)
-    return _CLIENT
+    return boto3.client("s3", **kwargs)
 
 
 def _reset_client_for_test() -> None:
-    """Drop the cached client. Test-only — production never re-initializes."""
-    global _CLIENT
-    _CLIENT = None
+    """Drop the cached clients. Test-only — production never re-initializes."""
+    global _CLIENT, _RANGE_CLIENT
+    with _CLIENT_MU:
+        _CLIENT = None
+        _RANGE_CLIENT = None
 
 
 def upload_file(key: str, file_path: str, content_type: str | None = None) -> bool:
@@ -194,10 +239,22 @@ def upload_base64(key: str, image_data: str, content_type: str | None = None) ->
         return False
 
 
-def upload_bytes(key: str, data: bytes, content_type: str | None = None) -> bool:
-    """Upload raw bytes."""
-    if len(data) > StorageConfig.MAX_UPLOAD_SIZE:
-        logger.error(f"Data too large: {len(data)} bytes > {StorageConfig.MAX_UPLOAD_SIZE} bytes")
+def upload_bytes(
+    key: str,
+    data: bytes,
+    content_type: str | None = None,
+    max_size: int | None = None,
+) -> bool:
+    """Upload raw bytes.
+
+    ``max_size`` overrides ``STORAGE_MAX_UPLOAD_SIZE`` for this call only.
+    Callers whose own domain cap is larger than the shared default (workspace
+    file blobs, at 100MB) pass it rather than lifting the guard globally for
+    avatars, charts, and memo binaries.
+    """
+    cap = StorageConfig.MAX_UPLOAD_SIZE if max_size is None else max_size
+    if len(data) > cap:
+        logger.error(f"Data too large: {len(data)} bytes > {cap} bytes")
         return False
 
     if not content_type:
@@ -244,6 +301,38 @@ def get_bytes(key: str) -> bytes | None:
         return None
 
 
+def get_bytes_range(key: str, start: int, length: int) -> bytes | None:
+    """Download ``length`` bytes of an object from offset ``start``.
+
+    ``None`` on failure or a missing object, like :func:`get_bytes`. A zero
+    length returns ``b""`` without a request: an empty HTTP range is invalid.
+    """
+    if length <= 0:
+        return b""
+    try:
+        client = _get_range_client()
+        response = client.get_object(
+            Bucket=StorageConfig.BUCKET_NAME,
+            Key=key,
+            Range=f"bytes={start}-{start + length - 1}",
+        )
+        body = response.get("Body")
+        if body is None:
+            return None
+        data = body.read()
+        return data if isinstance(data, bytes) else bytes(data)
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code")
+        if code in {"NoSuchKey", "404"}:
+            logger.debug(f"Object not found: {key}")
+            return None
+        logger.exception(f"Ranged download failed for {key}")
+        return None
+    except Exception:
+        logger.exception(f"Unexpected error downloading a range of {key}")
+        return None
+
+
 def does_object_exist(key: str) -> bool:
     """Check if an object exists in the bucket."""
     try:
@@ -278,6 +367,46 @@ def delete_object(key: str) -> bool:
 def get_public_url(key: str) -> str:
     """Get the public URL for an uploaded object."""
     return f"{StorageConfig.get_public_url_base()}/{key}"
+
+
+def get_signed_upload_url(
+    key: str,
+    *,
+    sha256_hex: str,
+    content_length: int,
+    content_type: str,
+    expires_in: int = 900,
+) -> tuple[str, dict[str, str]] | None:
+    """Presign a PUT bound to the object's content, not just its key.
+
+    The digest, length and type are signed into the URL, so the store rejects
+    any body that does not hash to ``sha256_hex`` or exceed ``content_length``
+    (BadDigest / SignatureDoesNotMatch). That binding is what lets an
+    untrusted uploader write into a shared content-addressed prefix. The
+    returned headers must be sent verbatim; Content-Length is set by the
+    uploader from the body it streams.
+    """
+    checksum_b64 = base64.b64encode(bytes.fromhex(sha256_hex)).decode("ascii")
+    try:
+        client = _get_client()
+        url = client.generate_presigned_url(
+            "put_object",
+            Params={
+                "Bucket": StorageConfig.BUCKET_NAME,
+                "Key": key,
+                "ContentLength": content_length,
+                "ContentType": content_type,
+                "ChecksumSHA256": checksum_b64,
+            },
+            ExpiresIn=expires_in,
+        )
+    except Exception as e:
+        logger.error(f"Failed to presign upload for {key}: {e}")
+        return None
+    return url, {
+        "Content-Type": content_type,
+        "x-amz-checksum-sha256": checksum_b64,
+    }
 
 
 def get_signed_url(key: str, expires_in: int = 3600) -> str | None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -65,6 +65,7 @@ _ALL_TABLES = [
     "user_skills",
     "user_plugins",
     "workspace_files",
+    "workspace_file_blobs",
     "watchlist_items",
     "watchlists",
     "user_portfolios",

--- a/tests/integration/test_workspace_file_blob_gc.py
+++ b/tests/integration/test_workspace_file_blob_gc.py
@@ -1,0 +1,250 @@
+"""The blob garbage-collection protocol, exercised against real Postgres.
+
+The protocol's guarantees are about lock ordering between a writer and the
+reap, which no mocked cursor can express. Object storage is a dict here: the
+race is in the database, and the store only has to be observable.
+
+Every interleaving below was first run live against a bucket
+(``gcprobe.py`` in the session scratchpad); these pin the decision table.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from psycopg_pool import AsyncConnectionPool
+
+from src.server.database import workspace_file_blobs as B
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+class _Store:
+    """Just enough of the storage facade for the registry to be observable."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.refuse_delete = False
+
+    def upload(self, key, data, content_type=None, max_size=None) -> bool:
+        self.objects[key] = data
+        return True
+
+    def get(self, key):
+        return self.objects.get(key)
+
+    def delete(self, key) -> bool:
+        if self.refuse_delete:
+            return False
+        self.objects.pop(key, None)
+        return True
+
+
+@pytest_asyncio.fixture
+async def gc(test_db_uri, test_db_pool, seed_workspace):
+    """A tuple-row pool (what production hands the module) patched in, plus a
+    fake store. Yields ``(store, run_sql, workspace_id)``."""
+    pool = AsyncConnectionPool(
+        conninfo=test_db_uri,
+        min_size=1,
+        max_size=4,
+        kwargs={"autocommit": True, "prepare_threshold": 0},
+        open=False,
+    )
+    await pool.open()
+    await pool.wait()
+
+    @asynccontextmanager
+    async def _gdc(conn=None):
+        if conn is not None:
+            yield conn
+            return
+        async with pool.connection() as owned:
+            yield owned
+
+    async def run(sql, params=()):
+        async with pool.connection() as conn, conn.cursor() as cur:
+            await cur.execute(sql, params)
+            return await cur.fetchall() if cur.description else None
+
+    store = _Store()
+    with (
+        patch.object(B, "get_db_connection", _gdc),
+        patch.object(B, "_storage_upload_bytes", store.upload),
+        patch.object(B, "_storage_get_bytes", store.get),
+        patch.object(B, "_storage_delete_object", store.delete),
+    ):
+        try:
+            yield store, run, seed_workspace["workspace_id"], seed_workspace["user_id"]
+        finally:
+            await run("DELETE FROM workspace_files WHERE workspace_id = %s", (seed_workspace["workspace_id"],))
+            await run("DELETE FROM workspace_file_blobs")
+            await pool.close()
+
+
+def _blob(tag: str) -> tuple[str, bytes]:
+    data = f"gc {tag} {uuid.uuid4()}".encode()
+    return hashlib.sha256(data).hexdigest(), data
+
+
+async def _state(run, sha):
+    rows = await run("SELECT condemned_at IS NOT NULL FROM workspace_file_blobs WHERE sha256 = %s", (sha,))
+    return None if not rows else ("condemned" if rows[0][0] else "live")
+
+
+async def _age_out(run, sha, *, days=8):
+    await run(
+        "UPDATE workspace_file_blobs SET last_referenced_at = NOW() - make_interval(days => %s) WHERE sha256 = %s",
+        (days, sha),
+    )
+
+
+async def _condemned(run, sha):
+    await _age_out(run, sha)
+    await B.condemn_orphan_blobs()
+    assert await _state(run, sha) == "condemned"
+
+
+async def test_lifecycle_condemn_then_reap(gc):
+    store, run, _, uid = gc
+    sha, data = _blob("a")
+    await B.store_blob(uid, sha, data)
+    assert await _state(run, sha) == "live" and store.get(B.blob_key(uid, sha)) == data
+
+    await _age_out(run, sha)
+    assert await B.condemn_orphan_blobs() == 1
+    assert await _state(run, sha) == "condemned"
+    # Still inside the second grace: nothing happens.
+    assert await B.reap_condemned_blobs(condemned_grace_hours=24) == (0, 0)
+    assert await B.reap_condemned_blobs(condemned_grace_hours=0) == (1, 0)
+    assert await _state(run, sha) is None and store.get(B.blob_key(uid, sha)) is None
+
+
+async def test_touch_shields_from_condemnation(gc):
+    store, run, _, uid = gc
+    sha, data = _blob("b")
+    await B.store_blob(uid, sha, data)
+    await _age_out(run, sha)
+    assert await B.registered_blobs(uid, [sha]) == {sha}
+    assert await B.condemn_orphan_blobs() == 0
+    assert await _state(run, sha) == "live"
+
+
+async def test_manifest_reference_shields_from_condemnation(gc):
+    store, run, ws, uid = gc
+    sha, data = _blob("c")
+    await B.store_blob(uid, sha, data)
+    await _age_out(run, sha)
+    await run(
+        "INSERT INTO workspace_files (workspace_id, file_path, file_name, file_size, content_hash, blob_sha256) "
+        "VALUES (%s, 'c.txt', 'c.txt', %s, %s, %s)",
+        (ws, len(data), sha, sha),
+    )
+    assert await B.condemn_orphan_blobs() == 0
+    assert await _state(run, sha) == "live"
+
+
+async def test_pack_membership_shields_the_chunk_from_condemnation(gc):
+    """A chunk is referenced through pack_sha256, never blob_sha256."""
+    store, run, ws, uid = gc
+    sha, data = _blob("chunk")
+    await B.store_blob(uid, sha, data)
+    await _age_out(run, sha)
+    await run(
+        "INSERT INTO workspace_files (workspace_id, file_path, file_name, file_size, content_hash, pack_sha256, pack_offset) "
+        "VALUES (%s, 'm.txt', 'm.txt', 2, repeat('0', 64), %s, 0)",
+        (ws, sha),
+    )
+    assert await B.condemn_orphan_blobs() == 0
+    assert await _state(run, sha) == "live"
+    await run("DELETE FROM workspace_files WHERE workspace_id = %s AND file_path = 'm.txt'", (ws,))
+    assert await B.condemn_orphan_blobs() == 1
+
+
+async def test_condemned_row_is_invisible_claimed_and_revived(gc):
+    store, run, _, uid = gc
+    sha, data = _blob("d")
+    await B.store_blob(uid, sha, data)
+    await _condemned(run, sha)
+    before = (await run("SELECT condemned_at FROM workspace_file_blobs WHERE sha256 = %s", (sha,)))[0][0]
+
+    # Not registered as far as a writer is concerned, but the check claims it.
+    assert await B.registered_blobs(uid, [sha]) == set()
+    after = (await run("SELECT condemned_at FROM workspace_file_blobs WHERE sha256 = %s", (sha,)))[0][0]
+    assert after > before
+
+    await B.register_blobs(uid, [(sha, len(data))])
+    assert await _state(run, sha) == "live"
+    assert await B.reap_condemned_blobs(condemned_grace_hours=0) == (0, 0)
+    assert store.get(B.blob_key(uid, sha)) == data
+
+
+async def test_writer_arriving_under_the_reap_lock_lands_live_with_its_object(gc):
+    """The reap holds the row lock across the object delete. A writer's claim
+    queues behind it, then finds no row, uploads, and inserts fresh."""
+    store, run, _, uid = gc
+    sha, data = _blob("e1")
+    await B.store_blob(uid, sha, data)
+    await _condemned(run, sha)
+
+    async with B.get_db_connection() as reap:
+        async with reap.transaction():
+            async with reap.cursor() as cur:
+                await cur.execute(
+                    "SELECT 1 FROM workspace_file_blobs WHERE sha256 = %s AND condemned_at < NOW() FOR UPDATE",
+                    (sha,),
+                )
+                assert await cur.fetchone()
+            writer = asyncio.create_task(B.store_blob(uid, sha, data))
+            await asyncio.sleep(0.5)
+            assert not writer.done(), "the writer's claim must block behind the row lock"
+            store.delete(B.blob_key(uid, sha))
+            async with reap.cursor() as cur:
+                await cur.execute("DELETE FROM workspace_file_blobs WHERE user_id = %s AND sha256 = %s", (uid, sha))
+        await writer
+
+    assert await _state(run, sha) == "live"
+    assert store.get(B.blob_key(uid, sha)) == data
+
+
+async def test_claim_that_lands_first_takes_the_row_out_of_the_reap(gc):
+    store, run, _, uid = gc
+    sha, data = _blob("e2")
+    await B.store_blob(uid, sha, data)
+    await _condemned(run, sha)
+    await run("UPDATE workspace_file_blobs SET condemned_at = NOW() - interval '2 hours' WHERE sha256 = %s", (sha,))
+
+    await B.registered_blobs(uid, [sha])  # the sync path's claim, before its upload
+    assert await B.reap_condemned_blobs(condemned_grace_hours=1) == (0, 0)
+    assert await _state(run, sha) == "condemned"
+    assert store.get(B.blob_key(uid, sha)) == data
+
+
+async def test_store_failure_leaves_the_row_condemned_for_the_next_cycle(gc):
+    store, run, _, uid = gc
+    sha, data = _blob("f")
+    await B.store_blob(uid, sha, data)
+    await _condemned(run, sha)
+
+    store.refuse_delete = True
+    assert await B.reap_condemned_blobs(condemned_grace_hours=0) == (0, 1)
+    assert await _state(run, sha) == "condemned" and store.get(B.blob_key(uid, sha)) == data
+
+    store.refuse_delete = False
+    assert await B.reap_condemned_blobs(condemned_grace_hours=0) == (1, 0)
+    assert await _state(run, sha) is None and store.get(B.blob_key(uid, sha)) is None
+
+
+async def test_sweep_is_single_flight_across_processes(gc):
+    store, run, _, uid = gc
+    async with B.get_db_connection() as other, other.cursor() as cur:
+        await cur.execute("SELECT pg_advisory_lock(hashtextextended(%s, 0))", (B._GC_LOCK_KEY,))
+        assert await B.sweep_blob_garbage() is None
+        await cur.execute("SELECT pg_advisory_unlock(hashtextextended(%s, 0))", (B._GC_LOCK_KEY,))
+    assert await B.sweep_blob_garbage() == {"condemned": 0, "deleted": 0, "failed": 0}

--- a/tests/unit/core/sandbox/test_docker_provider.py
+++ b/tests/unit/core/sandbox/test_docker_provider.py
@@ -428,6 +428,33 @@ class TestDockerRuntimeTarUpload:
         # The exec call is for mkdir
         container.exec.assert_called()
 
+    @pytest.mark.asyncio
+    async def test_uploads_are_owned_by_the_container_user(self, runtime, container):
+        """A tar entry defaults to root, and put_archive extracts what it says.
+
+        The container runs as its own non-root user, and a file that user does
+        not own can be read but never chmod'd or utime'd — which is what
+        placing a restored workspace file has to do."""
+        container.exec = AsyncMock(side_effect=lambda **kw: _make_exec_mock("1001\n1001\n"))
+        await runtime.upload_file(b"x", "/home/workspace/a.txt")
+        await runtime.upload_files([(b"y", "/home/workspace/b.txt")])
+        for call in container.put_archive.call_args_list:
+            with tarfile.open(fileobj=io.BytesIO(call[0][1]), mode="r") as tar:
+                for m in tar.getmembers():
+                    assert (m.uid, m.gid) == (1001, 1001)
+        # One lookup for the runtime's whole life, not one per upload.
+        cmds = [" ".join(c.kwargs["cmd"]) for c in container.exec.call_args_list]
+        assert sum("id -u" in c for c in cmds) == 1
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_uid_falls_back_to_root(self, runtime, container):
+        """Losing the lookup must not lose the upload; root is what it was before."""
+        container.exec = AsyncMock(side_effect=lambda **kw: _make_exec_mock(""))
+        await runtime.upload_file(b"x", "/home/workspace/a.txt")
+        tar_data = container.put_archive.call_args[0][1]
+        with tarfile.open(fileobj=io.BytesIO(tar_data), mode="r") as tar:
+            assert tar.getmembers()[0].uid == 0
+
 
 # ---------------------------------------------------------------------------
 # DockerRuntime — tar download

--- a/tests/unit/migrations/test_039_downgrade_guard.py
+++ b/tests/unit/migrations/test_039_downgrade_guard.py
@@ -1,0 +1,81 @@
+"""The 039 downgrade drops the only reference a moved row has to its bytes."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "migrations"
+    / "versions"
+    / "039_workspace_file_blobs.py"
+)
+
+
+@pytest.fixture
+def migration(monkeypatch):
+    spec = importlib.util.spec_from_file_location("migration_039", _PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    op = MagicMock()
+    monkeypatch.setattr(module, "op", op)
+    return module, op
+
+
+def test_downgrade_refuses_while_any_row_points_into_storage(migration):
+    module, op = migration
+    op.get_bind.return_value.execute.return_value.scalar.return_value = 3
+
+    with pytest.raises(RuntimeError, match=r"--reverse --apply"):
+        module.downgrade()
+
+    op.execute.assert_not_called()
+    op.get_context.assert_not_called()
+
+
+def test_downgrade_refuses_while_any_workspace_restore_is_incomplete(migration):
+    """With every row inline the flag is the only prune gate a flagged workspace
+    has left; dropping it lets the next sync prune the files that never arrived."""
+    module, op = migration
+    op.get_bind.return_value.execute.return_value.scalar.side_effect = [0, 2]
+
+    with pytest.raises(RuntimeError, match="files_restore_incomplete_at"):
+        module.downgrade()
+
+    op.execute.assert_not_called()
+
+
+def test_downgrade_runs_once_every_row_is_inline_again(migration):
+    module, op = migration
+    op.get_bind.return_value.execute.return_value.scalar.return_value = 0
+
+    module.downgrade()
+
+    dropped = [" ".join(str(c.args[0]).split()) for c in op.execute.call_args_list]
+    assert "DROP TABLE IF EXISTS workspace_file_blobs" in dropped
+
+
+def test_downgrade_locks_the_tables_before_it_counts(migration):
+    """A count taken outside the lock is a snapshot: a still-running worker can
+    publish a blob-backed row right after it, and the column drop that follows
+    would strand that file's bytes. The lock has to be held through the DDL,
+    so there is no autocommit block to commit it away."""
+    module, op = migration
+    bind = op.get_bind.return_value
+    bind.execute.return_value.scalar.return_value = 0
+
+    module.downgrade()
+
+    statements = [" ".join(str(c.args[0]).split()) for c in bind.execute.call_args_list]
+    lock = next(i for i, s in enumerate(statements) if s.startswith("LOCK TABLE"))
+    first_count = next(i for i, s in enumerate(statements) if s.startswith("SELECT"))
+    assert lock < first_count
+    # Session-level SET would outlive this transaction and cap every later
+    # migration on the same connection.
+    assert any(s.startswith("SET LOCAL lock_timeout") for s in statements)
+    assert "workspace_files" in statements[lock] and "workspaces" in statements[lock]
+    op.get_context.assert_not_called()

--- a/tests/unit/ptc_agent/core/sandbox/test_provider_absence_classification.py
+++ b/tests/unit/ptc_agent/core/sandbox/test_provider_absence_classification.py
@@ -16,6 +16,8 @@ that ordering, so the base tests say nothing about it and it is pinned
 separately at the bottom of this module.
 """
 
+from urllib.error import HTTPError
+
 from daytona.common.errors import DaytonaNotFoundError
 
 from ptc_agent.core.sandbox.providers.daytona import DaytonaProvider
@@ -81,14 +83,15 @@ def _daytona() -> DaytonaProvider:
 def _miss(path: str) -> DaytonaNotFoundError:
     """A per-path miss shaped exactly as the live API returns it.
 
-    Message and metadata transcribed from a probe against SDK 0.200.1: the
+    Message and metadata transcribed from a probe against SDK 0.200.1 (the
+    field was renamed ``error_code`` -> ``code`` in 0.201): the
     server echoes the requested path into the message, which is precisely what
     makes the message scan dangerous here.
     """
     return DaytonaNotFoundError(
         f"Failed to download file: file not found: {path}",
         status_code=404,
-        error_code="FILE_NOT_FOUND",
+        code="FILE_NOT_FOUND",
     )
 
 
@@ -130,8 +133,26 @@ def test_daytona_a_missing_sandbox_is_still_gone() -> None:
     assert (
         _daytona().classify_error(
             DaytonaNotFoundError(
-                "Sandbox not found", status_code=404, error_code="NOT_FOUND"
+                "Sandbox not found", status_code=404, code="NOT_FOUND"
             )
         )
         is SandboxFailureKind.SANDBOX_GONE
     )
+
+
+def test_daytona_an_int_code_on_a_wrapper_does_not_hide_the_sdk_string() -> None:
+    """``code`` is a common attribute name, and the outermost one is not the SDK's.
+
+    A transport error raised over the SDK's carries its own ``code``, an
+    integer: ``HTTPError`` is 404 the number. Stopping the chain walk at the
+    first exception that merely has the attribute loses ``FILE_NOT_FOUND``,
+    and the 404 left behind routes to ``SANDBOX_GONE``, so a missing file
+    authorizes destroying and replacing the sandbox it lives in.
+    """
+    from ptc_agent.core.sandbox.providers.daytona_secrets import daytona_error_code
+
+    wrapped = HTTPError("http://daytona/files", 404, "Not Found", None, None)
+    wrapped.__cause__ = _miss("/home/workspace/report.csv")
+
+    assert daytona_error_code(wrapped) == "FILE_NOT_FOUND"
+    assert _daytona().classify_error(wrapped) is SandboxFailureKind.PATH_ABSENT

--- a/tests/unit/ptc_agent/core/sandbox/test_wsfiles_transfer_runtime.py
+++ b/tests/unit/ptc_agent/core/sandbox/test_wsfiles_transfer_runtime.py
@@ -1,0 +1,1187 @@
+"""Exercise the sandbox-side transfer runtime against a loopback fake bucket.
+
+The runtime is stdlib-only and uploaded verbatim into sandboxes, so it is
+imported as a plain module here. Network tests carry ``enable_socket`` for
+the unit-suite tripwire and only ever talk to 127.0.0.1.
+"""
+
+import base64
+import hashlib
+import os
+import socket
+import stat
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from ptc_agent.core.sandbox import wsfiles_transfer_runtime as rt
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _b64sha(data: bytes) -> str:
+    return base64.b64encode(hashlib.sha256(data).digest()).decode()
+
+
+# ---------------------------------------------------------------------------
+# fake bucket
+# ---------------------------------------------------------------------------
+
+
+class _Bucket(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.objects: dict[str, bytes] = {}
+        self.fail_500: set[str] = set()
+        self.redirects: set[str] = set()
+        self.hits: dict[str, int] = {}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server: _Bucket
+
+    def log_message(self, *_):
+        pass
+
+    def _count(self):
+        self.server.hits[self.path] = self.server.hits.get(self.path, 0) + 1
+
+    def _redirect(self) -> bool:
+        if self.path not in self.server.redirects:
+            return False
+        self.send_response(307)
+        self.send_header("Location", f"{self.server.base}/elsewhere{self.path}")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+        return True
+
+    def do_PUT(self):
+        self._count()
+        n = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(n)
+        if self._redirect():
+            return
+        want = self.headers.get("x-amz-checksum-sha256")
+        if want is not None and want != _b64sha(body):
+            payload = b"<Error><Code>BadDigest</Code></Error>"
+            self.send_response(400)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        self.server.objects[self.path] = body
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self):
+        self._count()
+        if self._redirect():
+            return
+        if self.path in self.server.fail_500:
+            self.send_response(500)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        body = self.server.objects.get(self.path)
+        if body is None:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture
+def bucket():
+    srv = _Bucket(("127.0.0.1", 0), _Handler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    srv.base = f"http://127.0.0.1:{srv.server_address[1]}"
+    try:
+        yield srv
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff(monkeypatch):
+    monkeypatch.setattr(rt, "_BACKOFF_S", (0.0, 0.0))
+
+
+def _closed_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+# ---------------------------------------------------------------------------
+# path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_under_root_accepts_a_name_that_merely_starts_with_dots():
+    """Only a whole ".." component escapes. "..notes" is an ordinary file name,
+    and rejecting it silently dropped such files from every transfer."""
+    assert rt._resolve_under_root("/root", "..notes") == "/root/..notes"
+    assert rt._resolve_under_root("/root", "d/..hidden.txt") == "/root/d/..hidden.txt"
+    assert rt._resolve_under_root("/root", "...") == "/root/..."
+
+
+def test_resolve_under_root_still_rejects_traversal_and_absolutes():
+    for rel in ("../x", "..", "a/../../x", "/etc/passwd", "", "."):
+        assert rt._resolve_under_root("/root", rel) is None
+
+
+# ---------------------------------------------------------------------------
+# scan
+# ---------------------------------------------------------------------------
+
+
+def _write(root, rel: str, data: bytes = b"x") -> str:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(data)
+    return str(p)
+
+
+def _sans_ms(results):
+    return {k: {f: v for f, v in r.items() if f != "ms"} for k, r in results.items()}
+
+
+def _scan(root, **over):
+    spec = {
+        "root": str(root),
+        "exclude_dir_names": ["node_modules", ".git", "_internal"],
+        "exclude_rel_dirs": [".agents/threads", ".agents/skills/.staging"],
+        "exclude_rel_dir_prefixes": [".agents/skills/.trash-"],
+        "exclude_rel_files": [".agents/skills/.skills-sync.flock"],
+        "exclude_basenames": [".DS_Store", "__init__.py"],
+        "exclude_suffixes": [".pyc"],
+        "max_file_bytes": 100,
+        "prior": {},
+    }
+    spec.update(over)
+    return rt.scan(spec)
+
+
+def test_scan_reserves_a_file_by_relative_path_not_by_name(tmp_path):
+    _write(tmp_path, ".agents/skills/.skills-sync.flock", b"")
+    _write(tmp_path, "results/.skills-sync.flock", b"mine")
+    os.makedirs(tmp_path / "x")
+    os.symlink("../results/.skills-sync.flock", tmp_path / "x/.skills-sync.flock")
+    paths = {e["path"] for e in _scan(tmp_path)["entries"]}
+    assert ".agents/skills/.skills-sync.flock" not in paths
+    assert "results/.skills-sync.flock" in paths
+    assert "x/.skills-sync.flock" in paths
+
+
+def test_scan_exclusions_and_pruning(tmp_path):
+    _write(tmp_path, "a.txt", b"hello")
+    _write(tmp_path, "node_modules/x.js")
+    _write(tmp_path, "deep/node_modules/y.js")
+    _write(tmp_path, ".agents/threads/t.md")
+    _write(tmp_path, ".agents/user/u.md")
+    _write(tmp_path, "pkg/__init__.py")
+    _write(tmp_path, "pkg/mod.pyc")
+    _write(tmp_path, "pkg/mod.py")
+    _write(tmp_path, ".DS_Store")
+    _write(tmp_path, ".agents/skills/.trash-123/junk")
+    _write(tmp_path, ".agents/skills/.staging/junk")
+    # The reconciler's names are reserved under its own directory only.
+    _write(tmp_path, "pkg/.staging/mine.txt")
+    _write(tmp_path, "pkg/.trash-abc/mine.txt")
+    os.symlink("a.txt", tmp_path / "node_modules_link")
+
+    out = _scan(tmp_path)
+    paths = [e["path"] for e in out["entries"]]
+    # Pruned trees leave no trace beneath their parent; every kept dir has a row.
+    assert paths == [
+        ".agents", ".agents/skills", ".agents/user", ".agents/user/u.md", "a.txt", "deep",
+        "node_modules_link", "pkg", "pkg/.staging", "pkg/.staging/mine.txt",
+        "pkg/.trash-abc", "pkg/.trash-abc/mine.txt", "pkg/mod.py",
+    ]
+    assert paths == sorted(paths)
+    assert next(e for e in out["entries"] if e["path"] == "deep")["kind"] == "dir"
+    a = next(e for e in out["entries"] if e["path"] == "a.txt")
+    assert a["kind"] == "file" and a["size"] == 5 and a["sha256"] == _sha(b"hello")
+    assert a["is_binary"] is False
+    assert a["mode"] == stat.S_IMODE(os.stat(tmp_path / "a.txt").st_mode)
+    assert out["errors"] == [] and out["oversized"] == []
+
+
+def test_scan_symlink_named_like_excluded_dir_is_skipped(tmp_path):
+    _write(tmp_path, "a.txt")
+    os.symlink("a.txt", tmp_path / ".git")
+    os.symlink("a.txt", tmp_path / ".DS_Store")
+    out = _scan(tmp_path)
+    assert [e["path"] for e in out["entries"]] == ["a.txt"]
+
+
+def test_scan_prior_reuse_vs_rehash(tmp_path):
+    p = _write(tmp_path, "f.bin", b"abc")
+    st = os.stat(p)
+    prior = {"f.bin": [st.st_size, st.st_mtime_ns, "deadbeef"]}
+    out = _scan(tmp_path, prior=prior)
+    assert out["reused"] == 1 and out["hashed"] == 0
+    assert out["entries"][0]["sha256"] == "deadbeef"
+    assert out["entries"][0]["is_binary"] is None
+    assert out["entries"][0]["mtime_ns"] == st.st_mtime_ns
+
+    # The prior is stored at microsecond precision: same microsecond reuses.
+    us_truncated = {"f.bin": [st.st_size, (st.st_mtime_ns // 1000) * 1000, "deadbeef"]}
+    out = _scan(tmp_path, prior=us_truncated)
+    assert out["reused"] == 1 and out["hashed"] == 0
+
+    stale = {"f.bin": [st.st_size, st.st_mtime_ns + 1000, "deadbeef"]}
+    out = _scan(tmp_path, prior=stale)
+    assert out["reused"] == 0 and out["hashed"] == 1
+    assert out["entries"][0]["sha256"] == _sha(b"abc")
+    assert out["entries"][0]["is_binary"] is False
+
+    wrong_size = {"f.bin": [st.st_size + 1, st.st_mtime_ns, "deadbeef"]}
+    out = _scan(tmp_path, prior=wrong_size)
+    assert out["reused"] == 0 and out["hashed"] == 1
+
+
+def test_scan_size_describes_the_hashed_bytes(tmp_path, monkeypatch):
+    """A file that grows between the stat and the hash is reported with the
+    length the digest covers; the stale stat size would fail every later
+    length check against the same digest."""
+    path = _write(tmp_path, "grows.txt", b"short")
+    real = rt._hash_file
+
+    def grow_then_hash(p):
+        with open(p, "ab") as f:
+            f.write(b" and then longer")
+        return real(p)
+
+    monkeypatch.setattr(rt, "_hash_file", grow_then_hash)
+    (entry,) = _scan(tmp_path)["entries"]
+    assert entry["path"] == "grows.txt"
+    assert entry["size"] == len(b"short and then longer")
+    assert entry["sha256"] == _sha(b"short and then longer")
+    assert os.path.getsize(path) == entry["size"]
+
+
+def test_scan_is_binary_classification(tmp_path):
+    """``late_nul.bin`` is the one that matters: a NUL past any sampling window.
+
+    Text rows are stored in a column that cannot hold a NUL, so calling this
+    file text writes bytes that no longer hash to the row's own digest, and a
+    restore that verifies that digest then refuses to place it for good."""
+    _write(tmp_path, "text.md", "plain text, with ünïcödé\n".encode())
+    _write(tmp_path, "nul.bin", b"looks like text" + b"\0" + b"until here")
+    _write(tmp_path, "late_nul.bin", b"a" * 70000 + b"\0")
+    _write(tmp_path, "latin1.txt", b"caf\xe9")
+    _write(tmp_path, "empty", b"")
+    out = _scan(tmp_path, max_file_bytes=1_000_000)
+    by = {e["path"]: e["is_binary"] for e in out["entries"]}
+    assert by == {
+        "text.md": False,
+        "nul.bin": True,
+        "late_nul.bin": True,
+        "latin1.txt": True,
+        "empty": False,
+    }
+
+
+def test_scan_multibyte_char_split_at_sniff_window_is_text(tmp_path):
+    _write(tmp_path, "split.txt", b"a" * 8191 + "\u00e9tail\n".encode())
+    _write(tmp_path, "truncated.txt", b"a" * 8191 + b"\xc3")
+    out = _scan(tmp_path, max_file_bytes=10_000)
+    by = {e["path"]: e for e in out["entries"]}
+    assert by["split.txt"]["is_binary"] is False
+    assert by["truncated.txt"]["is_binary"] is True
+
+
+def test_scan_emits_every_dir_with_its_mode(tmp_path):
+    (tmp_path / "empty").mkdir()
+    (tmp_path / "outer/inner").mkdir(parents=True)
+    (tmp_path / "has_file").mkdir()
+    _write(tmp_path, "has_file/x")
+    (tmp_path / "only_excluded").mkdir()
+    _write(tmp_path, "only_excluded/.DS_Store")
+    os.chmod(tmp_path / "has_file", 0o700)
+    out = _scan(tmp_path)
+    by = {e["path"]: e for e in out["entries"]}
+    assert set(by) == {"empty", "outer", "outer/inner", "has_file", "has_file/x", "only_excluded"}
+    assert by["empty"]["kind"] == "dir" and by["empty"]["sha256"] is None
+    assert by["empty"]["mode"] == stat.S_IMODE(os.stat(tmp_path / "empty").st_mode)
+    assert by["has_file"]["kind"] == "dir" and by["has_file"]["mode"] == 0o700
+    assert [e["path"] for e in out["entries"]] == sorted(by)
+
+
+def test_pull_applies_dir_mode_after_children(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    out = rt.pull(
+        {
+            "root": str(root),
+            "items": [
+                {"path": "ro", "kind": "dir", "mode": 0o555, "mtime_ns": 1_000_000_000},
+                {"path": "ro/inner", "kind": "dir", "mode": 0o555, "mtime_ns": 1_000_000_000},
+                {"path": "ro/inner/f.txt", "kind": "file", "url": None, "size": 0, "sha256": None,
+                 "mode": 0o444, "mtime_ns": 1_000_000_000},
+            ],
+        },
+    )
+    assert out["results"]["ro"]["status"] == "ok"
+    assert out["results"]["ro/inner"]["status"] == "ok"
+    assert stat.S_IMODE(os.stat(root / "ro").st_mode) == 0o555
+    assert stat.S_IMODE(os.stat(root / "ro/inner").st_mode) == 0o555
+    assert os.stat(root / "ro").st_mtime_ns == 1_000_000_000
+    os.chmod(root / "ro", 0o755)
+    os.chmod(root / "ro/inner", 0o755)
+
+
+def test_scan_records_symlinks_without_following(tmp_path):
+    _write(tmp_path, "real.txt", b"data")
+    os.symlink("real.txt", tmp_path / "link")
+    os.symlink("/nowhere/at/all", tmp_path / "dangling")
+    (tmp_path / "d").mkdir()
+    os.symlink("..", tmp_path / "d/loop")
+    out = _scan(tmp_path)
+    by = {e["path"]: e for e in out["entries"]}
+    assert by["link"] == {
+        "path": "link",
+        "kind": "symlink",
+        "size": 0,
+        "mtime_ns": os.lstat(tmp_path / "link").st_mtime_ns,
+        "mode": 0,
+        "sha256": None,
+        "symlink_target": "real.txt",
+    }
+    assert by["dangling"]["symlink_target"] == "/nowhere/at/all"
+    assert by["d/loop"]["symlink_target"] == ".."
+    assert set(by) == {"real.txt", "link", "dangling", "d", "d/loop"}
+    assert out["errors"] == []
+
+
+def test_scan_oversized_reported_not_emitted(tmp_path):
+    _write(tmp_path, "big.bin", b"z" * 101)
+    _write(tmp_path, "ok.bin", b"z" * 100)
+    out = _scan(tmp_path)
+    assert [e["path"] for e in out["entries"]] == ["ok.bin"]
+    assert out["oversized"] == [{"path": "big.bin", "size": 101}]
+    assert out["hashed"] == 1
+
+
+def test_scan_unreadable_file_goes_to_errors(tmp_path):
+    if os.geteuid() == 0:
+        pytest.skip("root reads anything")
+    p = _write(tmp_path, "secret", b"s")
+    os.chmod(p, 0)
+    try:
+        out = _scan(tmp_path)
+    finally:
+        os.chmod(p, 0o600)
+    assert out["entries"] == []
+    assert out["errors"] and out["errors"][0]["path"] == "secret"
+
+
+# ---------------------------------------------------------------------------
+# push
+# ---------------------------------------------------------------------------
+
+
+def _push_item(bucket, path: str, data: bytes, key: str | None = None, size: int | None = None):
+    return {
+        "path": path,
+        "sha256": _sha(data),
+        "size": len(data) if size is None else size,
+        "url": f"{bucket.base}/{key or _sha(data)}",
+        "headers": {"x-amz-checksum-sha256": _b64sha(data), "Content-Type": "application/octet-stream"},
+    }
+
+
+@pytest.mark.enable_socket
+def test_push_ok_streams_bytes(tmp_path, bucket):
+    data = os.urandom(3 * 1024 * 1024 + 17)
+    _write(tmp_path, "dir/a.bin", data)
+    item = _push_item(bucket, "dir/a.bin", data)
+    out = rt.push({"root": str(tmp_path), "concurrency": 2, "timeout_s": 10, "items": [item]})
+    assert _sans_ms(out["results"]) == {_sha(data): {"status": "ok", "http": 200, "error": None}}
+    assert bucket.objects[f"/{_sha(data)}"] == data
+
+
+@pytest.mark.enable_socket
+def test_push_redirect_is_a_failure_that_keeps_the_chunk(tmp_path, bucket):
+    """A 3xx on a presigned PUT stored nothing; reporting it as ok would register
+    a digest with no object behind it and unlink the only copy of the chunk."""
+    data = b"chunk bytes"
+    _write(tmp_path, "_internal/packs/c", data)
+    item = _push_item(bucket, "_internal/packs/c", data)
+    item["unlink"] = True
+    bucket.redirects.add(f"/{_sha(data)}")
+    out = rt.push({"root": str(tmp_path), "timeout_s": 10, "items": [item]})
+    assert _sans_ms(out["results"]) == {_sha(data): {"status": "failed", "http": 307, "error": "HTTP 307"}}
+    assert f"/{_sha(data)}" not in bucket.objects
+    assert bucket.hits[f"/{_sha(data)}"] == 1
+    assert (tmp_path / "_internal/packs/c").read_bytes() == data
+
+    get = _file_item(bucket, "g.bin", b"served")
+    bucket.redirects.add(get["url"][len(bucket.base):])
+    out = rt.pull({"root": str(tmp_path), "timeout_s": 10, "items": [get]})
+    assert _sans_ms(out["results"]) == {"g.bin": {"status": "failed", "http": 307, "error": "HTTP 307"}}
+    assert not (tmp_path / "g.bin").exists()
+
+
+@pytest.mark.enable_socket
+def test_push_bad_digest_maps_to_changed(tmp_path, bucket):
+    signed = b"original"
+    _write(tmp_path, "a.bin", b"modified")
+    item = _push_item(bucket, "a.bin", signed)
+    out = rt.push({"root": str(tmp_path), "items": [item]})
+    res = out["results"][_sha(signed)]
+    assert res["status"] == "changed" and res["http"] == 400
+    assert bucket.hits[f"/{_sha(signed)}"] == 1, "4xx must not retry"
+
+
+def test_push_size_changed_before_upload_skips_http(tmp_path):
+    data = b"abc"
+    _write(tmp_path, "a.bin", b"abcd")
+    item = _push_item(bucket=type("B", (), {"base": "http://127.0.0.1:9"})(), path="a.bin", data=data)
+    out = rt.push({"root": str(tmp_path), "items": [item]})
+    assert out["results"][_sha(data)]["status"] == "changed"
+
+
+def test_bounded_body_stops_at_the_declared_length_and_notices_the_rest(tmp_path):
+    """http.client streams a file to EOF whatever Content-Length says."""
+    p = tmp_path / "a.bin"
+    p.write_bytes(b"0123456789")
+    with open(p, "rb") as fh:
+        body = rt._BoundedBody(fh, 4)
+        assert b"".join(iter(lambda: body.read(3), b"")) == b"0123"
+        assert body.overrun is True
+    with open(p, "rb") as fh:
+        body = rt._BoundedBody(fh, 10)
+        assert b"".join(iter(lambda: body.read(4), b"")) == b"0123456789"
+        assert body.overrun is False
+
+
+@pytest.mark.enable_socket
+def test_a_file_that_grows_during_its_own_put_is_reported_changed(tmp_path, bucket, monkeypatch):
+    """The store verifies the bytes it was framed to read, so the prefix
+    matches the signed digest and it answers 200. Only the sandbox can see
+    that the file is no longer the bytes the manifest would claim, and a row
+    written from them would be the file's whole content after a strict stop."""
+    data = b"scanned bytes\n" * 100
+    _write(tmp_path, "a.bin", data)
+    item = _push_item(bucket, "a.bin", data)
+
+    real_request = rt._request
+
+    def _grow_then_request(*args, **kwargs):
+        with open(tmp_path / "a.bin", "ab") as f:
+            f.write(b"appended tail")
+        return real_request(*args, **kwargs)
+
+    monkeypatch.setattr(rt, "_request", _grow_then_request)
+
+    out = rt.push({"root": str(tmp_path), "timeout_s": 10, "items": [item]})
+    res = out["results"][_sha(data)]
+    assert res["status"] == "changed" and res["http"] == 200
+    # The tail never reached the wire, so the object is the scanned prefix and
+    # the pooled connection is not left holding bytes the next request would
+    # read as its own status line.
+    assert bucket.objects[f"/{_sha(data)}"] == data
+
+
+@pytest.mark.enable_socket
+def test_push_unreachable_after_retries(tmp_path):
+    data = b"abc"
+    _write(tmp_path, "a.bin", data)
+    fake = type("B", (), {"base": f"http://127.0.0.1:{_closed_port()}"})()
+    item = _push_item(fake, "a.bin", data)
+    out = rt.push({"root": str(tmp_path), "items": [item], "timeout_s": 2})
+    res = out["results"][_sha(data)]
+    assert res["status"] == "unreachable" and res["http"] is None and res["error"]
+
+
+def test_push_rejects_path_escape(tmp_path):
+    item = {"path": "../x", "sha256": "0" * 64, "size": 1, "url": "http://127.0.0.1:9/x", "headers": {}}
+    out = rt.push({"root": str(tmp_path), "items": [item]})
+    assert out["results"]["0" * 64]["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# pull
+# ---------------------------------------------------------------------------
+
+
+def _file_item(bucket, path: str, data: bytes, mode: int = 0o640, mtime_ns: int = 1_700_000_000_123_456_789, **over):
+    key = f"/{_sha(data)}"
+    bucket.objects[key] = data
+    item = {
+        "path": path,
+        "kind": "file",
+        "sha256": _sha(data),
+        "size": len(data),
+        "url": f"{bucket.base}{key}",
+        "mode": mode,
+        "mtime_ns": mtime_ns,
+        "symlink_target": None,
+    }
+    item.update(over)
+    return item
+
+
+@pytest.mark.enable_socket
+def test_pull_ok_applies_mode_and_mtime(tmp_path, bucket):
+    data = os.urandom(2 * 1024 * 1024 + 5)
+    item = _file_item(bucket, "nested/deep/a.bin", data, mode=0o600, mtime_ns=1_600_000_000_000_000_000)
+    out = rt.pull({"root": str(tmp_path), "concurrency": 4, "timeout_s": 10, "items": [item]})
+    assert _sans_ms(out["results"]) == {"nested/deep/a.bin": {"status": "ok", "http": 200, "error": None}}
+    final = tmp_path / "nested/deep/a.bin"
+    assert final.read_bytes() == data
+    st = os.stat(final)
+    assert stat.S_IMODE(st.st_mode) == 0o600
+    assert st.st_mtime_ns == 1_600_000_000_000_000_000
+    assert not [p for p in os.listdir(final.parent) if p.startswith(".wsfiles-")]
+
+
+@pytest.mark.enable_socket
+def test_pull_mismatch_leaves_no_file(tmp_path, bucket):
+    item = _file_item(bucket, "a.bin", b"served", sha256=_sha(b"expected"))
+    out = rt.pull({"root": str(tmp_path), "items": [item]})
+    assert out["results"]["a.bin"]["status"] == "mismatch"
+    assert not (tmp_path / "a.bin").exists()
+    assert not [p for p in os.listdir(tmp_path) if p.startswith(".wsfiles-")]
+
+
+@pytest.mark.enable_socket
+def test_pull_404_failed_no_retry_and_500_retries(tmp_path, bucket):
+    missing = _file_item(bucket, "m.bin", b"m")
+    del bucket.objects[f"/{_sha(b'm')}"]
+    broken = _file_item(bucket, "b.bin", b"b")
+    bucket.fail_500.add(f"/{_sha(b'b')}")
+    out = rt.pull({"root": str(tmp_path), "items": [missing, broken]})
+    assert _sans_ms(out["results"])["m.bin"] == {"status": "failed", "http": 404, "error": "HTTP 404"}
+    assert bucket.hits[f"/{_sha(b'm')}"] == 1
+    assert out["results"]["b.bin"]["status"] == "failed" and out["results"]["b.bin"]["http"] == 500
+    assert bucket.hits[f"/{_sha(b'b')}"] == 3
+
+
+@pytest.mark.enable_socket
+def test_pull_unreachable(tmp_path):
+    item = {
+        "path": "a.bin",
+        "kind": "file",
+        "sha256": "0" * 64,
+        "size": 1,
+        "url": f"http://127.0.0.1:{_closed_port()}/x",
+        "mode": 0o644,
+        "mtime_ns": 0,
+        "symlink_target": None,
+    }
+    out = rt.pull({"root": str(tmp_path), "items": [item], "timeout_s": 2})
+    assert out["results"]["a.bin"]["status"] == "unreachable"
+
+
+def test_pull_symlink_replaces_file_link_or_empty_dir_but_not_a_populated_one(tmp_path):
+    """A fresh sandbox seeds ``data``, ``results`` and ``work`` before the
+    restore runs; a manifest that names one as a symlink has to win over the
+    empty seed, or the restore fails on every recreation and the next backup
+    records the seed in the symlink's place."""
+    _write(tmp_path, "was_file", b"f")
+    os.symlink("old", tmp_path / "was_link")
+    (tmp_path / "was_dir").mkdir()
+    (tmp_path / "full_dir").mkdir()
+    _write(tmp_path, "full_dir/child", b"c")
+    items = [
+        {"path": p, "kind": "symlink", "sha256": None, "size": 0, "url": None, "mode": 0, "mtime_ns": 1_500_000_000_000_000_000, "symlink_target": "target"}
+        for p in ("was_file", "was_link", "was_dir", "full_dir", "fresh/new")
+    ]
+    out = rt.pull({"root": str(tmp_path), "items": items})
+    r = out["results"]
+    assert r["was_file"]["status"] == "ok" and os.readlink(tmp_path / "was_file") == "target"
+    assert r["was_link"]["status"] == "ok" and os.readlink(tmp_path / "was_link") == "target"
+    assert r["fresh/new"]["status"] == "ok" and os.readlink(tmp_path / "fresh/new") == "target"
+    assert r["was_dir"]["status"] == "ok" and os.readlink(tmp_path / "was_dir") == "target"
+    assert r["full_dir"]["status"] == "failed" and (tmp_path / "full_dir/child").is_file()
+
+
+@pytest.mark.enable_socket
+def test_pull_dir_items_get_mode_and_mtime_after_children(tmp_path, bucket):
+    dir_item = {
+        "path": "d",
+        "kind": "dir",
+        "sha256": None,
+        "size": 0,
+        "url": None,
+        "mode": 0o750,
+        "mtime_ns": 1_400_000_000_000_000_000,
+        "symlink_target": None,
+    }
+    child = _file_item(bucket, "d/child", b"c")
+    out = rt.pull({"root": str(tmp_path), "items": [dir_item, child]})
+    assert out["results"]["d"]["status"] == "ok" and out["results"]["d/child"]["status"] == "ok"
+    st = os.stat(tmp_path / "d")
+    assert stat.S_IMODE(st.st_mode) == 0o750
+    assert st.st_mtime_ns == 1_400_000_000_000_000_000
+
+
+def test_pull_rejects_path_escape_and_absolute(tmp_path):
+    items = [
+        {"path": p, "kind": "file", "sha256": "0" * 64, "size": 1, "url": "http://127.0.0.1:9/x", "mode": 0o644, "mtime_ns": 0, "symlink_target": None}
+        for p in ("../outside", "a/../../outside", "/etc/passwd")
+    ]
+    out = rt.pull({"root": str(tmp_path), "items": items})
+    assert {k: v["status"] for k, v in out["results"].items()} == {
+        "../outside": "failed",
+        "a/../../outside": "failed",
+        "/etc/passwd": "failed",
+    }
+    assert not (tmp_path.parent / "outside").exists()
+
+
+def test_pull_file_over_a_populated_dir_fails_and_an_empty_one_yields(tmp_path):
+    (tmp_path / "d").mkdir()
+    _write(tmp_path, "d/child", b"c")
+    (tmp_path / "e").mkdir()
+    (tmp_path / ".wsfiles-relay-e").write_bytes(b"seeded over")
+    full = {"path": "d", "kind": "file", "sha256": "0" * 64, "size": 1, "url": "http://127.0.0.1:9/x", "mode": 0o644, "mtime_ns": 0, "symlink_target": None}
+    empty = {"path": "e", "kind": "file", "file": ".wsfiles-relay-e", "sha256": _sha(b"seeded over"), "size": 11, "mode": 0o644, "mtime_ns": 1}
+    out = rt.pull({"root": str(tmp_path), "items": [full, empty]})
+    assert out["results"]["d"]["status"] == "failed" and (tmp_path / "d/child").is_file()
+    assert out["results"]["e"]["status"] == "ok" and (tmp_path / "e").read_bytes() == b"seeded over"
+
+
+@pytest.mark.enable_socket
+def test_a_seed_dir_survives_a_transfer_that_fails_after_the_check(tmp_path, _no_backoff):
+    """The empty seed yields only once the bytes are verified: a failed pull or
+    a mismatched staged copy leaves ``data`` standing, so the path still exists
+    for the rest of the session and the next restore gets the same chance."""
+    (tmp_path / "data").mkdir()
+    (tmp_path / "work").mkdir()
+    (tmp_path / ".wsfiles-relay-work").write_bytes(b"not what the manifest says")
+    dead = {"path": "data", "kind": "file", "sha256": "0" * 64, "size": 1, "url": "http://127.0.0.1:9/x", "mode": 0o644, "mtime_ns": 0, "symlink_target": None}
+    bad = {"path": "work", "kind": "file", "file": ".wsfiles-relay-work", "sha256": "0" * 64, "size": 1, "mode": 0o644, "mtime_ns": 1}
+    out = rt.pull({"root": str(tmp_path), "items": [dead, bad]})
+    assert out["results"]["data"]["status"] == "unreachable"
+    assert out["results"]["work"]["status"] == "mismatch"
+    assert (tmp_path / "data").is_dir() and (tmp_path / "work").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_prints_result_line_and_exit_codes(tmp_path, capsys):
+    import base64
+    import json
+
+    def _result():
+        out = capsys.readouterr()
+        lines = [l for l in out.out.splitlines() if l.startswith(rt.RESULT_MARKER)]
+        return json.loads(lines[-1][len(rt.RESULT_MARKER):]) if lines else None, out.err
+
+    _write(tmp_path, "ws/a.txt", b"a")
+    spec = {"root": str(tmp_path / "ws")}
+    inline = base64.b64encode(json.dumps(spec).encode()).decode()
+    assert rt._main(["x", "scan", "--spec-b64", inline]) == 0
+    res, _ = _result()
+    assert res["entries"][0]["path"] == "a.txt"
+
+    spec_file = tmp_path / "in.json"
+    spec_file.write_text(json.dumps(spec))
+    assert rt._main(["x", "scan", str(spec_file)]) == 0
+    res, _ = _result()
+    assert res["entries"][0]["path"] == "a.txt"
+    assert not spec_file.exists(), "the spec file is consumed"
+
+    assert rt._main(["x", "scan", str(tmp_path / "missing.json")]) == 2
+    res, err = _result()
+    assert res is None and "invalid input" in err
+    assert rt._main(["x", "bogus", "--spec-b64", inline]) == 2
+    assert rt._main(["x", "scan"]) == 2
+
+
+def test_pull_file_places_a_staged_relay_upload(tmp_path):
+    """Bytes the server uploaded to a staging name are verified, moved into
+    place and stamped; a truncated or foreign staged copy never becomes the file."""
+    (tmp_path / ".wsfiles-relay-1").write_bytes(b"relayed")
+    item = {"path": "d/r.txt", "kind": "file", "file": ".wsfiles-relay-1", "sha256": _sha(b"relayed"),
+            "size": 7, "mode": 0o600, "mtime_ns": 1_500_000_000_000_000_000}
+    (tmp_path / ".wsfiles-relay-2").write_bytes(b"x")
+    short = {"path": "s.txt", "kind": "file", "file": ".wsfiles-relay-2", "sha256": _sha(b"xyz"),
+             "size": 3, "mode": 0o644, "mtime_ns": 1}
+    (tmp_path / ".wsfiles-relay-3").write_bytes(b"abc")
+    wrong = {"path": "w.txt", "kind": "file", "file": ".wsfiles-relay-3", "sha256": _sha(b"xyz"),
+             "size": 3, "mode": 0o644, "mtime_ns": 1}
+    gone = {"path": "gone.txt", "kind": "file", "file": ".wsfiles-relay-4", "sha256": _sha(b"a"), "size": 1}
+    no_url = {"path": "n.txt", "kind": "file", "url": None, "size": 1}
+    out = rt.pull({"root": str(tmp_path), "items": [item, short, wrong, gone, no_url]})
+    assert out["results"]["d/r.txt"]["status"] == "ok"
+    st = os.stat(tmp_path / "d/r.txt")
+    assert stat.S_IMODE(st.st_mode) == 0o600 and st.st_mtime_ns == 1_500_000_000_000_000_000
+    assert (tmp_path / "d/r.txt").read_bytes() == b"relayed"
+    assert out["results"]["s.txt"]["status"] == "mismatch"
+    assert out["results"]["w.txt"]["status"] == "mismatch"
+    assert out["results"]["gone.txt"]["status"] == "failed"
+    assert out["results"]["n.txt"] == {"status": "failed", "http": None, "error": "missing url", "ms": out["results"]["n.txt"]["ms"]}
+    assert not (tmp_path / "s.txt").exists() and not (tmp_path / "w.txt").exists()
+    assert not [p for p in os.listdir(tmp_path) if p.startswith(".wsfiles-")]
+
+
+def test_pull_removes_staging_files_no_item_claims(tmp_path):
+    """A relay upload the file API cut short leaves its partial bytes under
+    the staging name with no item pointing at it; the scan skips the prefix,
+    so the next pull op is the only thing that will ever remove it."""
+    (tmp_path / ".wsfiles-relay-orphan").write_bytes(b"partial")
+    (tmp_path / ".wsfiles-relay-1").write_bytes(b"relayed")
+    (tmp_path / ".wsfiles-tmpdead").write_bytes(b"a download the runtime died in")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub/.wsfiles-other").write_bytes(b"the user's own file")
+    item = {"path": "r.txt", "kind": "file", "file": ".wsfiles-relay-1", "sha256": _sha(b"relayed"),
+            "size": 7, "mode": 0o644, "mtime_ns": 1}
+    out = rt.pull({"root": str(tmp_path), "items": [item]})
+    assert out["results"]["r.txt"]["status"] == "ok"
+    assert not (tmp_path / ".wsfiles-relay-orphan").exists()
+    assert not (tmp_path / ".wsfiles-tmpdead").exists()
+    assert (tmp_path / "sub/.wsfiles-other").exists()
+    # A pull with nothing to stage (the direct pass) sweeps too.
+    (tmp_path / ".wsfiles-relay-orphan2").write_bytes(b"partial")
+    rt.pull({"root": str(tmp_path), "items": []})
+    assert not (tmp_path / ".wsfiles-relay-orphan2").exists()
+
+
+def test_pull_defers_dir_modes_and_reopens_a_closed_dir(tmp_path):
+    """With ``defer_dir_modes`` the directories stay writable for a later op;
+    that op reopens a directory an earlier attempt already closed, places the
+    file, and closes it again."""
+    dirs = [
+        {"path": "ro", "kind": "dir", "mode": 0o555, "mtime_ns": 1_000_000_000},
+        {"path": "ro/inner", "kind": "dir", "mode": 0o555, "mtime_ns": 1_000_000_000},
+    ]
+    out = rt.pull({"root": str(tmp_path), "items": dirs, "defer_dir_modes": True})
+    assert {p: r["status"] for p, r in out["results"].items()} == {"ro": "ok", "ro/inner": "ok"}
+    assert stat.S_IMODE(os.stat(tmp_path / "ro/inner").st_mode) & 0o300 == 0o300
+
+    os.chmod(tmp_path / "ro/inner", 0o555)
+    os.chmod(tmp_path / "ro", 0o555)
+    (tmp_path / ".wsfiles-relay-f").write_bytes(b"late")
+    staged = {"path": "ro/inner/f.txt", "kind": "file", "file": ".wsfiles-relay-f", "sha256": _sha(b"late"),
+              "size": 4, "mode": 0o444, "mtime_ns": 1_000_000_000}
+    out = rt.pull({"root": str(tmp_path), "items": [staged] + dirs})
+    assert {p: r["status"] for p, r in out["results"].items()} == {"ro": "ok", "ro/inner": "ok", "ro/inner/f.txt": "ok"}
+    assert (tmp_path / "ro/inner/f.txt").read_bytes() == b"late"
+    assert stat.S_IMODE(os.stat(tmp_path / "ro").st_mode) == 0o555
+    assert stat.S_IMODE(os.stat(tmp_path / "ro/inner").st_mode) == 0o555
+    assert os.stat(tmp_path / "ro/inner").st_mtime_ns == 1_000_000_000
+    os.chmod(tmp_path / "ro", 0o755)
+    os.chmod(tmp_path / "ro/inner", 0o755)
+
+
+@pytest.mark.enable_socket
+def test_pull_prefers_direct_egress_over_a_dead_proxy(tmp_path, bucket, monkeypatch):
+    """A proxy in the environment is not the route to the store: the runtime
+    connects directly and only falls back to the proxy when that fails."""
+    monkeypatch.setenv("http_proxy", "http://127.0.0.1:1")
+    monkeypatch.setenv("https_proxy", "http://127.0.0.1:1")
+    monkeypatch.delenv("no_proxy", raising=False)
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    rt._local.__dict__.clear()
+    item = _file_item(bucket, "direct.bin", b"direct")
+    out = rt.pull({"root": str(tmp_path), "items": [item], "concurrency": 1})
+    assert out["results"]["direct.bin"]["status"] == "ok"
+    assert (tmp_path / "direct.bin").read_bytes() == b"direct"
+    rt._local.__dict__.clear()
+
+
+@pytest.mark.enable_socket
+def test_a_body_read_that_fails_mid_stream_drops_the_pooled_connection(tmp_path, bucket, monkeypatch):
+    """A half-read response poisons the connection it came in on: the next
+    request on that thread fails with ``CannotSendRequest``, which the caller
+    reads as unreachable and spends a retry attempt on. The response carries
+    the pool key so the failing read can discard exactly its own connection.
+    """
+    rt._local.__dict__.clear()
+    monkeypatch.setattr(rt, "_CHUNK", 8)
+    key = ("http", "127.0.0.1", bucket.server_address[1])
+    item = _file_item(bucket, "half.bin", b"z" * 64)
+
+    stamped = []
+    real_request = rt._request
+    fail_next = [True]
+
+    class _ReadFailsMidBody:
+        """One chunk, then the peer goes away with the body unfinished."""
+
+        def __init__(self, resp):
+            self.status = resp.status
+            self.wsfiles_conn_key = resp.wsfiles_conn_key
+            stamped.append(resp.wsfiles_conn_key)
+            self._resp = resp
+            self._served = False
+
+        def read(self, amt=None):
+            if self._served:
+                raise ConnectionResetError("peer reset mid-body")
+            self._served = True
+            return self._resp.read(amt)
+
+    def _flaky_request(*args, **kwargs):
+        resp = real_request(*args, **kwargs)
+        if not fail_next[0]:
+            return resp
+        fail_next[0] = False
+        return _ReadFailsMidBody(resp)
+
+    monkeypatch.setattr(rt, "_request", _flaky_request)
+
+    with pytest.raises(ConnectionResetError):
+        rt._download_to_temp(item["url"], str(tmp_path), 10)
+    assert stamped == [key]
+    assert key not in rt._local.conns
+    assert not [p for p in os.listdir(tmp_path) if p.startswith(".wsfiles-")]
+
+    # The control: a body read that runs to the end keeps its connection.
+    name, _, _, _ = rt._download_to_temp(item["url"], str(tmp_path), 10)
+    os.unlink(name)
+    assert key in rt._local.conns
+    rt._local.__dict__.clear()
+
+
+# ---------------------------------------------------------------------------
+# pack
+# ---------------------------------------------------------------------------
+
+
+def _members(root, files: dict[str, bytes]):
+    for rel, data in files.items():
+        _write(root, rel, data)
+    return [{"path": rel, "sha256": _sha(data), "size": len(data)} for rel, data in files.items()]
+
+
+def _pack(root, members, max_bytes=32 * 1024 * 1024):
+    return rt.pack({"root": str(root), "out_dir": "_internal/packs", "max_bytes": max_bytes, "members": members})
+
+
+def test_pack_is_deterministic_in_path_order(tmp_path):
+    members = _members(tmp_path, {"b.txt": b"bee", "a/z.txt": b"zed", "a/y.txt": b"why"})
+    out = _pack(tmp_path, members)
+    assert out["changed"] == [] and len(out["chunks"]) == 1
+    chunk = out["chunks"][0]
+    data = b"whyzedbee"
+    assert [m["path"] for m in chunk["members"]] == ["a/y.txt", "a/z.txt", "b.txt"]
+    assert [(m["offset"], m["size"]) for m in chunk["members"]] == [(0, 3), (3, 3), (6, 3)]
+    assert chunk["sha256"] == _sha(data) and chunk["size"] == len(data)
+    assert chunk["path"].startswith("_internal/packs/op-") and chunk["path"].endswith(f"/chunk-{_sha(data)}")
+    assert (tmp_path / chunk["path"]).read_bytes() == data
+    # The same set handed over in another order yields the same chunk.
+    assert _pack(tmp_path, list(reversed(members)))["chunks"][0]["sha256"] == chunk["sha256"]
+
+
+def test_pack_splits_at_member_boundaries(tmp_path):
+    members = _members(tmp_path, {f"f{i}.bin": bytes([i]) * 4 for i in range(5)})
+    first = _pack(tmp_path, members, max_bytes=10)
+    assert [len(c["members"]) for c in first["chunks"]] == [2, 2, 1]
+    assert all(c["size"] <= 10 for c in first["chunks"])
+    # A member over the cap still gets a chunk of its own.
+    second = _pack(tmp_path, members + _members(tmp_path, {"big.bin": b"x" * 25}), max_bytes=10)
+    assert [c["size"] for c in second["chunks"]] == [25, 8, 8, 4]
+
+
+def test_overlapping_pack_ops_never_touch_each_other(tmp_path):
+    """Two syncs of one workspace can overlap; each op owns its directory,
+    and only directories nothing can still be pushing from are swept."""
+    members = _members(tmp_path, {"a.txt": b"aaa"})
+    first = _pack(tmp_path, members)
+    first_chunk = tmp_path / first["chunks"][0]["path"]
+    second = _pack(tmp_path, members)
+    assert first_chunk.exists() and (tmp_path / second["chunks"][0]["path"]).exists()
+    assert first["chunks"][0]["sha256"] == second["chunks"][0]["sha256"]
+    # Age the first op's directory past the sweep threshold: the next op removes it.
+    old = 1_000_000_000
+    os.utime(first_chunk.parent, ns=(old * 10**9, old * 10**9))
+    third = _pack(tmp_path, members)
+    assert not first_chunk.parent.exists()
+    assert (tmp_path / second["chunks"][0]["path"]).exists()
+    assert (tmp_path / third["chunks"][0]["path"]).exists()
+
+
+def test_unlink_removes_only_files_under_root(tmp_path):
+    _write(tmp_path, "_internal/packs/op-1/chunk-x", b"c")
+    (tmp_path / "d").mkdir()
+    out = rt.unlink({"root": str(tmp_path), "paths": ["_internal/packs/op-1/chunk-x", "d", "../escape", "missing"]})
+    assert out == {"removed": 1}
+    assert not (tmp_path / "_internal/packs/op-1/chunk-x").exists() and (tmp_path / "d").is_dir()
+
+
+def test_scan_skips_the_root_temp_namespace_only(tmp_path):
+    """Every transient file lives at the root under the prefix; a user's own
+    ``dir/.wsfiles-notes`` is a file like any other, or the next sync would
+    prune its row and a strict stop would lose it."""
+    _write(tmp_path, "keep.txt", b"k")
+    _write(tmp_path, ".wsfiles-abc123", b"partial")
+    _write(tmp_path, "dir/.wsfiles-notes", b"mine")
+    out = _scan(tmp_path, exclude_root_basename_prefixes=[".wsfiles-"])
+    assert sorted(e["path"] for e in out["entries"] if e["kind"] == "file") == ["dir/.wsfiles-notes", "keep.txt"]
+
+
+def test_scan_skips_the_sync_marker_at_the_root_only(tmp_path):
+    """The marker is a root file; the same name deeper down is the user's."""
+    _write(tmp_path, ".file_sync_marker", b"2026")
+    _write(tmp_path, ".file_sync_marker.bak", b"mine too")
+    _write(tmp_path, "results/.file_sync_marker", b"mine")
+    out = _scan(tmp_path, exclude_root_basenames=[".file_sync_marker"])
+    assert sorted(e["path"] for e in out["entries"] if e["kind"] == "file") == [
+        ".file_sync_marker.bak", "results/.file_sync_marker",
+    ]
+
+
+def test_scan_skips_reserved_root_names_for_every_entry_type(tmp_path):
+    """The pull op's sweep removes any unclaimed root ``.wsfiles-`` entry,
+    directories included, so a row for one would only promise what the next
+    restore deletes; the same names one level down are the user's."""
+    _write(tmp_path, ".wsfiles-relay-1/part", b"x")
+    _write(tmp_path, "keep.txt", b"k")
+    os.symlink("keep.txt", tmp_path / ".wsfiles-link")
+    os.symlink("keep.txt", tmp_path / ".file_sync_marker")
+    _write(tmp_path, "sub/.wsfiles-mine/part", b"y")
+    os.symlink("../keep.txt", tmp_path / "sub" / ".file_sync_marker")
+    out = _scan(
+        tmp_path,
+        exclude_root_basenames=[".file_sync_marker"],
+        exclude_root_basename_prefixes=[".wsfiles-"],
+    )
+    assert [e["path"] for e in out["entries"]] == [
+        "keep.txt", "sub", "sub/.file_sync_marker", "sub/.wsfiles-mine", "sub/.wsfiles-mine/part",
+    ]
+
+
+def test_pull_writes_its_temp_files_at_the_root(tmp_path):
+    """A temp beside the target would need the scan to skip the prefix at
+    every depth, which is what made a user's ``dir/.wsfiles-notes`` vanish."""
+    seen: list[str] = []
+    orig = rt.tempfile.NamedTemporaryFile
+
+    def spy(*a, **kw):
+        seen.append(kw["dir"])
+        return orig(*a, **kw)
+
+    rt.tempfile.NamedTemporaryFile = spy
+    try:
+        (tmp_path / ".wsfiles-relay-1").write_bytes(b"relayed")
+        item = {"path": "d/e/r.txt", "kind": "file", "file": ".wsfiles-relay-1", "sha256": _sha(b"relayed"), "size": 7}
+        rt.pull({"root": str(tmp_path), "items": [item]})
+        chunk = b"member"
+        (tmp_path / ".wsfiles-relay-c").write_bytes(chunk)
+        pack = {"kind": "pack", "file": ".wsfiles-relay-c", "sha256": _sha(chunk), "size": len(chunk),
+                "members": [{"path": "d/e/m.txt", "offset": 0, "size": 6, "sha256": _sha(b"member")}]}
+        out = rt.pull({"root": str(tmp_path), "items": [pack]})
+    finally:
+        rt.tempfile.NamedTemporaryFile = orig
+    assert out["results"]["d/e/m.txt"]["status"] == "ok"
+    assert seen and set(seen) == {str(tmp_path)}
+
+
+def test_hash_file_reads_a_late_bad_sequence_as_binary(tmp_path):
+    """A blob row is never re-read on the way out, so the whole file has to
+    decide: a bad sequence after the first pages would otherwise be served
+    as text with replacement marks."""
+    late = b"x" * (64 * 1024 + 1) + b"\xff\xfe"
+    (tmp_path / "late.txt").write_bytes(late)
+    big_text = ("caf\u00e9 " * 40_000).encode("utf-8")
+    (tmp_path / "big.txt").write_bytes(big_text)
+    (tmp_path / "nul.bin").write_bytes(b"a" * 10 + b"\0" + b"b" * 10)
+    assert rt._hash_file(str(tmp_path / "late.txt")) == (_sha(late), True, len(late))
+    assert rt._hash_file(str(tmp_path / "big.txt")) == (_sha(big_text), False, len(big_text))
+    assert rt._hash_file(str(tmp_path / "nul.bin"))[1] is True
+
+
+def test_pack_drops_a_member_that_changed_or_vanished(tmp_path):
+    members = _members(tmp_path, {"same.txt": b"same", "edited.txt": b"old!", "gone.txt": b"gone"})
+    (tmp_path / "edited.txt").write_bytes(b"new!")  # same size, different bytes
+    (tmp_path / "gone.txt").unlink()
+    out = _pack(tmp_path, members)
+    assert sorted(out["changed"]) == ["edited.txt", "gone.txt"]
+    assert [m["path"] for m in out["chunks"][0]["members"]] == ["same.txt"]
+    assert out["chunks"][0]["sha256"] == _sha(b"same")
+
+
+def test_pack_with_nothing_to_pack_writes_no_chunk(tmp_path):
+    assert _pack(tmp_path, []) == {"chunks": [], "changed": []}
+    assert os.listdir(tmp_path / "_internal/packs") == []
+
+
+@pytest.mark.enable_socket
+def test_push_unlink_removes_the_file_after_upload(tmp_path, bucket):
+    data = b"chunk bytes"
+    _write(tmp_path, "_internal/packs/chunk-x", data)
+    item = {**_push_item(bucket, "_internal/packs/chunk-x", data), "unlink": True}
+    out = rt.push({"root": str(tmp_path), "concurrency": 2, "timeout_s": 10, "items": [item]})
+    assert out["results"][_sha(data)]["status"] == "ok"
+    assert bucket.objects[f"/{_sha(data)}"] == data
+    assert not (tmp_path / "_internal/packs/chunk-x").exists()
+
+
+@pytest.mark.enable_socket
+def test_push_unlink_is_withheld_when_the_store_is_unreachable(tmp_path):
+    """The server relays a chunk the sandbox could not upload, by reading it
+    back out of the sandbox. Unlinking on a failed push loses those bytes."""
+    data = b"chunk bytes"
+    _write(tmp_path, "_internal/packs/chunk-x", data)
+    fake = type("B", (), {"base": f"http://127.0.0.1:{_closed_port()}"})()
+    item = {**_push_item(fake, "_internal/packs/chunk-x", data), "unlink": True}
+    out = rt.push({"root": str(tmp_path), "items": [item], "timeout_s": 2})
+    assert out["results"][_sha(data)]["status"] == "unreachable"
+    assert (tmp_path / "_internal/packs/chunk-x").read_bytes() == data
+
+
+@pytest.mark.enable_socket
+def test_push_unlink_is_withheld_when_the_store_rejected_the_chunk(tmp_path, bucket):
+    signed = b"original"
+    _write(tmp_path, "_internal/packs/chunk-x", b"modified")
+    item = {**_push_item(bucket, "_internal/packs/chunk-x", signed), "unlink": True}
+    out = rt.push({"root": str(tmp_path), "items": [item]})
+    assert out["results"][_sha(signed)]["status"] == "changed"
+    assert (tmp_path / "_internal/packs/chunk-x").exists()
+
+
+def _pack_item(bucket, members: dict[str, bytes], **over):
+    order = sorted(members)
+    data = b"".join(members[p] for p in order)
+    key = f"/{_sha(data)}"
+    bucket.objects[key] = data
+    entries, offset = [], 0
+    for p in order:
+        entries.append(
+            {"path": p, "offset": offset, "size": len(members[p]), "sha256": _sha(members[p]),
+             "mode": 0o640, "mtime_ns": 1_700_000_000_000_000_000}
+        )
+        offset += len(members[p])
+    item = {"kind": "pack", "sha256": _sha(data), "size": len(data), "url": f"{bucket.base}{key}", "members": entries}
+    item.update(over)
+    return item
+
+
+def _pull(root, *items):
+    return rt.pull({"root": str(root), "concurrency": 4, "timeout_s": 10, "items": list(items)})
+
+
+@pytest.mark.enable_socket
+def test_pull_pack_extracts_every_member_with_one_get(tmp_path, bucket):
+    item = _pack_item(bucket, {"a/one.txt": b"one", "two.txt": b"two two", "empty.txt": b""})
+    out = _pull(tmp_path, item)
+    assert _sans_ms(out["results"]) == {
+        p: {"status": "ok", "http": 200, "error": None} for p in ("a/one.txt", "two.txt", "empty.txt")
+    }
+    assert (tmp_path / "a/one.txt").read_bytes() == b"one"
+    assert (tmp_path / "two.txt").read_bytes() == b"two two"
+    assert (tmp_path / "empty.txt").read_bytes() == b""
+    st = os.stat(tmp_path / "two.txt")
+    assert stat.S_IMODE(st.st_mode) == 0o640 and st.st_mtime_ns == 1_700_000_000_000_000_000
+    assert bucket.hits[item["url"][len(bucket.base):]] == 1
+    assert not [p for p in os.listdir(tmp_path) if p.startswith(".wsfiles-")]
+    assert os.listdir(tmp_path / "_internal/packs") == []
+
+
+def test_pull_pack_consumes_a_chunk_already_in_the_sandbox(tmp_path):
+    """The relay path uploads the chunk itself; the runtime verifies, slices and removes it."""
+    members = {"names/trailing. ": b"sp", "names/new\nline.txt": b"nl", "c.txt": b"ccc"}
+    data = b"".join(members[p] for p in sorted(members))
+    (tmp_path / ".wsfiles-relay-x").write_bytes(data)
+    entries, off = [], 0
+    for p in sorted(members):
+        entries.append({"path": p, "offset": off, "size": len(members[p]), "sha256": _sha(members[p]), "mode": 0o600, "mtime_ns": 1_700_000_000_000_000_000})
+        off += len(members[p])
+    out = _pull(tmp_path, {"kind": "pack", "file": ".wsfiles-relay-x", "sha256": _sha(data), "size": len(data), "members": entries})
+    assert {p: r["status"] for p, r in out["results"].items()} == {p: "ok" for p in members}
+    assert (tmp_path / "names/trailing. ").read_bytes() == b"sp"
+    assert (tmp_path / "names/new\nline.txt").read_bytes() == b"nl"
+    assert stat.S_IMODE(os.stat(tmp_path / "c.txt").st_mode) == 0o600
+    assert not (tmp_path / ".wsfiles-relay-x").exists()
+
+
+def test_pull_pack_local_chunk_mismatch_fails_all_and_removes_the_chunk(tmp_path):
+    (tmp_path / ".wsfiles-relay-x").write_bytes(b"corrupt")
+    item = {"kind": "pack", "file": ".wsfiles-relay-x", "sha256": _sha(b"aaa"), "size": 3,
+            "members": [{"path": "a.txt", "offset": 0, "size": 3, "sha256": _sha(b"aaa"), "mode": 0o600, "mtime_ns": 0}]}
+    out = _pull(tmp_path, item)
+    assert out["results"]["a.txt"]["status"] == "mismatch"
+    assert not (tmp_path / "a.txt").exists()
+    assert not (tmp_path / ".wsfiles-relay-x").exists()
+    out = _pull(tmp_path, dict(item, file="../outside"))
+    assert out["results"]["a.txt"] == {"status": "failed", "http": None, "error": "file escapes root", "ms": out["results"]["a.txt"]["ms"]}
+
+
+@pytest.mark.enable_socket
+def test_pull_pack_chunk_mismatch_fails_every_member_and_writes_nothing(tmp_path, bucket):
+    item = _pack_item(bucket, {"a.txt": b"aaa", "b.txt": b"bbb"}, sha256=_sha(b"other"))
+    out = _pull(tmp_path, item)
+    assert {p: r["status"] for p, r in out["results"].items()} == {"a.txt": "mismatch", "b.txt": "mismatch"}
+    assert not (tmp_path / "a.txt").exists() and not (tmp_path / "b.txt").exists()
+
+
+@pytest.mark.enable_socket
+def test_pull_pack_member_mismatch_is_confined_to_that_member(tmp_path, bucket):
+    item = _pack_item(bucket, {"a.txt": b"aaa", "b.txt": b"bbb"})
+    item["members"][1]["sha256"] = _sha(b"xxx")
+    out = _pull(tmp_path, item)
+    assert {p: r["status"] for p, r in out["results"].items()} == {"a.txt": "ok", "b.txt": "mismatch"}
+    assert (tmp_path / "a.txt").read_bytes() == b"aaa" and not (tmp_path / "b.txt").exists()
+
+
+@pytest.mark.enable_socket
+def test_pull_pack_404_fails_all_and_500_retries(tmp_path, bucket):
+    item = _pack_item(bucket, {"a.txt": b"aaa"})
+    key = item["url"][len(bucket.base):]
+    bucket.fail_500.add(key)
+    out = _pull(tmp_path, item)
+    assert _sans_ms(out["results"]) == {"a.txt": {"status": "failed", "http": 500, "error": "HTTP 500"}}
+    assert bucket.hits[key] == rt._MAX_ATTEMPTS
+    missing = _pack_item(bucket, {"m.txt": b"m"})
+    del bucket.objects[missing["url"][len(bucket.base):]]
+    out = _pull(tmp_path, missing)
+    assert _sans_ms(out["results"]) == {"m.txt": {"status": "failed", "http": 404, "error": "HTTP 404"}}
+
+
+@pytest.mark.enable_socket
+def test_pull_packs_and_files_share_one_pass(tmp_path, bucket):
+    pack = _pack_item(bucket, {"small.txt": b"small"})
+    big = _file_item(bucket, "big.bin", os.urandom(4096))
+    out = _pull(tmp_path, big, pack)
+    assert {p: r["status"] for p, r in out["results"].items()} == {"small.txt": "ok", "big.bin": "ok"}
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["p"],
+        ["p", "scan"],
+        ["p", "nope", "spec.json"],
+        ["p", "scan", "--spec-b64"],
+        ["p", "scan", "spec.json", "extra"],
+        ["p", "scan", "spec.json", "--spec-b64"],
+    ],
+)
+def test_main_answers_every_malformed_argv_with_usage(argv, capsys):
+    assert rt._main(argv) == 2
+    assert capsys.readouterr().err == rt._USAGE
+
+
+def test_main_accepts_both_spec_forms(tmp_path, monkeypatch):
+    monkeypatch.setitem(rt._OPS, "scan", lambda spec: {"seen": spec})
+    b64 = base64.b64encode(b'{"root":"/x"}').decode()
+    assert rt._main(["p", "scan", "--spec-b64", b64]) == 0
+
+    path = tmp_path / "spec.json"
+    path.write_bytes(b'{"root":"/y"}')
+    assert rt._main(["p", "scan", str(path)]) == 0
+    # The file form consumes its spec, so a retry cannot read a stale one.
+    assert not path.exists()

--- a/tests/unit/scripts/ops/test_report_orphan_blobs.py
+++ b/tests/unit/scripts/ops/test_report_orphan_blobs.py
@@ -1,0 +1,47 @@
+"""The orphan report must describe exactly what the sweep will act on.
+
+An orphan is a blob no manifest row references, which is the same relation the
+condemn pass and the reap re-check evaluate. Two spellings of it drift, and the
+drift shows up as an operator chasing bytes the GC is never going to reclaim,
+so the report negates the sweep's own predicate rather than restating it.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+from scripts.ops.report_orphan_blobs import _GC_BACKLOG_SQL, _ORPHAN_PREDICATE
+from src.server.database.blob_keys import REFERENCED_SQL
+
+_EXISTS_BLOB = "EXISTS (SELECT 1 FROM workspace_files f JOIN workspaces w ON w.workspace_id = f.workspace_id WHERE f.blob_sha256 = b.sha256 AND w.user_id = b.user_id)"
+_EXISTS_PACK = "EXISTS (SELECT 1 FROM workspace_files f JOIN workspaces w ON w.workspace_id = f.workspace_id WHERE f.pack_sha256 = b.sha256 AND w.user_id = b.user_id)"
+
+
+def _evaluate(sql: str, *, blob_ref: bool, pack_ref: bool) -> bool:
+    """Read the predicate as a boolean expression over its two EXISTS clauses."""
+    expr = sql.replace(_EXISTS_BLOB, str(blob_ref)).replace(_EXISTS_PACK, str(pack_ref))
+    assert "EXISTS" not in expr, f"unsubstituted subquery in {expr!r}"
+    for sql_op, py_op in (("NOT", "not"), (" OR ", " or "), (" AND ", " and ")):
+        expr = expr.replace(sql_op, py_op)
+    return bool(eval(expr))  # noqa: S307 - operands are the booleans just substituted
+
+
+def test_orphan_predicate_is_the_negation_of_referenced():
+    for blob_ref, pack_ref in itertools.product([True, False], repeat=2):
+        referenced = _evaluate(REFERENCED_SQL, blob_ref=blob_ref, pack_ref=pack_ref)
+        orphan = _evaluate(_ORPHAN_PREDICATE, blob_ref=blob_ref, pack_ref=pack_ref)
+        assert orphan is not referenced, (blob_ref, pack_ref)
+
+
+def test_gc_backlog_counters_are_taken_over_orphans_only():
+    """A referenced blob past the grace period is not condemnable and a
+    condemned one that regained a reference is revived by the reap, so counting
+    either reports a backlog the sweep will never work through."""
+    assert _ORPHAN_PREDICATE in _GC_BACKLOG_SQL
+
+
+def test_referenced_predicate_covers_both_pointer_columns():
+    """A row referenced through either column is referenced; the pack column is
+    the one a reader forgets, and forgetting it deletes live chunks."""
+    assert _evaluate(REFERENCED_SQL, blob_ref=False, pack_ref=True)
+    assert _evaluate(REFERENCED_SQL, blob_ref=True, pack_ref=False)

--- a/tests/unit/server/app/test_public_redaction.py
+++ b/tests/unit/server/app/test_public_redaction.py
@@ -801,3 +801,89 @@ class TestReplayStripsWorkspaceId:
             assert "sandbox_state" not in d
         # The stored event object must be untouched (no in-place mutation).
         assert stored == original
+
+
+# ---------------------------------------------------------------------------
+# TestPublicWarmSandboxFallback — a storage failure is not the end of the read
+# ---------------------------------------------------------------------------
+
+_RESOLVE_TEXT = "src.server.services.persistence.resolve.resolve_file_text_or_none"
+_RESOLVE_BYTES = "src.server.services.persistence.resolve.resolve_file_bytes_or_none"
+
+
+def _warm_manager(content: bytes):
+    """A WorkspaceManager holding a ready session whose sandbox serves ``content``."""
+    from unittest.mock import MagicMock
+
+    sandbox = MagicMock()
+    sandbox.working_dir = "/home/workspace"
+    sandbox.validate_and_normalize_path.return_value = ("/home/workspace/data/x.txt", None)
+    sandbox.virtualize_path.return_value = "data/x.txt"
+    sandbox.adownload_file_bytes = AsyncMock(return_value=content)
+    session = MagicMock()
+    session.sandbox = sandbox
+    mgr = MagicMock()
+    mgr.get_session_if_ready.return_value = session
+    holder = MagicMock()
+    holder.get_instance.return_value = mgr
+    return holder
+
+
+class TestPublicWarmSandboxFallback:
+    """The resolver answers None for a storage failure as it does for an absent
+    row. With a warm sandbox in this worker the live copy is served; the
+    uniform 404 is kept for when there is none."""
+
+    async def test_read_falls_through_to_the_warm_sandbox(self, public_client):
+        with (
+            patch(_THREAD_BY_TOKEN, AsyncMock(return_value=_make_thread())),
+            patch(_DB_GET_WS, AsyncMock(return_value=_make_workspace(status="running"))),
+            patch(_WORK_DIR, return_value="/home/workspace"),
+            patch(_NORM_PATH, return_value="data/x.txt"),
+            patch(_FILE_SVC, AsyncMock(return_value=_make_file_record(None))),
+            patch(_RESOLVE_TEXT, AsyncMock(return_value=None)),
+            patch(_WSMGR, _warm_manager(b"live copy")),
+        ):
+            resp = await public_client.get(
+                f"/api/v1/public/shared/{_SHARE_TOKEN}/files/read",
+                params={"path": "data/x.txt"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "live copy"
+        assert resp.json()["source"] == "sandbox"
+
+    async def test_download_falls_through_to_the_warm_sandbox(self, public_client):
+        with (
+            patch(_THREAD_BY_TOKEN, AsyncMock(return_value=_make_thread())),
+            patch(_DB_GET_WS, AsyncMock(return_value=_make_workspace(status="running"))),
+            patch(_WORK_DIR, return_value="/home/workspace"),
+            patch(_NORM_PATH, return_value="data/x.txt"),
+            patch(_FILE_SVC, AsyncMock(return_value=_make_file_record(None))),
+            patch(_RESOLVE_BYTES, AsyncMock(return_value=None)),
+            patch(_WSMGR, _warm_manager(b"live copy")),
+        ):
+            resp = await public_client.get(
+                f"/api/v1/public/shared/{_SHARE_TOKEN}/files/download",
+                params={"path": "data/x.txt"},
+            )
+        assert resp.status_code == 200
+        assert resp.content == b"live copy"
+
+    async def test_read_stays_a_uniform_404_without_a_warm_sandbox(self, public_client):
+        holder, mgr = _no_warm_manager()
+        with (
+            patch(_THREAD_BY_TOKEN, AsyncMock(return_value=_make_thread())),
+            patch(_DB_GET_WS, AsyncMock(return_value=_make_workspace(status="running"))),
+            patch(_WORK_DIR, return_value="/home/workspace"),
+            patch(_NORM_PATH, return_value="data/x.txt"),
+            patch(_FILE_SVC, AsyncMock(return_value=_make_file_record(None))),
+            patch(_RESOLVE_TEXT, AsyncMock(return_value=None)),
+            patch(_WSMGR, holder),
+        ):
+            resp = await public_client.get(
+                f"/api/v1/public/shared/{_SHARE_TOKEN}/files/read",
+                params={"path": "data/x.txt"},
+            )
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "File not found"
+        mgr.get_session_for_workspace.assert_not_awaited()

--- a/tests/unit/server/app/test_workspace_files_routing.py
+++ b/tests/unit/server/app/test_workspace_files_routing.py
@@ -113,3 +113,26 @@ async def test_files_during_concurrent_failing_lazy_init(
     assert isinstance(b_outcome, dict), f"B should not raise 503 / error: {b_outcome!r}"
     assert b_outcome["source"] == "database"
     assert b_outcome["files"] == ["results/x.txt"]
+
+
+@pytest.mark.asyncio
+@patch("src.server.database.workspace_file.get_workspace_total_size", new_callable=AsyncMock, return_value=7)
+@patch("src.server.database.workspace_file.get_file_metadata_for_sync", new_callable=AsyncMock)
+@patch("src.server.app.workspace_files.crud.db_get_workspace")
+async def test_backup_status_of_a_stopped_workspace_lists_files_only(mock_get_ws, mock_meta, _size):
+    """The sync metadata carries directory and symlink rows; the status is
+    about files, and the running branch only ever sees files."""
+    from src.server.app.workspace_files.crud import get_backup_status
+
+    mock_get_ws.return_value = _workspace("ws-stopped", "user-1", status="stopped")
+    mock_meta.return_value = {
+        "data": {"kind": "directory", "file_size": 0},
+        "link": {"kind": "symlink", "file_size": 0},
+        "data/a.csv": {"kind": "file", "file_size": 7},
+        "legacy.txt": {"file_size": 3},
+    }
+
+    result = await get_backup_status(workspace_id="ws-stopped", x_user_id="user-1")
+
+    assert set(result["backed_up"]) == {"data/a.csv", "legacy.txt"}
+    assert result["total_backed_up_size"] == 7

--- a/tests/unit/server/database/test_backfill_workspace_file_blobs.py
+++ b/tests/unit/server/database/test_backfill_workspace_file_blobs.py
@@ -1,0 +1,256 @@
+"""Contracts for the blob backfill operator script.
+
+Only the decisions that decide whether a rollback is byte-exact are pinned
+here: which inline column the bytes go back into, and what the reverse pass
+refuses to write. The upload path is exercised against a real bucket, not
+mocked.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _load_backfill():
+    """Import the script by path — it lives outside any package."""
+    name = "_backfill_under_test"
+    path = (
+        Path(__file__).resolve().parents[4]
+        / "scripts"
+        / "ops"
+        / "backfill_workspace_file_blobs.py"
+    )
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    # Registered before exec: the script's dataclasses have string annotations
+    # (`from __future__ import annotations`), which dataclasses resolves via
+    # sys.modules[cls.__module__].
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+backfill = _load_backfill()
+
+
+def test_binary_rows_restore_to_bytea():
+    assert backfill._inline_columns(b"\x89PNG\x00", is_binary=True) == (None, b"\x89PNG\x00")
+
+
+def test_clean_text_restores_to_text():
+    assert backfill._inline_columns("hello 股票".encode(), is_binary=False) == (
+        "hello 股票",
+        None,
+    )
+
+
+def test_nul_bearing_text_restores_to_bytea_byte_exact():
+    """The rollback path must not write a lossy copy.
+
+    ``_detect_is_binary`` only scans the first 64KiB for NUL, so a large UTF-8
+    file with a NUL past that is stored as text. Stripping the NUL to satisfy
+    Postgres would leave ``content_hash`` describing bytes the row no longer
+    holds — exactly the state the forward pass refuses to touch, stranding the
+    row inline forever with its real bytes only in an orphaned blob.
+    """
+    data = b"a" * 70_000 + b"\x00" + b"b" * 10
+    text, binary = backfill._inline_columns(data, is_binary=False)
+    assert text is None
+    assert binary == data
+
+
+def test_empty_file_restores_to_text_not_dropped():
+    assert backfill._inline_columns(b"", is_binary=False) == ("", None)
+
+
+@pytest.mark.parametrize("sha", ["", "not-a-digest", "../../etc/passwd"])
+def test_uploads_go_through_the_shared_key_guard(sha):
+    """The script builds keys with the same validated helper as the store."""
+    from src.server.database.blob_keys import BlobError, blob_key
+
+    assert backfill.blob_key is blob_key
+    with pytest.raises(BlobError):
+        blob_key("user-1", sha)
+
+
+def test_invalid_utf8_in_a_text_row_restores_to_bytea_byte_exact():
+    """``is_binary`` is set by a 64KiB NUL scan, so a text-classified file can
+    still hold invalid UTF-8 further in. Decoding it with ``errors="replace"``
+    would write U+FFFD where the original bytes were and leave ``content_hash``
+    describing bytes the row no longer holds."""
+    data = b"a" * 70_000 + b"\xff\xfe" + b"b" * 10
+    assert backfill._inline_columns(data, is_binary=False) == (None, data)
+
+
+# --- the reverse pass verifies before it NULLs the pointer -------------------
+
+
+class _Conn:
+    """Records statements; ``rowcount`` decides whether the reverse CAS matched."""
+
+    def __init__(self, rowcount: int = 1):
+        self.statements: list[tuple] = []
+        self.rowcount = rowcount
+
+    def cursor(self, row_factory=None):
+        conn = self
+
+        class _Cur:
+            rowcount = conn.rowcount
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def execute(self, sql, params=None):
+                conn.statements.append((" ".join(sql.split()), params))
+
+            async def fetchone(self):
+                return (0,)  # _count_blob_backed: nothing left blob-backed
+
+        return _Cur()
+
+
+def _row(**over):
+    data = over.pop("_data", b"hello")
+    sha = hashlib.sha256(data).hexdigest()
+    row = {
+        "workspace_file_id": uuid.uuid4(),
+        "workspace_id": "ws-1",
+        "user_id": "user-1",
+        "file_path": "a.txt",
+        "content_hash": sha,
+        "content_text": None,
+        "content_binary": None,
+        "blob_sha256": sha,
+        "pack_sha256": None,
+        "pack_offset": None,
+        "file_size": len(data),
+        "is_binary": False,
+    }
+    row.update(over)
+    return row
+
+
+async def _run_reverse(row, *, blob_bytes=None, range_bytes=None, rowcount=1):
+    """Drive ``_reverse`` over one row. Returns ``(exit_code, statements)``."""
+    conn = _Conn(rowcount)
+    pages = iter([[str(row["workspace_file_id"])], []])
+
+    async def _next_ids(*a, **k):
+        return next(pages)
+
+    async def _load_row(*a, **k):
+        return row
+
+    with (
+        patch.object(backfill, "_next_ids", _next_ids),
+        patch.object(backfill, "_load_row", _load_row),
+        patch.object(backfill, "get_bytes", lambda key: blob_bytes),
+        patch.object(backfill, "get_bytes_range", lambda key, off, length: range_bytes),
+    ):
+        code = await backfill._reverse(conn, True, 10, None)
+    updates = [st for st in conn.statements if st[0].startswith("UPDATE workspace_files")]
+    return code, updates
+
+
+@pytest.mark.asyncio
+async def test_reverse_cas_pins_every_column_the_read_observed():
+    """Two packs with different member boundaries can share a digest, so the
+    pointer columns alone do not identify the row that was read: a re-pointed
+    row would take a slice cut for its predecessor."""
+    data = b"hello"
+    row = _row(_data=data)
+    code, updates = await _run_reverse(row, blob_bytes=data)
+
+    assert code == 0
+    assert len(updates) == 1
+    sql, params = updates[0]
+    for column in ("blob_sha256", "pack_sha256", "content_hash", "pack_offset", "file_size"):
+        assert f"AND {column} IS NOT DISTINCT FROM %s" in sql
+    assert params[-5:] == (
+        row["blob_sha256"],
+        None,
+        row["content_hash"],
+        None,
+        row["file_size"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_reverse_skips_a_row_whose_object_is_the_wrong_length():
+    """The write NULLs the only pointer to the good bytes, so a short read has
+    to be reported rather than restored."""
+    code, updates = await _run_reverse(_row(file_size=99), blob_bytes=b"hello")
+    assert updates == []
+    assert code == 1
+
+
+@pytest.mark.asyncio
+async def test_reverse_verifies_length_even_with_no_stored_hash():
+    """A packed row's expected digest is ``content_hash``, which can be NULL.
+    Length is the check that still applies, and skipping it would restore a
+    truncated member."""
+    row = _row(
+        blob_sha256=None,
+        pack_sha256=hashlib.sha256(b"chunk").hexdigest(),
+        pack_offset=0,
+        content_hash=None,
+        file_size=5,
+    )
+    code, updates = await _run_reverse(row, range_bytes=b"hel")
+    assert updates == []
+    assert code == 1
+
+
+async def _run_forward(row, *, include_legacy_owners=False):
+    """Dry-run ``_forward`` over one row. Returns the counts the summary logs."""
+    conn = _Conn()
+    pages = iter([[str(row["workspace_file_id"])], []])
+
+    async def _next_ids(*a, **k):
+        return next(pages)
+
+    async def _load_row(*a, **k):
+        return row
+
+    with (
+        patch.object(backfill, "_next_ids", _next_ids),
+        patch.object(backfill, "_load_row", _load_row),
+        patch.object(backfill.logger, "info") as info,
+    ):
+        await backfill._forward(conn, False, 10, None, include_legacy_owners)
+    summary = info.call_args.args
+    return dict(zip(("moved", "bytes", "lossy", "raced", "empty", "legacy", "failed"), summary[2:]))
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_owner_is_left_inline_by_default():
+    """A non-UUID owner is re-keyed by its first platform login; objects
+    under the old id would not follow it."""
+    row = _row(user_id="legacy-user", blob_sha256=None, content_text="hello")
+    counts = await _run_forward(row)
+    assert counts["legacy"] == 1 and counts["moved"] == 0
+
+
+@pytest.mark.asyncio
+async def test_include_legacy_owners_moves_the_row():
+    row = _row(user_id="legacy-user", blob_sha256=None, content_text="hello")
+    counts = await _run_forward(row, include_legacy_owners=True)
+    assert counts["legacy"] == 0 and counts["moved"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_uuid_owner_moves_without_the_flag():
+    row = _row(user_id=str(uuid.uuid4()), blob_sha256=None, content_text="hello")
+    counts = await _run_forward(row)
+    assert counts["legacy"] == 0 and counts["moved"] == 1

--- a/tests/unit/server/database/test_restore_flag_identity.py
+++ b/tests/unit/server/database/test_restore_flag_identity.py
@@ -1,0 +1,74 @@
+"""The completeness flag lands only while the row names the expected sandbox."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+
+from src.server.database import workspace as ws
+
+
+class _Cur:
+    def __init__(self) -> None:
+        self.sql = ""
+        self.params: tuple = ()
+        self.rowcount = 1
+
+    async def execute(self, sql, params=None):
+        self.sql = " ".join(sql.split())
+        self.params = params
+
+
+@pytest.fixture
+def cur():
+    c = _Cur()
+
+    @asynccontextmanager
+    async def _cursor(conn=None):
+        yield c
+
+    with patch.object(ws, "_ws_cursor", _cursor):
+        yield c
+
+
+GUARDED = "WHERE workspace_id = %s AND sandbox_id IS NOT DISTINCT FROM %s"
+
+
+@pytest.mark.asyncio
+async def test_a_clear_naming_a_sandbox_lands_only_on_that_row(cur):
+    await ws.set_files_restore_incomplete("ws-1", False, sandbox_id="sb-1")
+    assert cur.sql.endswith(GUARDED)
+    assert cur.params == (None, "ws-1", "sb-1")
+
+
+@pytest.mark.asyncio
+async def test_a_raise_names_the_sandbox_the_row_is_expected_to_hold(cur):
+    await ws.set_files_restore_incomplete("ws-1", True, sandbox_id="sb-previous")
+    assert cur.sql.endswith(GUARDED)
+    assert cur.params[1:] == ("ws-1", "sb-previous")
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_row_is_expected_to_name_no_sandbox(cur):
+    """A never-provisioned workspace holds NULL; the CAS that follows expects
+    exactly that, so the raise must too, and equality would never match."""
+    await ws.set_files_restore_incomplete("ws-1", True, sandbox_id=None)
+    assert cur.sql.endswith(GUARDED)
+    assert cur.params[1:] == ("ws-1", None)
+
+
+@pytest.mark.asyncio
+async def test_any_sandbox_skips_the_guard(cur):
+    """A runtime with no sandbox id (a local provider) still has to write."""
+    await ws.set_files_restore_incomplete("ws-1", False, sandbox_id=ws.ANY_SANDBOX)
+    assert cur.sql.endswith("WHERE workspace_id = %s")
+    assert cur.params == (None, "ws-1")
+
+
+@pytest.mark.asyncio
+async def test_the_write_reports_whether_it_landed(cur):
+    assert await ws.set_files_restore_incomplete("ws-1", True, sandbox_id="sb-1") is True
+    cur.rowcount = 0
+    assert await ws.set_files_restore_incomplete("ws-1", True, sandbox_id="sb-1") is False

--- a/tests/unit/server/database/test_workspace_file_blobs.py
+++ b/tests/unit/server/database/test_workspace_file_blobs.py
@@ -1,0 +1,434 @@
+"""Contracts for the content-addressed workspace file blob store.
+
+Pins the invariants that are easy to regress silently: the object key must be
+derived only from a real digest, ``b""`` is a legitimate blob, and a fetch that
+comes back wrong must raise rather than hand a caller the wrong file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from src.server.database import workspace_file_blobs as blobs
+from src.server.database.blob_keys import BLOB_KEY_PREFIX, MAX_BLOB_BYTES
+from src.server.database.workspace_file_blobs import (
+    BlobError,
+    BlobFetchError,
+    BlobUploadError,
+    blob_key,
+    fetch_blob,
+    fetch_blob_range,
+    registered_blobs,
+    store_blob,
+)
+
+EMPTY_SHA = hashlib.sha256(b"").hexdigest()
+HELLO = b"hello blob"
+HELLO_SHA = hashlib.sha256(HELLO).hexdigest()
+USER = "user-a"
+
+
+class _FakeConn:
+    """Minimal async connection stub; records executed statements."""
+
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+        self.statements: list[tuple] = []
+
+    def cursor(self):
+        conn = self
+
+        class _Cur:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def execute(self, sql, params=None):
+                if conn.fail:
+                    raise RuntimeError("db down")
+                conn.statements.append((sql, params))
+
+        return _Cur()
+
+
+class _RowsConn(_FakeConn):
+    """A connection that also answers with a scripted result set."""
+
+    def __init__(self, rows: list[tuple]):
+        super().__init__()
+        self.rows = rows
+
+    def cursor(self):
+        conn = self
+
+        class _Cur:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def execute(self, sql, params=None):
+                conn.statements.append((sql, params))
+
+            async def fetchall(self):
+                return conn.rows
+
+        return _Cur()
+
+
+class _ReapConn:
+    """Enough psycopg surface for ``_reap_one``: a transaction whose exit is
+    recorded in ``events``, and a cursor answering the reap's two probes."""
+
+    def __init__(self, events: list[str]):
+        self.events = events
+
+    def transaction(self):
+        conn = self
+
+        class _Tx:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                conn.events.append("transaction end")
+                return False
+
+        return _Tx()
+
+    def cursor(self):
+        conn = self
+
+        class _Cur:
+            sql = ""
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def execute(self, sql, params=None):
+                self.sql = " ".join(sql.split())
+                if self.sql.startswith("DELETE"):
+                    conn.events.append("row deleted")
+
+            async def fetchone(self):
+                # The FOR UPDATE probe finds the condemned row; the reference
+                # re-check finds nothing, so the reap proceeds to the delete.
+                return (1,) if "FOR UPDATE" in self.sql else None
+
+        return _Cur()
+
+
+def _squash(sql: str) -> str:
+    """Collapse SQL whitespace so an embedded statement can be matched."""
+    return " ".join(sql.split())
+
+
+def _conn_ctx(conn):
+    class _Ctx:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return lambda: _Ctx()
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        None,
+        "not-a-digest",
+        "../../etc/passwd",
+        HELLO_SHA.upper(),  # uppercase hex is not the canonical digest form
+        HELLO_SHA[:-1],
+        HELLO_SHA + "a",
+        f"{HELLO_SHA}/../evil",
+    ],
+)
+def test_blob_key_refuses_non_digests(bad):
+    """The key is derived from the digest, so a non-digest must never form one."""
+    with pytest.raises(BlobError):
+        blob_key(USER, bad)
+
+
+def test_blob_key_shape():
+    assert blob_key(USER, HELLO_SHA) == f"{BLOB_KEY_PREFIX}{USER}/{HELLO_SHA}"
+
+
+@pytest.mark.parametrize("bad", ["", None, "../other", "a/b", "user a", "-x", "x" * 256])
+def test_blob_key_refuses_malformed_user_ids(bad):
+    """The user segment is a path component; it must never carry a separator
+    or an empty value that would land the object in another namespace."""
+    with pytest.raises(BlobError):
+        blob_key(bad, HELLO_SHA)
+
+
+def test_blob_keys_module_stays_import_clean():
+    """``scripts/ops/`` shares these constants by importing this module.
+
+    It can import ``blob_keys`` only because that module pulls in nothing but
+    ``re``. An import of the app's config (directly or transitively) would fire
+    ``load_dotenv()`` and silently retarget a mutating operator script at
+    whatever ``.env`` is on disk.
+    """
+    import ast
+    from pathlib import Path
+
+    import src.server.database.blob_keys as blob_keys
+
+    tree = ast.parse(Path(blob_keys.__file__).read_text())
+    imported = {
+        node.module.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    } | {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    assert imported <= {"re", "__future__"}
+
+
+@pytest.mark.asyncio
+async def test_store_blob_uploads_then_registers():
+    conn = _FakeConn()
+    with (
+        patch.object(blobs, "_storage_upload_bytes", return_value=True) as up,
+        patch.object(blobs, "get_db_connection", _conn_ctx(conn)),
+    ):
+        await store_blob(USER, HELLO_SHA, HELLO)
+
+    # Upload carries the explicit cap; the shared 10MB facade default would
+    # otherwise reject every file between 10MB and MAX_FILE_SIZE.
+    assert up.call_args.args[0] == blob_key(USER, HELLO_SHA)
+    assert up.call_args.kwargs["max_size"] == MAX_BLOB_BYTES
+    # Claim first, upload, then the reviving upsert: a live row always has an
+    # object behind it, and a concurrent reap cannot slip between the two.
+    assert len(conn.statements) == 2
+    claim, register = conn.statements
+    assert "condemned_at IS NOT NULL" in claim[0] and claim[1] == (USER, [HELLO_SHA])
+    assert "ON CONFLICT (user_id, sha256) DO UPDATE" in register[0] and "condemned_at = NULL" in register[0]
+    assert register[1] == (USER, HELLO_SHA, len(HELLO))
+
+
+@pytest.mark.asyncio
+async def test_store_blob_registers_empty_blob():
+    """sha256(b"") is a real blob — an empty file must round-trip, not vanish."""
+    conn = _FakeConn()
+    with (
+        patch.object(blobs, "_storage_upload_bytes", return_value=True),
+        patch.object(blobs, "get_db_connection", _conn_ctx(conn)),
+    ):
+        await store_blob(USER, EMPTY_SHA, b"")
+    assert conn.statements[-1][1] == (USER, EMPTY_SHA, 0)
+
+
+@pytest.mark.asyncio
+async def test_store_blob_raises_when_upload_rejected():
+    """The facade returns False rather than raising; this is where that becomes
+    an error the sync path can count."""
+    with (
+        patch.object(blobs, "_storage_upload_bytes", return_value=False),
+        patch.object(blobs, "get_db_connection", _conn_ctx(_FakeConn())),
+    ):
+        with pytest.raises(BlobUploadError):
+            await store_blob(USER, HELLO_SHA, HELLO)
+
+
+@pytest.mark.asyncio
+async def test_store_blob_raises_when_registry_insert_fails():
+    conn = _FakeConn(fail=True)
+    with (
+        patch.object(blobs, "_storage_upload_bytes", return_value=True),
+        patch.object(blobs, "get_db_connection", _conn_ctx(conn)),
+    ):
+        with pytest.raises(BlobUploadError):
+            await store_blob(USER, HELLO_SHA, HELLO)
+
+
+@pytest.mark.asyncio
+async def test_store_blob_never_deletes_on_failure():
+    """An orphan object is cheap; deleting a shared content-addressed key another
+    writer already committed a manifest row against is not."""
+    conn = _FakeConn(fail=True)
+    with (
+        patch.object(blobs, "_storage_upload_bytes", return_value=True),
+        patch.object(blobs, "_storage_delete_object") as delete,
+        patch.object(blobs, "get_db_connection", _conn_ctx(conn)),
+    ):
+        with pytest.raises(BlobUploadError):
+            await store_blob(USER, HELLO_SHA, HELLO)
+    delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_blob_round_trips():
+    with patch.object(blobs, "_storage_get_bytes", return_value=HELLO):
+        assert await fetch_blob(USER, HELLO_SHA) == HELLO
+
+
+@pytest.mark.asyncio
+async def test_fetch_blob_returns_empty_bytes_not_an_error():
+    """`if data is None`, never truthiness — b"" is falsy but valid."""
+    with patch.object(blobs, "_storage_get_bytes", return_value=b""):
+        assert await fetch_blob(USER, EMPTY_SHA) == b""
+
+
+@pytest.mark.asyncio
+async def test_fetch_blob_raises_on_missing_object():
+    with patch.object(blobs, "_storage_get_bytes", return_value=None):
+        with pytest.raises(BlobFetchError):
+            await fetch_blob(USER, HELLO_SHA)
+
+
+@pytest.mark.asyncio
+async def test_fetch_blob_raises_on_content_mismatch():
+    """Silent corruption would restore the wrong file; make it loud instead."""
+    with patch.object(blobs, "_storage_get_bytes", return_value=b"tampered"):
+        with pytest.raises(BlobFetchError):
+            await fetch_blob(USER, HELLO_SHA)
+
+
+# --- ranged reads for pack members ------------------------------------------
+
+MEMBER = b"lo b"
+MEMBER_SHA = hashlib.sha256(MEMBER).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_fetch_blob_range_reads_and_verifies_the_member():
+    with patch.object(blobs, "_storage_get_bytes_range", return_value=MEMBER) as get:
+        assert await fetch_blob_range(USER, HELLO_SHA, 3, 4, expected_sha256=MEMBER_SHA) == MEMBER
+    get.assert_called_once_with(blob_key(USER, HELLO_SHA), 3, 4)
+
+
+@pytest.mark.asyncio
+async def test_fetch_blob_range_raises_on_missing_short_or_wrong_bytes():
+    """A wrong offset or a mis-keyed chunk must be as loud as a corrupt object."""
+    with patch.object(blobs, "_storage_get_bytes_range", return_value=None):
+        with pytest.raises(BlobFetchError):
+            await fetch_blob_range(USER, HELLO_SHA, 3, 4)
+    with patch.object(blobs, "_storage_get_bytes_range", return_value=b"lo"):
+        with pytest.raises(BlobFetchError):
+            await fetch_blob_range(USER, HELLO_SHA, 3, 4)
+    with patch.object(blobs, "_storage_get_bytes_range", return_value=b"xxxx"):
+        with pytest.raises(BlobFetchError):
+            await fetch_blob_range(USER, HELLO_SHA, 3, 4, expected_sha256=MEMBER_SHA)
+
+
+# --- registry dedup is scoped to what the caller already has -----------------
+
+
+@pytest.mark.asyncio
+async def test_registered_blobs_reports_live_rows_under_the_user():
+    """A hit is a live registry row under the caller's own user: the registry
+    is keyed per user, so a hit means the user already holds those bytes."""
+    conn = _RowsConn([(HELLO_SHA, True), (EMPTY_SHA, False)])
+    with patch.object(blobs, "get_db_connection", _conn_ctx(conn)):
+        assert await registered_blobs(USER, [HELLO_SHA, EMPTY_SHA]) == {HELLO_SHA}
+    sql, params = conn.statements[0]
+    assert "last_referenced_at = NOW()" in sql and "user_id = %s" in sql
+    assert params[0] == USER
+    assert sorted(params[1]) == sorted([HELLO_SHA, EMPTY_SHA])
+
+
+@pytest.mark.asyncio
+async def test_registered_blobs_touches_every_digest_it_was_asked_about():
+    """An unreported digest is one the caller is about to upload, so its row
+    still needs the touch that keeps the sweep off it."""
+    conn = _RowsConn([])
+    with patch.object(blobs, "get_db_connection", _conn_ctx(conn)):
+        assert await registered_blobs(USER, [HELLO_SHA]) == set()
+    sql, params = conn.statements[0]
+    assert _squash(blobs._TOUCH_SQL) in _squash(sql)
+    assert params == (USER, [HELLO_SHA])
+
+
+class _PerUserConn(_FakeConn):
+    """Answers only for the user the rows were registered under."""
+
+    def __init__(self, owner: str, rows: list[tuple]):
+        super().__init__()
+        self.owner = owner
+        self.rows = rows
+
+    def cursor(self):
+        conn = self
+
+        class _Cur:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def execute(self, sql, params=None):
+                conn.statements.append((sql, params))
+                conn.matched = params[0] == conn.owner
+
+            async def fetchall(self):
+                return conn.rows if conn.matched else []
+
+        return _Cur()
+
+
+@pytest.mark.asyncio
+async def test_digest_registered_under_one_user_is_a_miss_for_another():
+    """A digest the sandbox merely names must not become a pointer to bytes the
+    user never had, and the answer must not reveal who else holds them."""
+    conn = _PerUserConn("user-a", [(HELLO_SHA, True)])
+    with patch.object(blobs, "get_db_connection", _conn_ctx(conn)):
+        assert await registered_blobs("user-a", [HELLO_SHA]) == {HELLO_SHA}
+        assert await registered_blobs("user-b", [HELLO_SHA]) == set()
+    assert [p[0] for _, p in conn.statements] == ["user-a", "user-b"]
+
+
+# --- the reap's object delete outlives a cancellation ------------------------
+
+
+@pytest.mark.asyncio
+async def test_reap_holds_the_row_lock_until_a_cancelled_delete_settles():
+    """Shutdown must not roll the transaction back with the delete in flight.
+
+    The lock is the only thing stopping a writer from claiming the digest,
+    uploading, and reviving it; released early, the still-running thread would
+    then delete that writer's fresh object.
+    """
+    events: list[str] = []
+    started = threading.Event()
+    release = threading.Event()
+
+    def _delete(key):
+        started.set()
+        release.wait(5)
+        events.append("object deleted")
+        return True
+
+    conn = _ReapConn(events)
+    with patch.object(blobs, "_storage_delete_object", _delete):
+        task = asyncio.create_task(blobs._reap_one(conn, USER, HELLO_SHA, 24))
+        while not started.is_set():
+            await asyncio.sleep(0.01)
+        task.cancel()
+        await asyncio.sleep(0.05)
+        assert not task.done(), "the cancel must not abandon the running delete"
+        assert events == [], "the transaction must still be open"
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert events == ["object deleted", "transaction end"]

--- a/tests/unit/server/database/test_workspace_file_blobs_gc_lock.py
+++ b/tests/unit/server/database/test_workspace_file_blobs_gc_lock.py
@@ -1,0 +1,175 @@
+"""The GC sweep's session lock is released the way the workspace sync lock is.
+
+The sweep holds one session-level advisory lock across many transactions. A
+cancelled or failing sweep that returned its connection to the pool with the
+lock still held would silence every later sweep on every worker until that
+connection happened to be closed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.server.database import workspace_file_blobs as blobs
+
+
+class _Cursor:
+    def __init__(self, conn) -> None:
+        self._conn = conn
+
+    async def execute(self, sql: str, params=None) -> None:
+        flat = " ".join(sql.split())
+        self._conn.executed.append(flat)
+        if "pg_advisory_unlock" in flat and self._conn.refuse_unlock:
+            raise RuntimeError("connection lost")
+
+    async def fetchone(self):
+        if self._conn.fetch_responses:
+            return self._conn.fetch_responses.pop(0)
+        return (True,)
+
+
+class _Conn:
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+        self.refuse_unlock = False
+        self.closed = False
+        self.fetch_responses: list = []
+
+    @asynccontextmanager
+    async def cursor(self, **_kw):
+        yield _Cursor(self)
+
+    @asynccontextmanager
+    async def transaction(self):
+        self.executed.append("BEGIN")
+        try:
+            yield
+        finally:
+            self.executed.append("END")
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def conn():
+    c = _Conn()
+
+    @asynccontextmanager
+    async def _acquire(existing=None):
+        yield c
+
+    with patch.object(blobs, "get_db_connection", _acquire):
+        yield c
+
+
+def _unlocks(conn: _Conn) -> int:
+    return sum("pg_advisory_unlock" in s for s in conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_a_failing_sweep_still_releases_the_lock(conn):
+    with (
+        patch.object(
+            blobs, "condemn_orphan_blobs", AsyncMock(side_effect=RuntimeError("boom"))
+        ),
+        patch.object(blobs, "reap_condemned_blobs", AsyncMock()),
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            await blobs.sweep_blob_garbage()
+
+    assert _unlocks(conn) == 1
+    assert not conn.closed
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_sweep_still_releases_the_lock(conn):
+    started = asyncio.Event()
+
+    async def _condemn(*_a, **_kw):
+        started.set()
+        await asyncio.sleep(3600)
+
+    with (
+        patch.object(blobs, "condemn_orphan_blobs", _condemn),
+        patch.object(blobs, "reap_condemned_blobs", AsyncMock()),
+    ):
+        task = asyncio.create_task(blobs.sweep_blob_garbage())
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert _unlocks(conn) == 1
+    assert not conn.closed
+
+
+@pytest.mark.asyncio
+async def test_an_unconfirmed_release_closes_the_session_so_the_lock_dies_with_it(conn):
+    conn.refuse_unlock = True
+    with (
+        patch.object(blobs, "condemn_orphan_blobs", AsyncMock(return_value=0)),
+        patch.object(blobs, "reap_condemned_blobs", AsyncMock(return_value=(0, 0))),
+    ):
+        with pytest.raises(RuntimeError, match="connection lost"):
+            await blobs.sweep_blob_garbage()
+
+    assert conn.closed
+
+
+@pytest.mark.asyncio
+async def test_a_reap_cancelled_twice_keeps_its_row_lock_until_the_delete_settles(conn):
+    """The delete thread cannot be interrupted and the transaction's row lock
+    is what keeps a writer from reviving the digest under it. A cancellation
+    re-delivered at the next await must not roll the transaction back first."""
+    import threading
+    import time
+
+    started = threading.Event()
+
+    def _slow_delete(_key):
+        started.set()
+        time.sleep(0.2)
+        conn.executed.append("DELETED")
+        return True
+
+    conn.fetch_responses = [(1,), None]  # still condemned, not referenced
+    with patch.object(blobs, "_storage_delete_object", _slow_delete):
+        task = asyncio.create_task(blobs._reap_one(conn, "u", "a" * 64, 1))
+        while not started.is_set():
+            await asyncio.sleep(0.01)
+        task.cancel()
+        await asyncio.sleep(0.02)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert conn.executed.index("DELETED") < conn.executed.index("END")
+
+
+@pytest.mark.asyncio
+async def test_a_cancellation_during_the_grant_releases_the_session(conn):
+    granted = asyncio.Event()
+    original = _Cursor.execute
+
+    async def _execute(self, sql, params=None):
+        await original(self, sql, params)
+        if "pg_try_advisory_lock(" in " ".join(sql.split()):
+            # The grant lands server-side; the reply is what gets cancelled.
+            granted.set()
+            await asyncio.sleep(3600)
+
+    with patch.object(_Cursor, "execute", _execute):
+        task = asyncio.create_task(blobs.sweep_blob_garbage())
+        await granted.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert _unlocks(conn) == 1
+    assert not conn.closed

--- a/tests/unit/server/database/test_workspace_sync_lock_acquire.py
+++ b/tests/unit/server/database/test_workspace_sync_lock_acquire.py
@@ -1,0 +1,65 @@
+"""A session lock granted under a cancelled acquisition must not reach the pool."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+
+from src.server.database import workspace_file as wf
+
+
+class _Cursor:
+    def __init__(self, conn) -> None:
+        self._conn = conn
+
+    async def execute(self, sql: str, params=None) -> None:
+        flat = " ".join(sql.split())
+        self._conn.executed.append(flat)
+        if "pg_advisory_lock(" in flat:
+            # The grant lands server-side; the reply is what gets cancelled.
+            self._conn.granted.set()
+            await asyncio.sleep(3600)
+
+
+class _Conn:
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+        self.granted = asyncio.Event()
+        self.closed = False
+
+    @asynccontextmanager
+    async def cursor(self, **_kw):
+        yield _Cursor(self)
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_a_cancellation_during_the_grant_releases_the_session():
+    conn = _Conn()
+
+    @asynccontextmanager
+    async def _acquire(existing=None):
+        yield conn
+
+    async def _hold():
+        async with wf.workspace_sync_lock("ws-1"):
+            pass  # pragma: no cover
+
+    with patch.object(wf, "get_db_connection", _acquire):
+        task = asyncio.create_task(_hold())
+        await conn.granted.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert any("pg_advisory_unlock" in s for s in conn.executed)
+    assert not conn.closed

--- a/tests/unit/server/services/test_file_bytes_resolver.py
+++ b/tests/unit/server/services/test_file_bytes_resolver.py
@@ -1,0 +1,150 @@
+"""Contracts for the single byte-resolution ladder shared by every read path.
+
+This replaced four copy-pasted ladders (restore, authenticated read/download,
+unauthenticated serve, share-token routes) that had drifted apart. The cases
+below are the ones the copies disagreed on.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.server.services.persistence.resolve import (
+    FileBytesUnavailable,
+    resolve_file_bytes,
+    resolve_file_bytes_or_none,
+    resolve_file_text_or_none,
+)
+from src.server.database.workspace_file_blobs import BlobFetchError
+
+SHA = hashlib.sha256(b"blob bytes").hexdigest()
+USER = "user-a"
+
+
+@pytest.mark.asyncio
+async def test_inline_text_row():
+    assert await resolve_file_bytes({"content_text": "hi", "is_binary": False}, user_id=USER) == b"hi"
+
+
+@pytest.mark.asyncio
+async def test_inline_binary_row():
+    assert (
+        await resolve_file_bytes({"content_binary": b"\x00\x01", "is_binary": True}, user_id=USER)
+        == b"\x00\x01"
+    )
+
+
+@pytest.mark.asyncio
+async def test_memoryview_is_materialized():
+    """psycopg hands BYTEA back as a memoryview; callers hash and len() it."""
+    out = await resolve_file_bytes(
+        {"content_binary": memoryview(b"\x00\x01"), "is_binary": True}, user_id=USER
+    )
+    assert out == b"\x00\x01"
+    assert isinstance(out, bytes)
+
+
+@pytest.mark.asyncio
+async def test_empty_binary_is_content_not_absence():
+    """The pre-existing truthiness bug: `if content_binary` 404s an empty file.
+
+    Under blobs it was worse — the row would fall through to a pointless network
+    fetch for zero bytes.
+    """
+    assert await resolve_file_bytes({"content_binary": b"", "is_binary": True}, user_id=USER) == b""
+
+
+@pytest.mark.asyncio
+async def test_empty_text_is_content_not_absence():
+    assert await resolve_file_bytes({"content_text": "", "is_binary": False}, user_id=USER) == b""
+
+
+@pytest.mark.asyncio
+async def test_blob_row_fetches_by_pointer():
+    with patch(
+        "src.server.services.persistence.resolve.fetch_blob",
+        new=AsyncMock(return_value=b"blob bytes"),
+    ) as f:
+        row = {"content_text": None, "content_binary": None, "blob_sha256": SHA}
+        assert await resolve_file_bytes(row, user_id=USER) == b"blob bytes"
+    f.assert_awaited_once_with(USER, SHA)
+
+
+@pytest.mark.asyncio
+async def test_inline_wins_over_blob_pointer():
+    """A row that still carries bytes is served without touching the network."""
+    with patch(
+        "src.server.services.persistence.resolve.fetch_blob", new=AsyncMock()
+    ) as f:
+        row = {"content_text": "inline", "blob_sha256": SHA}
+        assert await resolve_file_bytes(row, user_id=USER) == b"inline"
+    f.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_content_anywhere_is_none():
+    """Genuinely absent — distinct from unavailable, so callers can 404."""
+    assert await resolve_file_bytes({"content_text": None, "blob_sha256": None}, user_id=USER) is None
+
+
+@pytest.mark.asyncio
+async def test_missing_keys_do_not_raise():
+    """Sparse records (older fixtures, metadata-only selects) flow through."""
+    assert await resolve_file_bytes({"file_path": "a.txt"}, user_id=USER) is None
+
+
+@pytest.mark.asyncio
+async def test_blob_failure_is_unavailable_not_absent():
+    """A storage blip must not be reported as 'your file does not exist'."""
+    with patch(
+        "src.server.services.persistence.resolve.fetch_blob",
+        new=AsyncMock(side_effect=BlobFetchError("storage down")),
+    ):
+        with pytest.raises(FileBytesUnavailable):
+            await resolve_file_bytes({"blob_sha256": SHA}, user_id=USER)
+
+
+@pytest.mark.asyncio
+async def test_or_none_collapses_unavailable_to_absent():
+    """The uniform-absent policy for routes whose only credential is the URL.
+
+    ``wsfiles`` and the share-token endpoints authenticate nothing beyond an
+    opaque id, so a 503 for "storage is down" next to a 404 for "no such file"
+    would confirm to a guesser that the workspace and path exist.
+    """
+    with patch(
+        "src.server.services.persistence.resolve.fetch_blob",
+        new=AsyncMock(side_effect=BlobFetchError("storage down")),
+    ):
+        assert (
+            await resolve_file_bytes_or_none({"blob_sha256": SHA}, user_id=USER, context="t") is None
+        )
+        assert (
+            await resolve_file_text_or_none({"blob_sha256": SHA}, user_id=USER, context="t") is None
+        )
+
+
+@pytest.mark.asyncio
+async def test_or_none_text_decodes_utf8():
+    """The text routes must never hand redact() a None from
+    `.get("content_text", "")` — the key exists with a NULL value."""
+    assert await resolve_file_text_or_none({"content_text": "股票"}, user_id=USER, context="t") == "股票"
+    assert (
+        await resolve_file_text_or_none(
+            {"content_text": None, "blob_sha256": None}, user_id=USER, context="t"
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_or_none_still_returns_real_content():
+    """Suppressing the error must not suppress an empty-but-present file."""
+    with patch(
+        "src.server.services.persistence.resolve.fetch_blob",
+        new=AsyncMock(return_value=b""),
+    ):
+        assert await resolve_file_bytes_or_none({"blob_sha256": SHA}, user_id=USER, context="t") == b""

--- a/tests/unit/server/services/test_file_persistence_restore.py
+++ b/tests/unit/server/services/test_file_persistence_restore.py
@@ -1,14 +1,13 @@
 """
-Unit tests for FilePersistenceService.restore_to_sandbox parallel path.
+Unit tests for restore_to_sandbox on the relay path.
 
-The restore path previously ran files through a batch-of-10
-``asyncio.gather`` loop and issued one ``mkdir -p`` per file. The new
-path:
+Rows that still carry inline bytes (and every file row when blob transfer
+is ``relay``) are uploaded from this process. That path:
 
-1. Collects unique parent directories and issues a single bulk mkdir.
-2. Uploads all files through a semaphore-bounded worker pool so the
-   next upload starts the instant any slot frees up — no per-batch
-   wait for the slowest file.
+1. Uploads every file to a staging name through a semaphore-bounded worker
+   pool, so the next upload starts the instant any slot frees up.
+2. Hands the staged names to one runtime op that verifies, places and
+   stamps them, with directory modes applied after the last file is in.
 
 These tests pin that behavior so regressions of the restore latency
 budget are visible in CI.
@@ -17,11 +16,80 @@ budget are visible in CI.
 from __future__ import annotations
 
 import asyncio
+import logging
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.server.services.persistence.file import FilePersistenceService
+from src.server.database.workspace_file import WorkspaceSyncBusy
+from src.server.services.persistence import restore
+from src.server.services.persistence.transfer import TransferRuntimeError
+
+import hashlib
+
+
+@pytest.fixture(autouse=True)
+def restore_flag():
+    """Restore records its own completeness in Postgres; unit tests have no DB."""
+    with patch(
+        "src.server.services.persistence.restore.set_files_restore_incomplete",
+        new_callable=AsyncMock,
+    ) as flag:
+        yield flag
+
+
+@pytest.fixture(autouse=True)
+def flag_state():
+    """maybe_restore reads the flag beside a marker; unit tests have no DB."""
+    with patch(
+        "src.server.services.persistence.restore.files_restore_incomplete",
+        new=AsyncMock(return_value=False),
+    ) as read:
+        yield read
+
+
+@pytest.fixture(autouse=True)
+def owner():
+    """Restore resolves the owning user once per pass; unit tests have no DB."""
+    with patch(
+        "src.server.services.persistence.restore.workspace_owner",
+        new=AsyncMock(return_value="user-restore"),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def sync_lock():
+    """Restore serializes on a Postgres advisory lock; unit tests have no DB."""
+
+    @asynccontextmanager
+    async def _lock(_workspace_id):
+        yield "conn"
+
+    with patch("src.server.services.persistence.restore.workspace_sync_lock", _lock):
+        yield
+
+
+def _place_everything(_sandbox, items, **_kw):
+    """What the runtime answers when every staged file verifies."""
+    out = {}
+    for i in items:
+        if i.get("kind") == "pack":
+            out.update({m["path"]: {"status": "ok"} for m in i["members"]})
+        else:
+            out[i["path"]] = {"status": "ok"}
+    return out
+
+
+@pytest.fixture(autouse=True)
+def no_runtime():
+    """The placement op runs the sandbox runtime; these tests have none."""
+    with patch(
+        "src.server.services.persistence.restore.pull_direct",
+        new=AsyncMock(side_effect=_place_everything),
+    ) as pull:
+        yield pull
 
 
 def _file(path: str, text: str = "hello") -> dict:
@@ -30,6 +98,8 @@ def _file(path: str, text: str = "hello") -> dict:
         "is_binary": False,
         "content_binary": None,
         "content_text": text,
+        "content_hash": hashlib.sha256(text.encode()).hexdigest(),
+        "file_size": len(text),
     }
 
 
@@ -43,75 +113,184 @@ def _mock_sandbox() -> MagicMock:
 
 
 @pytest.mark.asyncio
-@patch("src.server.services.persistence.file.update_file_mtime", new_callable=AsyncMock)
-@patch("src.server.services.persistence.file.get_files_for_workspace", new_callable=AsyncMock)
-async def test_restore_bulk_creates_unique_dirs_once(mock_get, mock_update):
-    """All unique parent dirs are created in a SINGLE acreate_directories
-    call. 50 files across 3 unique parent dirs → 1 bulk mkdir, not 50."""
-    files = (
-        [_file(f"data/a/file_{i}.txt") for i in range(20)]
-        + [_file(f"data/b/file_{i}.txt") for i in range(20)]
-        + [_file(f"reports/file_{i}.txt") for i in range(10)]
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_relayed_files_are_staged_then_placed_by_the_runtime(mock_get, no_runtime):
+    """Nothing is uploaded to its final path. Each file goes to a scan-excluded
+    staging name, and one runtime op verifies it against the manifest, moves it
+    into place and stamps it, carrying the directory items so their modes land
+    after the last file. A truncated upload can then never be mistaken for the
+    file's next content."""
+    mock_get.return_value = [
+        _file("a/one.txt", "one"),
+        _file("two.txt", "two"),
+        {"file_path": "a", "kind": "dir", "permissions": "0555"},
+    ]
+    sandbox = _mock_sandbox()
+
+    result = await restore.restore_to_sandbox("ws-1", sandbox)
+
+    uploads = {c.args[0]: c.args[1] for c in sandbox.aupload_file_bytes.await_args_list}
+    staged = {p: b for p, b in uploads.items() if not p.endswith(".file_sync_marker")}
+    assert set(staged.values()) == {b"one", b"two"}
+    assert all(p.startswith("/workspace/.wsfiles-relay-") for p in staged)
+    # No final path was ever written directly.
+    assert "/workspace/a/one.txt" not in uploads and "/workspace/two.txt" not in uploads
+
+    structure, placement = [c.args[1] for c in no_runtime.await_args_list]
+    assert [i["path"] for i in structure] == ["a"]
+    assert no_runtime.await_args_list[0].kwargs == {"defer_dir_modes": True}
+    by_path = {i["path"]: i for i in placement}
+    assert set(by_path) == {"a/one.txt", "two.txt", "a"}
+    one = by_path["a/one.txt"]
+    assert f"/workspace/{one['file']}" in staged and staged[f"/workspace/{one['file']}"] == b"one"
+    assert one["sha256"] == hashlib.sha256(b"one").hexdigest() and one["size"] == 3
+    assert by_path["a"]["kind"] == "dir" and by_path["a"]["mode"] == 0o555
+    assert result == {"restored": 3, "errors": 0}
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_a_row_whose_file_size_disagrees_with_its_bytes_is_still_placed(
+    mock_get, no_runtime
+):
+    """The placement check asks whether the upload arrived whole, so it has to
+    describe what was sent. A row written before ``file_size`` was taken from
+    the content itself can state a length its own bytes disagree with, and
+    checking against the column would refuse that file on every start, which
+    also leaves the manifest unable to ever prune."""
+    row = _file("stale.txt", "hello")
+    row["file_size"] = 999_999
+    mock_get.return_value = [row]
+
+    result = await restore.restore_to_sandbox("ws-1", _mock_sandbox())
+
+    item = no_runtime.await_args_list[0].args[1][0]
+    assert item["size"] == 5
+    assert item["sha256"] == hashlib.sha256(b"hello").hexdigest()
+    assert result == {"restored": 1, "errors": 0}
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_bytes_that_miss_their_own_hash_are_placed_but_named(
+    mock_get, no_runtime, caplog
+):
+    """Deriving the digest from the bytes drops the only reading the column
+    could still have given, so the disagreement is logged rather than lost."""
+    row = _file("drifted.txt", "hello")
+    row["content_hash"] = "0" * 64
+    mock_get.return_value = [row]
+
+    with caplog.at_level(logging.WARNING):
+        result = await restore.restore_to_sandbox("ws-1", _mock_sandbox())
+
+    item = no_runtime.await_args_list[0].args[1][0]
+    assert item["sha256"] == hashlib.sha256(b"hello").hexdigest()
+    assert "does not reproduce" in caplog.text or "do not reproduce" in caplog.text
+    assert result == {"restored": 1, "errors": 0}
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_a_failed_directory_stamp_in_a_relay_restore_is_an_error(mock_get, no_runtime, restore_flag):
+    """The structure pass creates the directory, the placement op applies its
+    final mode and mtime. When that last step fails the files are back but the
+    metadata is not, and a restore that clears the flag anyway lets the next
+    backup record the wrong mode as the user's own."""
+    mock_get.return_value = [
+        _file("a/one.txt", "one"),
+        _file("two.txt", "two"),
+        {"file_path": "a", "kind": "dir", "permissions": "0555"},
+    ]
+
+    def _place(sandbox, items, **kw):
+        out = _place_everything(sandbox, items, **kw)
+        if not kw.get("defer_dir_modes"):
+            out["a"] = {"status": "failed", "error": "chmod: EPERM"}
+        return out
+
+    no_runtime.side_effect = _place
+    sandbox = _mock_sandbox()
+
+    result = await restore.restore_to_sandbox("ws-1", sandbox)
+
+    # The structure pass already counted the directory; the failed stamp
+    # adds an error rather than taking that count back.
+    assert result == {"restored": 3, "errors": 1}
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", True)]
+    assert not any(
+        c.args[0].endswith(".file_sync_marker") for c in sandbox.aupload_file_bytes.await_args_list
     )
-    mock_get.return_value = files
-
-    sandbox = _mock_sandbox()
-    # short-circuit post-restore mtime sync to keep the test focused
-    with patch.object(
-        FilePersistenceService, "list_sandbox_files", new=AsyncMock(return_value={})
-    ):
-        result = await FilePersistenceService.restore_to_sandbox("ws-1", sandbox)
-
-    assert result == {"restored": 50, "errors": 0}
-
-    # Exactly one bulk-mkdir call, with all three unique dirs.
-    sandbox.acreate_directories.assert_awaited_once()
-    dirs_arg = sandbox.acreate_directories.await_args.args[0]
-    dirs_set = set(dirs_arg)
-    assert dirs_set == {"/workspace/data/a", "/workspace/data/b", "/workspace/reports"}
-
-    # Per-file mkdir is NOT invoked on the happy bulk-success path.
-    sandbox.acreate_directory.assert_not_awaited()
-
-    # Upload is called once per file (+1 for the sync marker at the end).
-    upload_paths = [c.args[0] for c in sandbox.aupload_file_bytes.await_args_list]
-    file_uploads = [p for p in upload_paths if not p.endswith(".file_sync_marker")]
-    assert len(file_uploads) == 50
 
 
 @pytest.mark.asyncio
-@patch("src.server.services.persistence.file.get_files_for_workspace", new_callable=AsyncMock)
-async def test_restore_falls_back_to_per_dir_when_bulk_fails(mock_get):
-    """If acreate_directories returns False (e.g. command line too long
-    for huge workspaces), restore falls back to parallel per-dir creates
-    before uploads start."""
-    mock_get.return_value = [_file("a/x.txt"), _file("b/y.txt")]
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_directory_modes_are_still_applied_when_every_file_fails_to_stage(mock_get, no_runtime, restore_flag):
+    """The structure pass leaves the directories open for the relay pass to
+    place files under, and only the placement op closes them again. Returning
+    early because no file survived staging strands them at their working modes,
+    and the next backup records those as the user's own."""
+    mock_get.return_value = [
+        _file("a/one.txt", "one"),
+        _file("two.txt", "two"),
+        {"file_path": "a", "kind": "dir", "permissions": "0555"},
+    ]
     sandbox = _mock_sandbox()
-    sandbox.acreate_directories = AsyncMock(return_value=False)
+    sandbox.aupload_file_bytes = AsyncMock(
+        side_effect=lambda path, _content: ".wsfiles-relay-" not in path
+    )
 
-    with patch.object(
-        FilePersistenceService, "list_sandbox_files", new=AsyncMock(return_value={})
-    ):
-        result = await FilePersistenceService.restore_to_sandbox("ws-1", sandbox)
+    result = await restore.restore_to_sandbox("ws-1", sandbox)
 
-    assert result == {"restored": 2, "errors": 0}
-    sandbox.acreate_directories.assert_awaited_once()
-    # Fallback fires acreate_directory per unique parent dir.
-    dirs_from_fallback = {
-        call.args[0] for call in sandbox.acreate_directory.await_args_list
+    structure, placement = [c.args[1] for c in no_runtime.await_args_list]
+    assert [i["path"] for i in structure] == ["a"]
+    assert no_runtime.await_args_list[0].kwargs == {"defer_dir_modes": True}
+    # Nothing but the directory items, and the op ran all the same.
+    assert [(i["path"], i["kind"], i["mode"]) for i in placement] == [("a", "dir", 0o555)]
+    assert result == {"restored": 1, "errors": 2}
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", True)]
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_a_staged_file_the_runtime_rejects_is_an_error_and_keeps_the_flag(mock_get, no_runtime, restore_flag):
+    mock_get.return_value = [_file("a.txt", "aaa"), _file("b.txt", "bbb")]
+    no_runtime.side_effect = lambda sb, items, **kw: {
+        i["path"]: {"status": "mismatch" if i["path"] == "a.txt" else "ok", "error": "got bytes=1"} for i in items
     }
-    assert dirs_from_fallback == {"/workspace/a", "/workspace/b"}
-    upload_paths = [c.args[0] for c in sandbox.aupload_file_bytes.await_args_list]
-    file_uploads = [p for p in upload_paths if not p.endswith(".file_sync_marker")]
-    assert len(file_uploads) == 2
+
+    result = await restore.restore_to_sandbox("ws-1", _mock_sandbox())
+
+    assert result == {"restored": 1, "errors": 1}
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", True)]
 
 
 @pytest.mark.asyncio
-@patch("src.server.services.persistence.file.get_files_for_workspace", new_callable=AsyncMock)
-async def test_restore_isolates_per_file_failures(mock_get):
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_a_placement_op_that_raises_counts_every_staged_file(mock_get, no_runtime, restore_flag):
+    mock_get.return_value = [_file("a.txt"), _file("b.txt")]
+    no_runtime.side_effect = TransferRuntimeError("sandbox went away")
+
+    result = await restore.restore_to_sandbox("ws-1", _mock_sandbox())
+
+    assert result == {"restored": 0, "errors": 2}
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", True)]
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_restore_isolates_per_file_failures(mock_get, restore_flag):
     """A single failed upload doesn't block the rest. 5 files, one
     raises, one returns False — healthy 3 still restore, error count
-    tallied correctly, method does not raise."""
+    tallied correctly, method does not raise.
+
+    Incompleteness is recorded in Postgres and the sandbox marker is
+    WITHHELD. Pruning against a sandbox that failed to restore deletes the
+    manifest rows for exactly the files that never came back, losing them
+    from both tiers, so the flag that prevents it has to be durable and
+    visible to another worker. The marker only claims "this sandbox has
+    been populated"; withholding it makes the next start retry.
+    """
     mock_get.return_value = [_file(f"f_{i}.txt") for i in range(5)]
     sandbox = _mock_sandbox()
 
@@ -127,20 +306,89 @@ async def test_restore_isolates_per_file_failures(mock_get):
 
     sandbox.aupload_file_bytes = AsyncMock(side_effect=flaky_upload)
 
-    with patch.object(
-        FilePersistenceService, "list_sandbox_files", new=AsyncMock(return_value={})
-    ):
-        result = await FilePersistenceService.restore_to_sandbox("ws-1", sandbox)
+    result = await restore.restore_to_sandbox("ws-1", sandbox)
 
     assert result["restored"] == 3
     assert result["errors"] == 2
-    # 5 file uploads + 1 sync-marker upload (sync marker runs in a best-effort
-    # try/except so it runs even when some files errored).
-    assert sandbox.aupload_file_bytes.await_count == 6
+    # 5 file uploads and no marker — restore stays retryable next start.
+    assert sandbox.aupload_file_bytes.await_count == 5
+    upload_paths = [c.args[0] for c in sandbox.aupload_file_bytes.await_args_list]
+    assert not any(p.endswith(".file_sync_marker") for p in upload_paths)
+    # Raised up front and never cleared.
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", True)]
 
 
 @pytest.mark.asyncio
-@patch("src.server.services.persistence.file.get_files_for_workspace", new_callable=AsyncMock)
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_a_clean_restore_raises_the_flag_then_clears_it(mock_get, restore_flag):
+    """The flag is durable before the first byte moves, not after the last one."""
+    mock_get.return_value = [_file("a.txt")]
+    result = await restore.restore_to_sandbox("ws-1", _mock_sandbox())
+
+    assert result == {"restored": 1, "errors": 0}
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", True), ("ws-1", False)]
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.pull_direct", new_callable=AsyncMock)
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_a_transfer_that_raises_leaves_the_workspace_flagged(
+    mock_get, mock_pull, restore_flag
+):
+    """``maybe_restore`` and the workspace manager swallow a TransferRuntimeError
+    as a warning. If the flag were written after the transfers, the sandbox would
+    be left a partial mirror with nothing recording it, and the next sync would
+    prune the manifest rows for every file that never arrived."""
+    mock_get.return_value = [{"file_path": "d", "kind": "dir", "permissions": "0755"}]
+    mock_pull.side_effect = TransferRuntimeError("sandbox went away")
+
+    with pytest.raises(TransferRuntimeError):
+        await restore.restore_to_sandbox("ws-1", _mock_sandbox())
+
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", True)]
+
+
+@pytest.mark.asyncio
+async def test_a_lock_wait_that_times_out_still_flags_the_workspace(restore_flag):
+    """The lock wait is the one step before the flag is raised. Both callers
+    swallow ``WorkspaceSyncBusy`` as a warning, so without the flag the sandbox
+    starts as an empty mirror of a full manifest and the next sync prunes it."""
+
+    @asynccontextmanager
+    async def _busy(_workspace_id):
+        raise WorkspaceSyncBusy("held")
+        yield  # pragma: no cover
+
+    with patch("src.server.services.persistence.restore.workspace_sync_lock", _busy):
+        with pytest.raises(WorkspaceSyncBusy):
+            await restore.restore_to_sandbox("ws-1", _mock_sandbox())
+
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", True)]
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_maybe_restore_counts_structural_rows_as_files_to_restore(mock_get):
+    """A workspace of directories and symlinks is not an empty one. Reading it as
+    empty writes the marker and clears the flag, and the next backup then prunes
+    the structural rows the sandbox was never given."""
+    mock_get.return_value = [{"file_path": "d", "kind": "dir", "permissions": "0755"}]
+    sandbox = _mock_sandbox()
+    sandbox.adownload_file_bytes = AsyncMock(return_value=None)  # no sync marker
+
+    with patch.object(
+        restore, "restore_to_sandbox", new_callable=AsyncMock
+    ) as restore_fn:
+        await restore.maybe_restore("ws-1", sandbox)
+
+    restore_fn.assert_awaited_once_with(
+        "ws-1", sandbox, expected_sandbox_id=sandbox.sandbox_id
+    )
+    assert mock_get.await_args.kwargs["all_kinds"] is True
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
 async def test_restore_caps_concurrency_at_semaphore_size(mock_get):
     """Worker pool semaphore caps concurrent uploads at 16. With 40
     files each taking a tick, peak in-flight must never exceed 16."""
@@ -160,10 +408,7 @@ async def test_restore_caps_concurrency_at_semaphore_size(mock_get):
 
     sandbox.aupload_file_bytes = AsyncMock(side_effect=tracking_upload)
 
-    with patch.object(
-        FilePersistenceService, "list_sandbox_files", new=AsyncMock(return_value={})
-    ):
-        await FilePersistenceService.restore_to_sandbox("ws-1", sandbox)
+    await restore.restore_to_sandbox("ws-1", sandbox)
 
     assert peak <= 16, f"Concurrency cap breached: peak={peak}"
     # Sanity: parallelism actually happened (not forced to 1).
@@ -171,14 +416,255 @@ async def test_restore_caps_concurrency_at_semaphore_size(mock_get):
 
 
 @pytest.mark.asyncio
-@patch("src.server.services.persistence.file.get_files_for_workspace", new_callable=AsyncMock)
-async def test_restore_empty_file_list_is_noop(mock_get):
-    """Zero files → no sandbox calls, no errors."""
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_restore_empty_file_list_is_noop(mock_get, restore_flag):
+    """Zero files → no sandbox calls, no errors, and nothing left flagged."""
     mock_get.return_value = []
     sandbox = _mock_sandbox()
 
-    result = await FilePersistenceService.restore_to_sandbox("ws-1", sandbox)
+    result = await restore.restore_to_sandbox("ws-1", sandbox)
 
     assert result == {"restored": 0, "errors": 0}
     sandbox.acreate_directories.assert_not_awaited()
     sandbox.aupload_file_bytes.assert_not_awaited()
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", True), ("ws-1", False)]
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_a_manifest_read_that_raises_leaves_the_workspace_flagged(
+    mock_get, restore_flag
+):
+    """The window the flag has to cover starts at the manifest read, not at the
+    first transfer: a sandbox that was recreated is empty either way."""
+    mock_get.side_effect = RuntimeError("db blip")
+
+    with pytest.raises(RuntimeError):
+        await restore.restore_to_sandbox("ws-1", _mock_sandbox())
+
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", True)]
+
+
+@pytest.mark.asyncio
+async def test_the_flag_is_raised_before_the_lock_is_requested(restore_flag):
+    """A worker whose wait times out must not flag a restore another worker
+    completed meanwhile. The holder clears the flag as its last write before
+    releasing the lock, so a flag written before the wait began is always the
+    older of the two; one written after the timeout could be the newer."""
+    order: list[str] = []
+    restore_flag.side_effect = lambda *a, **k: order.append(f"flag={a[1]}") or True
+
+    @asynccontextmanager
+    async def _busy(_workspace_id):
+        order.append("lock")
+        raise WorkspaceSyncBusy("held")
+        yield  # pragma: no cover
+
+    with patch("src.server.services.persistence.restore.workspace_sync_lock", _busy):
+        with pytest.raises(WorkspaceSyncBusy):
+            await restore.restore_to_sandbox("ws-1", _mock_sandbox())
+
+    assert order == ["flag=True", "lock"]
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_a_clean_restore_clears_the_flag_after_the_marker(mock_get, restore_flag):
+    """The clear is the holder's last write: see the test above."""
+    mock_get.return_value = [_file("a.txt", "a")]
+    order: list[str] = []
+    restore_flag.side_effect = lambda *a, **k: order.append(f"flag={a[1]}") or True
+    sandbox = _mock_sandbox()
+
+    async def upload(path, _data):
+        if path.endswith(".file_sync_marker"):
+            order.append("marker")
+        return True
+
+    sandbox.aupload_file_bytes = AsyncMock(side_effect=upload)
+
+    await restore.restore_to_sandbox("ws-1", sandbox)
+
+    assert order == ["flag=True", "marker", "flag=False"]
+
+
+@pytest.mark.asyncio
+async def test_a_flag_left_standing_beside_a_marker_is_cleared(restore_flag, flag_state):
+    """A restore writes the marker and then clears the flag; a process that dies
+    between the two leaves a populated sandbox whose every later backup would
+    withhold pruning. The marker is written only after a zero-error restore, so
+    the flag beside it is stale."""
+    flag_state.return_value = True
+    sandbox = _mock_sandbox()
+    sandbox.adownload_file_bytes = AsyncMock(return_value=b"2026")
+
+    with patch.object(restore, "restore_to_sandbox", new_callable=AsyncMock) as restore_fn:
+        await restore.maybe_restore("ws-1", sandbox)
+
+    restore_fn.assert_not_awaited()
+    assert [c.args for c in restore_flag.await_args_list] == [("ws-1", False)]
+
+
+@pytest.mark.asyncio
+async def test_a_marker_with_no_flag_writes_nothing(restore_flag):
+    sandbox = _mock_sandbox()
+    sandbox.adownload_file_bytes = AsyncMock(return_value=b"2026")
+
+    with patch.object(restore, "restore_to_sandbox", new_callable=AsyncMock) as restore_fn:
+        await restore.maybe_restore("ws-1", sandbox)
+
+    restore_fn.assert_not_awaited()
+    restore_flag.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_flag_write_that_fails_aborts_before_the_lock(restore_flag):
+    """Without the guard an empty sandbox reads as an emptied workspace. The
+    caller has to abort provisioning, so the failure must not look like any
+    other restore error, which the callers swallow."""
+    restore_flag.side_effect = RuntimeError("db away")
+    requested = []
+
+    @asynccontextmanager
+    async def _lock(_workspace_id):
+        requested.append(True)
+        yield "conn"
+
+    with patch("src.server.services.persistence.restore.workspace_sync_lock", _lock):
+        with pytest.raises(restore.RestoreGuardUnavailable):
+            await restore.restore_to_sandbox("ws-1", _mock_sandbox())
+
+    assert requested == []
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_the_raise_and_the_clear_each_name_their_sandbox(mock_get, restore_flag):
+    """A restore runs on a provisional sandbox before the identity CAS. The
+    raise names the sandbox the CAS expects to replace; the clear lands only
+    while the row names this sandbox, so a clean restore that then loses the
+    race cannot vouch for the winner."""
+    mock_get.return_value = [_file("a.txt")]
+    sandbox = _mock_sandbox()
+    sandbox.sandbox_id = "sb-provisional"
+
+    await restore.restore_to_sandbox("ws-1", sandbox, expected_sandbox_id="sb-previous")
+
+    raised, cleared = restore_flag.await_args_list
+    assert raised.args == ("ws-1", True)
+    assert raised.kwargs["sandbox_id"] == "sb-previous"
+    assert cleared.args == ("ws-1", False)
+    assert cleared.kwargs["sandbox_id"] == "sb-provisional"
+
+
+@pytest.mark.asyncio
+async def test_a_raise_that_lands_nowhere_aborts_as_identity_lost(restore_flag):
+    """Another provisioner bound the workspace while this one was still
+    building; a restore now would fill a sandbox the CAS is about to discard,
+    and its flag would stand on the winner's row with nothing left to clear it."""
+    restore_flag.return_value = False
+    requested = []
+
+    @asynccontextmanager
+    async def _lock(_workspace_id):
+        requested.append(True)
+        yield "conn"
+
+    with patch("src.server.services.persistence.restore.workspace_sync_lock", _lock):
+        with pytest.raises(restore.RestoreIdentityLost):
+            await restore.restore_to_sandbox(
+                "ws-1", _mock_sandbox(), expected_sandbox_id="sb-previous"
+            )
+
+    assert requested == []
+    assert issubclass(restore.RestoreIdentityLost, restore.RestoreGuardUnavailable)
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_a_reconcile_on_a_bound_sandbox_expects_the_row_to_name_it(mock_get, restore_flag):
+    mock_get.return_value = [_file("a.txt")]
+    sandbox = _mock_sandbox()
+    sandbox.sandbox_id = "sb-bound"
+    sandbox.adownload_file_bytes = AsyncMock(return_value=None)
+
+    await restore.maybe_restore("ws-1", sandbox)
+
+    raised = restore_flag.await_args_list[0]
+    assert raised.args == ("ws-1", True)
+    assert raised.kwargs["sandbox_id"] == "sb-bound"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_flag_beside_a_marker_is_cleared_for_that_sandbox(restore_flag, flag_state):
+    flag_state.return_value = True
+    sandbox = _mock_sandbox()
+    sandbox.sandbox_id = "sb-bound"
+    sandbox.adownload_file_bytes = AsyncMock(return_value=b"2026")
+
+    await restore.maybe_restore("ws-1", sandbox)
+
+    assert restore_flag.await_args.kwargs["sandbox_id"] == "sb-bound"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_clear_beside_the_marker_is_retried(restore_flag, flag_state):
+    """The reconcile after the bind is the last one a warm session gets; a
+    single transient failure there must not leave pruning withheld until the
+    sandbox is recreated, when the restore would bring deleted files back."""
+    flag_state.return_value = True
+    restore_flag.side_effect = [RuntimeError("db away"), True]
+    sandbox = _mock_sandbox()
+    sandbox.sandbox_id = "sb-bound"
+    sandbox.adownload_file_bytes = AsyncMock(return_value=b"2026")
+
+    with patch("src.server.services.persistence.restore._FLAG_CLEAR_BACKOFF_S", 0):
+        await restore.maybe_restore("ws-1", sandbox)
+
+    assert restore_flag.await_count == 2
+    assert all(c.args == ("ws-1", False) for c in restore_flag.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_a_clear_that_keeps_failing_is_logged_as_an_error(restore_flag, flag_state, caplog):
+    flag_state.return_value = True
+    restore_flag.side_effect = RuntimeError("db away")
+    sandbox = _mock_sandbox()
+    sandbox.adownload_file_bytes = AsyncMock(return_value=b"2026")
+
+    with patch("src.server.services.persistence.restore._FLAG_CLEAR_BACKOFF_S", 0):
+        await restore.maybe_restore("ws-1", sandbox)
+
+    assert restore_flag.await_count == restore._FLAG_CLEAR_ATTEMPTS
+    assert any(
+        r.levelname == "ERROR" and "completeness flag" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_maybe_restore_lets_a_missing_guard_reach_the_caller(mock_get, restore_flag):
+    """On the lazy-start and reconnect paths this is the only restore; the
+    generic handler must not turn the guard's absence into a warning."""
+    mock_get.return_value = [_file("a.txt")]
+    restore_flag.side_effect = RuntimeError("db away")
+    sandbox = _mock_sandbox()
+    sandbox.adownload_file_bytes = AsyncMock(return_value=None)
+
+    with pytest.raises(restore.RestoreGuardUnavailable):
+        await restore.maybe_restore("ws-1", sandbox)
+
+
+@pytest.mark.asyncio
+@patch("src.server.services.persistence.restore.get_files_for_workspace", new_callable=AsyncMock)
+async def test_maybe_restore_treats_an_unreadable_manifest_as_a_missing_guard(mock_get, restore_flag):
+    """A manifest read that fails leaves the flag unraised and the sandbox
+    empty, so it has to unwind provisioning the same way a failed raise does."""
+    mock_get.side_effect = RuntimeError("db away")
+    sandbox = _mock_sandbox()
+    sandbox.adownload_file_bytes = AsyncMock(return_value=None)
+
+    with pytest.raises(restore.RestoreGuardUnavailable):
+        await restore.maybe_restore("ws-1", sandbox)
+    restore_flag.assert_not_awaited()

--- a/tests/unit/server/services/test_persistence_direct_transfer.py
+++ b/tests/unit/server/services/test_persistence_direct_transfer.py
@@ -1,0 +1,542 @@
+"""Contracts for sync/restore driven by the sandbox-side transfer runtime.
+
+The persistence service no longer touches file bytes on the blob path: the
+sandbox scans and hashes itself, the registry says which digests already have
+an object, and only the missing ones move, straight from the sandbox to the
+store under a content-bound presigned PUT. These pin the decision table that
+was verified live (direct, relay fallback, store rejection, storage off).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.database.workspace_file import datetime_to_micros, micros_to_datetime
+from src.server.services.persistence import backup, blobs, resolve, restore
+from src.server.services.persistence._rows import (
+    _detect_is_binary,
+    _mode_int,
+    _ns_to_datetime,
+    _row_base,
+)
+from src.server.services.persistence.transfer import ScanEntry, ScanResult
+
+
+@pytest.fixture(autouse=True)
+def _transfer_mode_from_provider():
+    """The mode is read from the environment at import; pin it so a developer's
+    .env cannot reroute these through the other path."""
+    with (
+        patch("src.utils.storage.BLOB_TRANSFER_MODE", "auto"),
+        patch("src.utils.storage.STORAGE_PROVIDER", "s3"),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _sync_lock():
+    """Sync and restore serialize on a Postgres advisory lock; there is no DB here."""
+
+    @asynccontextmanager
+    async def _lock(_workspace_id):
+        yield None
+
+    with (
+        patch.object(backup, "workspace_sync_lock", _lock),
+        patch.object(restore, "workspace_sync_lock", _lock),
+    ):
+        yield
+
+
+WS = "ws-direct"
+USER = "user-direct"
+NS = 1_700_000_000_123_456_789
+A = "a" * 64
+B = "b" * 64
+
+
+def _entry(path, sha=A, size=3, mode=0o644, kind="file", target=None, is_binary=False, mtime_ns=NS):
+    return ScanEntry(path, kind, size, mtime_ns, mode, sha if kind == "file" else None, target, is_binary)
+
+
+def _scan(*entries):
+    return ScanResult(list(entries), [], [], hashed=len(entries), reused=0)
+
+
+def _sandbox(provider="daytona"):
+    sb = MagicMock()
+    sb.working_dir = "/workspace"
+    sb.config.sandbox.provider = provider
+    sb.adownload_file_bytes = AsyncMock(return_value=b"abc")
+    return sb
+
+
+CLOCK = datetime(2026, 9, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def db():
+    """Every database and store seam, so each test states only what differs."""
+    with (
+        patch.object(backup, "manifest_clock", new=AsyncMock(return_value=CLOCK)),
+        patch.object(backup, "get_file_metadata_for_sync", new=AsyncMock(return_value={})) as meta,
+        patch.object(backup, "files_restore_incomplete", new=AsyncMock(return_value=False)),
+        patch.object(backup, "delete_removed_files", new=AsyncMock(return_value=0)) as deleter,
+        patch.object(backup, "get_workspace_total_size", new=AsyncMock(return_value=0)),
+        patch.object(backup, "bulk_upsert_files", new=AsyncMock(side_effect=lambda ws, rows, conn=None: len(rows))) as upsert,
+        patch.object(backup, "bulk_update_file_stamps", new=AsyncMock()) as mtimes,
+        patch.object(backup, "is_storage_enabled", return_value=True),
+        patch.object(backup, "workspace_owner", new=AsyncMock(return_value=USER)),
+        # These pin the per-object path; the pack set has its own tests.
+        patch.object(backup, "PACK_CUTOFF", -1),
+        patch.object(blobs, "registered_blobs", new=AsyncMock(return_value=set())) as registered,
+        patch.object(blobs, "register_blobs", new=AsyncMock()) as register,
+        patch.object(blobs, "get_signed_upload_url", return_value=("https://put", {"h": "v"})) as presign,
+        patch.object(blobs, "push_direct", new=AsyncMock(return_value={})) as push,
+        patch.object(blobs, "store_blob", new=AsyncMock()) as store,
+        patch.object(backup, "scan_workspace", new=AsyncMock(return_value=_scan())) as scan,
+    ):
+        yield {
+            "meta": meta, "deleter": deleter, "upsert": upsert, "mtimes": mtimes,
+            "registered": registered, "register": register, "presign": presign,
+            "push": push, "store": store, "scan": scan,
+        }
+
+
+def _rows(db):
+    return {r["file_path"]: r for r in db["upsert"].await_args.args[1]}
+
+
+# --- timestamps ------------------------------------------------------------
+
+
+def test_micros_round_trip_is_exact():
+    """A float epoch loses the last microsecond on some values; integers do not."""
+    dt = datetime(2026, 9, 3, 12, 41, 7, 536614, tzinfo=timezone.utc)
+    micros = datetime_to_micros(dt)
+    assert micros_to_datetime(micros) == dt
+    assert _ns_to_datetime(micros * 1000 + 781) == dt
+
+
+# --- sync: direct path -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_files_go_direct_and_register_only_what_the_store_took(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A), _entry("b.bin", B, size=5, is_binary=True), _entry("dup.txt", A))
+    db["push"].return_value = {A: {"status": "ok", "http": 200}, B: {"status": "ok", "http": 200}}
+
+    result = await backup.sync_to_db(WS, _sandbox())
+
+    # One presign and one push item per distinct digest, never per path.
+    assert db["presign"].call_count == 2
+    items = db["push"].await_args.args[1]
+    assert sorted(i["sha256"] for i in items) == [A, B]
+    assert all(i["url"] == "https://put" and i["headers"] == {"h": "v"} for i in items)
+    assert sorted(db["register"].await_args.args[1]) == [(A, 3), (B, 5)]
+    db["store"].assert_not_awaited()  # no bytes through this process
+    rows = _rows(db)
+    assert set(rows) == {"a.txt", "b.bin", "dup.txt"}
+    assert rows["a.txt"]["blob_sha256"] == A and rows["a.txt"]["content_text"] is None
+    assert rows["b.bin"]["is_binary"] is True and rows["a.txt"]["is_binary"] is False
+    assert rows["a.txt"]["permissions"] == "0644"
+    assert rows["a.txt"]["sandbox_modified_at"] == micros_to_datetime(NS // 1000)
+    assert result == {"synced": 3, "skipped": 0, "deleted": 0, "errors": 0, "oversized": 0, "total_size": 0}
+
+
+@pytest.mark.asyncio
+async def test_registered_digest_skips_upload_entirely(db):
+    """The registry is the proof of an object; a hit costs no bytes and no HTTP."""
+    db["scan"].return_value = _scan(_entry("a.txt", A))
+    db["registered"].return_value = {A}
+
+    await backup.sync_to_db(WS, _sandbox())
+
+    db["presign"].assert_not_called()
+    db["push"].assert_not_awaited()
+    db["register"].assert_not_awaited()
+    assert _rows(db)["a.txt"]["blob_sha256"] == A
+
+
+@pytest.mark.asyncio
+async def test_store_rejection_withholds_the_row_and_counts_an_error(db):
+    """A reached store that said no is final this pass; the old row survives."""
+    db["scan"].return_value = _scan(_entry("a.txt", A), _entry("b.txt", B))
+    db["push"].return_value = {A: {"status": "failed", "http": 403}, B: {"status": "changed", "http": 400}}
+
+    result = await backup.sync_to_db(WS, _sandbox())
+
+    db["store"].assert_not_awaited()  # no relay after a rejection
+    db["upsert"].assert_not_awaited()
+    assert result["errors"] == 2 and result["synced"] == 0
+    db["deleter"].assert_awaited_once()
+    assert db["deleter"].await_args.args[1] == {"a.txt", "b.txt"}  # paths still active: never pruned
+
+
+@pytest.mark.asyncio
+async def test_unreachable_store_falls_back_to_relay_in_the_same_pass(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A))
+    db["push"].return_value = {A: {"status": "unreachable"}}
+    sb = _sandbox()
+    sb.adownload_file_bytes = AsyncMock(return_value=b"\x00" * 3)  # sha256 differs from A
+
+    with patch.object(blobs.hashlib, "sha256") as sha:
+        sha.return_value.hexdigest.return_value = A
+        result = await backup.sync_to_db(WS, sb)
+
+    sb.adownload_file_bytes.assert_awaited_once_with("/workspace/a.txt")
+    db["store"].assert_awaited_once_with(USER, A, b"\x00" * 3)
+    assert _rows(db)["a.txt"]["blob_sha256"] == A
+    assert result["errors"] == 0
+
+
+@pytest.mark.asyncio
+async def test_relay_mode_and_unpresignable_store_never_push(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A))
+    for setup in ({"provider": "docker"}, {"presign": None}):
+        db["push"].reset_mock()
+        db["store"].reset_mock()
+        db["presign"].return_value = ("https://put", {}) if "presign" not in setup else None
+        sb = _sandbox(setup.get("provider", "daytona"))
+        with patch.object(blobs.hashlib, "sha256") as sha:
+            sha.return_value.hexdigest.return_value = A
+            await backup.sync_to_db(WS, sb)
+        db["push"].assert_not_awaited()
+        db["store"].assert_awaited_once()
+
+
+# --- sync: classification --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unchanged_pointer_row_with_new_mode_is_refreshed_without_bytes(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A, mode=0o600))
+    db["meta"].return_value = {
+        "a.txt": {"kind": "file", "file_size": 3, "content_hash": A, "mtime_ns": NS, "permissions": "0644",
+                  "blob_sha256": A, "is_binary": False, "mime_type": "text/plain"},
+    }
+
+    result = await backup.sync_to_db(WS, _sandbox())
+
+    db["registered"].assert_not_awaited()
+    db["push"].assert_not_awaited()
+    row = _rows(db)["a.txt"]
+    assert row["permissions"] == "0600" and row["blob_sha256"] == A
+    assert result["skipped"] == 1 and result["synced"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unchanged_inline_row_only_gets_its_mtime_refreshed(db):
+    """An inline row cannot be upserted without the bytes it carries."""
+    db["scan"].return_value = _scan(_entry("a.txt", A, mtime_ns=NS + 5_000_000))
+    db["meta"].return_value = {
+        "a.txt": {"kind": "file", "file_size": 3, "content_hash": A, "mtime_ns": NS, "permissions": "0644",
+                  "blob_sha256": None},
+    }
+
+    await backup.sync_to_db(WS, _sandbox())
+
+    db["upsert"].assert_not_awaited()
+    db["mtimes"].assert_awaited_once()
+    (path, when, perms), = db["mtimes"].await_args.args[1]
+    assert path == "a.txt" and when == micros_to_datetime((NS + 5_000_000) // 1000)
+    assert perms == "0644"
+
+
+@pytest.mark.asyncio
+async def test_unchanged_inline_row_persists_a_mode_only_change(db):
+    """chmod +x on a file whose bytes did not move: the row has no pointer to
+    refresh through an upsert, so the stamps update carries the new mode, or
+    the file comes back from a recreated sandbox with its old one."""
+    db["scan"].return_value = _scan(_entry("a.txt", A, mode=0o755))
+    db["meta"].return_value = {
+        "a.txt": {"kind": "file", "file_size": 3, "content_hash": A, "mtime_ns": NS, "permissions": "0644",
+                  "blob_sha256": None},
+    }
+
+    await backup.sync_to_db(WS, _sandbox())
+
+    db["upsert"].assert_not_awaited()
+    (path, when, perms), = db["mtimes"].await_args.args[1]
+    assert path == "a.txt" and when == micros_to_datetime(NS // 1000) and perms == "0755"
+
+
+def test_a_zero_mode_is_recorded_and_restored_as_zero():
+    """0000 is a real mode (a file made unreadable on purpose); only a symlink,
+    whose mode is never applied, records none. Absent is what restore reads
+    as the 0644 default, so zero must never collapse into it."""
+    assert _row_base(_entry("locked", mode=0))["permissions"] == "0000"
+    assert _row_base(_entry("l", kind="symlink", target="a", mode=0))["permissions"] is None
+    assert _mode_int("0000", "file") == 0
+    assert _mode_int(None, "file") == 0o644
+
+
+def test_a_multibyte_character_split_at_the_scan_window_is_still_text():
+    """The probe reads 8KiB of a longer file, so its end can land inside a
+    character. Decoding that window on its own made the truncation look like
+    invalid UTF-8, and ordinary CJK or accented prose was stored as bytes and
+    dropped out of text search. A sequence that is invalid wherever it sits
+    still reads as binary.
+    """
+    # The window ends one byte into the euro sign, which is three bytes long.
+    straddles = b"a" * 8191 + "€".encode() + b"b" * 100
+    assert _detect_is_binary("notes.txt", straddles) is False
+    assert _detect_is_binary("notes.txt", b"a" * 100 + b"\xff\xfe" + b"b" * 9000) is True
+    # The whole content decides, not the first window: a blob row is never
+    # re-read on the way out.
+    assert _detect_is_binary("notes.txt", b"a" * 9000 + b"\xff\xfe") is True
+    assert _detect_is_binary("notes.txt", ("caf\u00e9 " * 400_000).encode("utf-8")) is False
+    # A NUL is not sampled either: text goes to a column that cannot hold one.
+    assert _detect_is_binary("notes.txt", b"a" * 70000 + b"\x00") is True
+
+
+@pytest.mark.asyncio
+async def test_same_microsecond_stamp_is_a_pure_skip(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A, mtime_ns=NS + 100))  # same microsecond
+    db["meta"].return_value = {
+        "a.txt": {"kind": "file", "file_size": 3, "content_hash": A, "mtime_ns": NS, "permissions": "0644",
+                  "blob_sha256": A},
+    }
+    result = await backup.sync_to_db(WS, _sandbox())
+    db["upsert"].assert_not_awaited()
+    db["mtimes"].assert_not_awaited()
+    assert result["skipped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_directories_and_symlinks_become_rows_without_content(db):
+    db["scan"].return_value = _scan(
+        _entry("empty", kind="dir", mode=0o755),
+        _entry("link", kind="symlink", mode=0, target="../t.txt"),
+    )
+    await backup.sync_to_db(WS, _sandbox())
+    db["registered"].assert_not_awaited()
+    rows = _rows(db)
+    assert rows["empty"]["kind"] == "dir" and rows["empty"]["permissions"] == "0755"
+    assert rows["empty"]["content_hash"] is None and rows["empty"]["blob_sha256"] is None
+    assert rows["link"]["kind"] == "symlink" and rows["link"]["symlink_target"] == "../t.txt"
+    assert rows["link"]["file_size"] == 0
+
+
+@pytest.mark.asyncio
+async def test_scan_read_errors_count_against_a_strict_backup(db):
+    db["scan"].return_value = ScanResult([_entry("ok.txt", A)], [], [{"path": "bad", "error": "EACCES"}], 1, 0)
+    db["push"].return_value = {A: {"status": "ok"}}
+    result = await backup.sync_to_db(WS, _sandbox())
+    assert result["errors"] == 1 and result["synced"] == 1
+
+
+@pytest.mark.asyncio
+async def test_storage_off_keeps_bytes_inline(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A), _entry("b.bin", B, is_binary=True))
+    sb = _sandbox()
+    sb.adownload_file_bytes = AsyncMock(side_effect=[b"text", b"\x00\x01"])
+    with patch.object(backup, "is_storage_enabled", return_value=False):
+        await backup.sync_to_db(WS, sb)
+    db["registered"].assert_not_awaited()
+    rows = _rows(db)
+    assert rows["a.txt"]["content_text"] == "text" and rows["a.txt"]["blob_sha256"] is None
+    assert rows["b.bin"]["content_binary"] == b"\x00\x01" and rows["b.bin"]["is_binary"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_late_nul_is_stored_whole_with_no_store_to_fall_back_on(db):
+    """The inline row has to reproduce its own digest, and a text column cannot.
+
+    With no object store the row is the only copy, and the text column drops a
+    NUL on the way in. A file whose NUL sits past any leading sniff would then
+    be stored short of its digest, and restore, which verifies it, would refuse
+    to place the file on every start from then on."""
+    content = b"a" * 70000 + b"\x00"
+    digest = hashlib.sha256(content).hexdigest()
+    db["scan"].return_value = _scan(_entry("log.txt", digest, size=len(content)))
+    sb = _sandbox()
+    sb.adownload_file_bytes = AsyncMock(return_value=content)
+    with patch.object(backup, "is_storage_enabled", return_value=False):
+        await backup.sync_to_db(WS, sb)
+    row = _rows(db)["log.txt"]
+    assert row["is_binary"] is True
+    assert row["content_text"] is None and row["content_binary"] == content
+    assert row["content_hash"] == digest and row["file_size"] == len(content)
+
+
+# --- restore ---------------------------------------------------------------
+
+
+def _row(path, *, kind="file", blob=None, text=None, perms="0644", target=None, size=3):
+    return {
+        "file_path": path, "kind": kind, "blob_sha256": blob, "content_text": text, "content_binary": None,
+        "is_binary": False, "permissions": perms, "symlink_target": target, "file_size": size,
+        "content_hash": blob or (hashlib.sha256(text.encode()).hexdigest() if text else None),
+        "sandbox_modified_at": micros_to_datetime(NS // 1000),
+    }
+
+
+@pytest.fixture
+def restore_db():
+    with (
+        patch.object(restore, "get_files_for_workspace", new=AsyncMock(return_value=[])) as rows,
+        patch.object(restore, "set_files_restore_incomplete", new=AsyncMock()) as flag,
+        patch.object(restore, "workspace_owner", new=AsyncMock(return_value=USER)),
+        patch.object(restore, "get_signed_url", return_value="https://get") as sign,
+        patch.object(restore, "pull_direct", new=AsyncMock(return_value={})) as pull,
+    ):
+        yield {"rows": rows, "flag": flag, "sign": sign, "pull": pull}
+
+
+@pytest.mark.asyncio
+async def test_restore_pulls_pointer_rows_and_structure_in_one_runtime_call(restore_db):
+    restore_db["rows"].return_value = [
+        _row("a.txt", blob=A, perms="0600"),
+        _row("d", kind="dir", perms="0755"),
+        _row("l", kind="symlink", target="a.txt"),
+        _row("old.txt", text="inline"),
+    ]
+    restore_db["pull"].side_effect = [
+        {"a.txt": {"status": "ok"}, "d": {"status": "ok"}, "l": {"status": "ok"}},
+        {"old.txt": {"status": "ok"}},  # the stamp after the relay upload
+    ]
+    sb = _sandbox()
+    sb.acreate_directories = AsyncMock(return_value=True)
+    sb.aupload_file_bytes = AsyncMock(return_value=True)
+
+    result = await restore.restore_to_sandbox(WS, sb)
+
+    first = restore_db["pull"].await_args_list[0]
+    by_path = {i["path"]: i for i in first.args[1]}
+    assert set(by_path) == {"a.txt", "d", "l"}
+    assert by_path["a.txt"]["url"] == "https://get" and by_path["a.txt"]["mode"] == 0o600
+    assert by_path["a.txt"]["mtime_ns"] == (NS // 1000) * 1000
+    assert by_path["d"]["url"] is None and by_path["l"]["symlink_target"] == "a.txt"
+    # A relay pass follows, so the first op leaves the directories open.
+    assert first.kwargs == {"defer_dir_modes": True}
+    # The legacy inline row went through the server to a staging name; the
+    # placement op verifies and moves it, and closes the directory after it.
+    uploads = [c.args[0] for c in sb.aupload_file_bytes.await_args_list]
+    assert "/workspace/old.txt" not in uploads
+    (staged,) = [p for p in uploads if p.startswith("/workspace/.wsfiles-relay-")]
+    placement = restore_db["pull"].await_args_list[1].args[1]
+    old = restore._pull_item(_row("old.txt", text="inline"), url=None)
+    # Size and digest describe the bytes relayed, not the row: this fixture's
+    # own file_size is stale, the shape a row written before file_size came
+    # from the content itself is in.
+    old.update({
+        "file": staged.removeprefix("/workspace/"),
+        "sha256": hashlib.sha256(b"inline").hexdigest(),
+        "size": len(b"inline"),
+    })
+    assert placement == [old, restore._pull_item(_row("d", kind="dir", perms="0755"), url=None)]
+    assert result == {"restored": 4, "errors": 0}
+    assert [c.args for c in restore_db["flag"].await_args_list] == [(WS, True), (WS, False)]
+    assert any(p.endswith(".file_sync_marker") for p in uploads)
+
+
+@pytest.mark.asyncio
+async def test_restore_unreachable_store_relays_and_a_mismatch_is_an_error(restore_db):
+    restore_db["rows"].return_value = [_row("a.txt", blob=A), _row("b.txt", blob=B)]
+    restore_db["pull"].side_effect = [
+        {"a.txt": {"status": "unreachable"}, "b.txt": {"status": "unreachable"}},
+        {"a.txt": {"status": "ok"}, "b.txt": {"status": "ok"}},
+    ]
+    sb = _sandbox()
+    sb.acreate_directories = AsyncMock(return_value=True)
+    sb.aupload_file_bytes = AsyncMock(return_value=True)
+    with patch.object(resolve, "fetch_blob", new=AsyncMock(return_value=b"abc")) as fetch:
+        result = await restore.restore_to_sandbox(WS, sb)
+    assert fetch.await_count == 2
+    assert result == {"restored": 2, "errors": 0}
+
+    restore_db["pull"].side_effect = [{"a.txt": {"status": "mismatch"}, "b.txt": {"status": "ok"}}]
+    result = await restore.restore_to_sandbox(WS, sb)
+    assert result == {"restored": 1, "errors": 1}
+    assert restore_db["flag"].await_args.args == (WS, True)
+
+
+@pytest.mark.asyncio
+async def test_restore_relay_mode_never_presigns(restore_db):
+    restore_db["rows"].return_value = [_row("a.txt", blob=A)]
+    restore_db["pull"].return_value = {"a.txt": {"status": "ok"}}
+    sb = _sandbox("docker")
+    sb.acreate_directories = AsyncMock(return_value=True)
+    sb.aupload_file_bytes = AsyncMock(return_value=True)
+    with patch.object(resolve, "fetch_blob", new=AsyncMock(return_value=b"abc")):
+        result = await restore.restore_to_sandbox(WS, sb)
+    restore_db["sign"].assert_not_called()
+    assert result == {"restored": 1, "errors": 0}
+
+
+# --- the sandbox exchange -----------------------------------------------------
+
+
+def _exec_sandbox(*responses):
+    """A sandbox whose runtime.exec yields ``responses`` in order."""
+    sandbox = MagicMock()
+    sandbox.working_dir = "/home/workspace"
+    sandbox.runtime.exec = AsyncMock(
+        side_effect=[MagicMock(stdout=out, exit_code=code) for out, code in responses]
+    )
+    sandbox.runtime.upload_file = AsyncMock()
+
+    async def _call(func, *args, retry_policy=None, **kw):
+        return await func(*args)
+
+    sandbox._runtime_call = AsyncMock(side_effect=_call)
+    return sandbox
+
+
+@pytest.mark.asyncio
+async def test_transfer_op_is_one_exec_with_the_result_on_stdout():
+    from src.server.services.persistence import transfer
+
+    marker = transfer.RESULT_MARKER
+    sandbox = _exec_sandbox((f"noise\n{marker}" + '{"results":{"a":{"status":"ok"}}}\n', 0))
+    out = await transfer.run_transfer_op(sandbox, "pull", {"root": "/home/workspace", "items": []}, timeout_s=30)
+    assert out == {"results": {"a": {"status": "ok"}}}
+    assert sandbox.runtime.exec.await_count == 1
+    sandbox.runtime.upload_file.assert_not_awaited()
+    cmd = sandbox.runtime.exec.await_args.args[0]
+    assert " pull --spec-b64 " in cmd
+
+
+@pytest.mark.asyncio
+async def test_transfer_op_reships_a_missing_or_stale_runtime_once():
+    from src.server.services.persistence import transfer
+
+    marker = transfer.RESULT_MARKER
+    sandbox = _exec_sandbox(
+        ("python3: can't open file: No such file or directory\n", 2),
+        (f"{marker}" + '{"entries":[],"errors":[],"oversized":[],"hashed":0,"reused":0}\n', 0),
+    )
+    out = await transfer.run_transfer_op(sandbox, "scan", {"root": "/home/workspace"}, timeout_s=30)
+    assert out["entries"] == []
+    assert sandbox.runtime.exec.await_count == 2
+    sandbox.runtime.upload_file.assert_awaited_once()
+    assert sandbox.runtime.upload_file.await_args.args[1].endswith("/_internal/src/wsfiles_transfer.py")
+
+
+@pytest.mark.asyncio
+async def test_transfer_op_large_spec_is_uploaded_then_run():
+    from src.server.services.persistence import transfer
+
+    marker = transfer.RESULT_MARKER
+    sandbox = _exec_sandbox((f"{marker}" + '{"results":{}}\n', 0))
+    items = [{"path": f"f{i}", "url": "https://s/" + "x" * 600} for i in range(400)]
+    await transfer.run_transfer_op(sandbox, "pull", {"root": "/home/workspace", "items": items}, timeout_s=30)
+    sandbox.runtime.upload_file.assert_awaited_once()
+    assert "/_internal/.wsfiles/pull-" in sandbox.runtime.upload_file.await_args.args[1]
+    assert "--spec-b64" not in sandbox.runtime.exec.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_transfer_op_without_a_result_line_is_a_runtime_error():
+    from src.server.services.persistence import transfer
+
+    sandbox = _exec_sandbox(("Traceback: boom\n", 1))
+    with pytest.raises(transfer.TransferRuntimeError):
+        await transfer.run_transfer_op(sandbox, "scan", {"root": "/home/workspace"}, timeout_s=30)

--- a/tests/unit/server/services/test_persistence_packs.py
+++ b/tests/unit/server/services/test_persistence_packs.py
@@ -1,0 +1,493 @@
+"""Contracts for the pack set: small files stored as members of shared chunks.
+
+Verified live first (2168 files into one 4.3 MB chunk; edit, restore, and
+serve while stopped) against a real sandbox and bucket. These pin the
+decisions: which files pack, when the set is rewritten, what a rejected
+chunk does to the manifest, and how a restore or a read addresses a member.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.server.services.persistence import backup, blobs, resolve, restore
+from src.server.services.persistence.resolve import resolve_file_bytes
+from src.server.services.persistence.transfer import PACK_CUTOFF, ScanEntry, ScanResult
+from src.server.database.workspace_file import micros_to_datetime
+
+
+@pytest.fixture(autouse=True)
+def _transfer_mode_from_provider():
+    """The mode is read from the environment at import; pin it so a developer's
+    .env cannot reroute these through the other path."""
+    with (
+        patch("src.utils.storage.BLOB_TRANSFER_MODE", "auto"),
+        patch("src.utils.storage.STORAGE_PROVIDER", "s3"),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _sync_lock():
+    """``sync_to_db`` serializes on a Postgres advisory lock; there is no DB here."""
+
+    @asynccontextmanager
+    async def _lock(_workspace_id):
+        yield None
+
+    with patch.object(backup, "workspace_sync_lock", _lock):
+        yield
+
+
+WS = "ws-packs"
+USER = "user-packs"
+NS = 1_700_000_000_123_456_000
+CLOCK = datetime(2026, 9, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+A, B, BIG = b"aaa", b"bbbbb", b"x" * (PACK_CUTOFF + 1)
+CHUNK = _sha(A + B)
+
+
+def _entry(path, data, mode=0o644, mtime_ns=NS):
+    return ScanEntry(path, "file", len(data), mtime_ns, mode, _sha(data), None, False)
+
+
+def _scan(*entries):
+    return ScanResult(entries=list(entries), oversized=[], errors=[], hashed=len(entries), reused=0)
+
+
+def _sandbox(provider="daytona"):
+    sb = MagicMock()
+    sb.working_dir = "/workspace"
+    sb.config.sandbox.provider = provider
+    sb.adownload_file_bytes = AsyncMock(return_value=A + B)
+    return sb
+
+
+def _chunk(members):
+    """What the pack op reports for one chunk holding ``members`` in path order."""
+    out, offset = [], 0
+    for path, data in sorted(members):
+        out.append({"path": path, "offset": offset, "size": len(data), "sha256": _sha(data)})
+        offset += len(data)
+    data = b"".join(d for _, d in sorted(members))
+    return {"path": f"_internal/packs/chunk-{_sha(data)}", "sha256": _sha(data), "size": len(data), "members": out}
+
+
+def _packed_meta(path, data, chunk=CHUNK, offset=0, mode="0644"):
+    return {
+        "kind": "file", "file_size": len(data), "content_hash": _sha(data), "mtime_ns": NS,
+        "permissions": mode, "pack_sha256": chunk, "pack_offset": offset, "blob_sha256": None, "is_binary": False,
+    }
+
+
+@pytest.fixture
+def db():
+    def _ok(sandbox, items):
+        return {i["sha256"]: {"status": "ok"} for i in items}
+
+    with (
+        patch.object(backup, "manifest_clock", new=AsyncMock(return_value=CLOCK)),
+        patch.object(backup, "get_file_metadata_for_sync", new=AsyncMock(return_value={})) as meta,
+        patch.object(backup, "files_restore_incomplete", new=AsyncMock(return_value=False)),
+        patch.object(backup, "delete_removed_files", new=AsyncMock(return_value=0)),
+        patch.object(backup, "get_workspace_total_size", new=AsyncMock(return_value=0)),
+        patch.object(backup, "bulk_upsert_files", new=AsyncMock(side_effect=lambda ws, rows, conn=None: len(rows))) as upsert,
+        patch.object(backup, "bulk_update_file_stamps", new=AsyncMock()),
+        patch.object(backup, "is_storage_enabled", return_value=True),
+        patch.object(backup, "workspace_owner", new=AsyncMock(return_value=USER)),
+        patch.object(blobs, "registered_blobs", new=AsyncMock(return_value=set())) as registered,
+        patch.object(blobs, "register_blobs", new=AsyncMock()) as register,
+        patch.object(blobs, "get_signed_upload_url", return_value=("https://put", {})),
+        patch.object(blobs, "push_direct", new=AsyncMock(side_effect=_ok)) as push,
+        patch.object(blobs, "pack_direct", new=AsyncMock(return_value={"chunks": [_chunk([("a.txt", A), ("b.txt", B)])], "changed": []})) as pack,
+        patch.object(backup, "scan_workspace", new=AsyncMock(return_value=_scan(_entry("a.txt", A), _entry("b.txt", B), _entry("big.bin", BIG)))) as scan,
+    ):
+        yield {"meta": meta, "upsert": upsert, "registered": registered, "register": register, "push": push, "pack": pack, "scan": scan}
+
+
+def _rows(db):
+    return {r["file_path"]: r for r in db["upsert"].await_args.args[1]}
+
+
+# --- sync ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_files_at_or_below_the_cutoff_pack_and_larger_ones_go_per_object(db):
+    result = await backup.sync_to_db(WS, _sandbox())
+
+    db["pack"].assert_awaited_once()
+    members = db["pack"].await_args.args[1]
+    assert members == [{"path": "a.txt", "sha256": _sha(A), "size": 3}, {"path": "b.txt", "sha256": _sha(B), "size": 5}]
+    pushed = {i["path"]: i for c in db["push"].await_args_list for i in c.args[1]}
+    assert pushed[f"_internal/packs/chunk-{CHUNK}"]["unlink"] is True
+    assert pushed["big.bin"]["unlink"] is False
+    rows = _rows(db)
+    assert rows["a.txt"]["pack_sha256"] == CHUNK and rows["a.txt"]["pack_offset"] == 0
+    assert rows["b.txt"]["pack_sha256"] == CHUNK and rows["b.txt"]["pack_offset"] == 3
+    assert rows["a.txt"]["blob_sha256"] is None and rows["a.txt"]["content_text"] is None
+    assert rows["a.txt"]["content_hash"] == _sha(A) and rows["a.txt"]["file_size"] == 3
+    assert rows["big.bin"]["blob_sha256"] == _sha(BIG) and rows["big.bin"]["pack_sha256"] is None
+    registered = {sha for c in db["register"].await_args_list for sha, _ in c.args[1]}
+    assert registered == {CHUNK, _sha(BIG)}
+    assert result["synced"] == 3 and result["errors"] == 0
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_pack_set_is_a_skip_without_the_pack_op(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A), _entry("b.txt", B))
+    db["meta"].return_value = {"a.txt": _packed_meta("a.txt", A), "b.txt": _packed_meta("b.txt", B, offset=3)}
+    result = await backup.sync_to_db(WS, _sandbox())
+    db["pack"].assert_not_awaited()
+    db["push"].assert_not_awaited()
+    assert result["skipped"] == 2 and result["synced"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_moved_stamp_on_an_unchanged_member_refreshes_the_row_without_bytes(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A, mode=0o600), _entry("b.txt", B))
+    db["meta"].return_value = {"a.txt": _packed_meta("a.txt", A), "b.txt": _packed_meta("b.txt", B, offset=3)}
+    result = await backup.sync_to_db(WS, _sandbox())
+    db["pack"].assert_not_awaited()
+    rows = _rows(db)
+    assert set(rows) == {"a.txt"}
+    assert rows["a.txt"]["permissions"] == "0600" and rows["a.txt"]["pack_sha256"] == CHUNK
+    assert result["skipped"] == 2
+
+
+@pytest.mark.asyncio
+async def test_a_moved_stamp_is_left_unrecorded_while_pruning_is_withheld(db):
+    """A restore that placed the file but failed its chmod leaves a moved
+    stamp; recording it would make the wrong mode the one the retry restores."""
+    backup.files_restore_incomplete.return_value = True
+    db["scan"].return_value = _scan(_entry("a.txt", A, mode=0o600), _entry("b.txt", B))
+    db["meta"].return_value = {"a.txt": _packed_meta("a.txt", A), "b.txt": _packed_meta("b.txt", B, offset=3)}
+    result = await backup.sync_to_db(WS, _sandbox())
+    db["pack"].assert_not_awaited()
+    db["upsert"].assert_not_awaited()
+    assert result["skipped"] == 2
+
+
+@pytest.mark.asyncio
+async def test_one_changed_member_rewrites_the_whole_set(db):
+    a2 = b"AAA"
+    db["scan"].return_value = _scan(_entry("a.txt", a2), _entry("b.txt", B))
+    db["meta"].return_value = {"a.txt": _packed_meta("a.txt", A), "b.txt": _packed_meta("b.txt", B, offset=3)}
+    db["pack"].return_value = {"chunks": [_chunk([("a.txt", a2), ("b.txt", B)])], "changed": []}
+    await backup.sync_to_db(WS, _sandbox())
+    assert [m["path"] for m in db["pack"].await_args.args[1]] == ["a.txt", "b.txt"]
+    rows = _rows(db)
+    assert rows["a.txt"]["pack_sha256"] == rows["b.txt"]["pack_sha256"] == _sha(a2 + B)
+
+
+@pytest.mark.asyncio
+async def test_a_member_that_left_rewrites_the_set(db):
+    """The old chunk stays referenced by nothing, so the set must not keep pointing at it."""
+    db["scan"].return_value = _scan(_entry("a.txt", A))
+    db["meta"].return_value = {"a.txt": _packed_meta("a.txt", A), "b.txt": _packed_meta("b.txt", B, offset=3)}
+    db["pack"].return_value = {"chunks": [_chunk([("a.txt", A)])], "changed": []}
+    await backup.sync_to_db(WS, _sandbox())
+    assert [m["path"] for m in db["pack"].await_args.args[1]] == ["a.txt"]
+    assert _rows(db)["a.txt"]["pack_sha256"] == _sha(A)
+
+
+@pytest.mark.asyncio
+async def test_a_member_absent_while_pruning_is_withheld_does_not_rewrite_the_set(db):
+    """The flag keeps the absent file's row, and the file is expected back on
+    the next restore. Repacking around it would repeat on every sync."""
+    backup.files_restore_incomplete.return_value = True
+    db["scan"].return_value = _scan(_entry("a.txt", A))
+    db["meta"].return_value = {"a.txt": _packed_meta("a.txt", A), "b.txt": _packed_meta("b.txt", B, offset=3)}
+    result = await backup.sync_to_db(WS, _sandbox())
+    db["pack"].assert_not_awaited()
+    db["push"].assert_not_awaited()
+    assert result["skipped"] == 1 and result["synced"] == 0 and result["deleted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_per_object_row_below_the_cutoff_joins_the_pack(db):
+    """Rows stored per object before packs existed migrate on their next pass."""
+    db["scan"].return_value = _scan(_entry("a.txt", A), _entry("b.txt", B))
+    db["meta"].return_value = {
+        "a.txt": {**_packed_meta("a.txt", A), "pack_sha256": None, "pack_offset": None, "blob_sha256": _sha(A)},
+        "b.txt": {**_packed_meta("b.txt", B), "pack_sha256": None, "pack_offset": None, "blob_sha256": _sha(B)},
+    }
+    await backup.sync_to_db(WS, _sandbox())
+    db["pack"].assert_awaited_once()
+    rows = _rows(db)
+    assert rows["a.txt"]["pack_sha256"] == CHUNK and rows["a.txt"]["blob_sha256"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_the_store_rejected_withholds_its_members_rows(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A), _entry("b.txt", B), _entry("big.bin", BIG))
+    db["push"].side_effect = lambda sb, items: {
+        i["sha256"]: {"status": "failed" if i["sha256"] == CHUNK else "ok"} for i in items
+    }
+    result = await backup.sync_to_db(WS, _sandbox())
+    rows = _rows(db)
+    assert set(rows) == {"big.bin"}
+    assert result["errors"] == 2 and result["synced"] == 1
+
+
+@pytest.mark.asyncio
+async def test_members_that_changed_during_packing_count_as_errors(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A), _entry("b.txt", B))
+    db["pack"].return_value = {"chunks": [_chunk([("a.txt", A)])], "changed": ["b.txt"]}
+    result = await backup.sync_to_db(WS, _sandbox())
+    assert set(_rows(db)) == {"a.txt"} and result["errors"] == 1
+
+
+@pytest.mark.asyncio
+async def test_storage_off_never_packs(db):
+    db["scan"].return_value = _scan(_entry("a.txt", A))
+    sb = _sandbox()
+    sb.adownload_file_bytes = AsyncMock(return_value=A)
+    with patch.object(backup, "is_storage_enabled", return_value=False):
+        await backup.sync_to_db(WS, sb)
+    db["pack"].assert_not_awaited()
+    rows = _rows(db)
+    assert rows["a.txt"]["content_text"] == "aaa" and rows["a.txt"]["pack_sha256"] is None
+
+
+# --- restore ------------------------------------------------------------------
+
+
+def _row(path, data, *, pack=None, offset=None, blob=None, perms="0644"):
+    return {
+        "file_path": path, "kind": "file", "blob_sha256": blob, "pack_sha256": pack, "pack_offset": offset,
+        "content_text": None, "content_binary": None, "is_binary": False, "permissions": perms,
+        "symlink_target": None, "file_size": len(data), "content_hash": _sha(data),
+        "sandbox_modified_at": micros_to_datetime(NS // 1000),
+    }
+
+
+@asynccontextmanager
+async def _no_lock(_workspace_id):
+    yield None
+
+
+@pytest.fixture
+def restore_db():
+    with (
+        patch.object(restore, "get_files_for_workspace", new=AsyncMock(return_value=[
+            _row("a.txt", A, pack=CHUNK, offset=0, perms="0600"),
+            _row("b.txt", B, pack=CHUNK, offset=3),
+            _row("big.bin", BIG, blob=_sha(BIG)),
+        ])) as rows,
+        patch.object(restore, "set_files_restore_incomplete", new=AsyncMock()) as flag,
+        patch.object(restore, "workspace_owner", new=AsyncMock(return_value=USER)),
+        patch.object(restore, "get_signed_url", side_effect=lambda key, exp: f"https://get/{key}") as sign,
+        patch.object(restore, "pull_direct", new=AsyncMock(return_value={})) as pull,
+        patch.object(restore, "workspace_sync_lock", _no_lock),
+    ):
+        yield {"rows": rows, "flag": flag, "sign": sign, "pull": pull}
+
+
+def _restore_sandbox(provider="daytona"):
+    sb = _sandbox(provider)
+    sb.acreate_directories = AsyncMock(return_value=True)
+    sb.aupload_file_bytes = AsyncMock(return_value=True)
+    return sb
+
+
+@pytest.mark.asyncio
+async def test_restore_pulls_a_pack_as_one_item_with_its_members(restore_db):
+    restore_db["pull"].return_value = {"a.txt": {"status": "ok"}, "b.txt": {"status": "ok"}, "big.bin": {"status": "ok"}}
+    result = await restore.restore_to_sandbox(WS, _restore_sandbox())
+    items = restore_db["pull"].await_args.args[1]
+    packs = [i for i in items if i.get("kind") == "pack"]
+    assert len(packs) == 1 and len(items) == 2
+    pack = packs[0]
+    assert pack["sha256"] == CHUNK and pack["url"] == f"https://get/blobs/{USER}/{CHUNK}" and pack["size"] == 8
+    by_path = {m["path"]: m for m in pack["members"]}
+    assert by_path["a.txt"] == {"path": "a.txt", "offset": 0, "size": 3, "sha256": _sha(A), "mode": 0o600, "mtime_ns": (NS // 1000) * 1000}
+    assert by_path["b.txt"]["offset"] == 3
+    assert restore_db["sign"].call_count == 2  # one per chunk, one per object
+    assert result == {"restored": 3, "errors": 0}
+    # Raised before the first transfer, cleared only after a clean finish.
+    assert [c.args for c in restore_db["flag"].await_args_list] == [(WS, True), (WS, False)]
+
+
+RELAY_CHUNK = f"/workspace/.wsfiles-relay-{CHUNK}"
+
+
+def _pack_calls(pull):
+    return [c.args[1] for c in pull.await_args_list if any(i.get("file") for i in c.args[1])]
+
+
+@pytest.mark.asyncio
+async def test_restore_relays_an_unreachable_pack_as_one_upload(restore_db):
+    """Direct pull unreachable: the chunk is uploaded whole, the per-object row
+    goes to a staging name, and one placement op slices and moves both."""
+    restore_db["pull"].side_effect = [
+        {"a.txt": {"status": "unreachable"}, "b.txt": {"status": "unreachable"}, "big.bin": {"status": "unreachable"}},
+        {"a.txt": {"status": "ok"}, "b.txt": {"status": "ok"}, "big.bin": {"status": "ok"}},
+    ]
+    sb = _restore_sandbox()
+    fetched = {CHUNK: A + B, _sha(BIG): BIG}
+    fetch = AsyncMock(side_effect=lambda uid, sha: fetched[sha])
+    with (
+        patch.object(restore, "fetch_blob", new=fetch),
+        patch.object(resolve, "fetch_blob", new=fetch),
+    ):
+        result = await restore.restore_to_sandbox(WS, sb)
+    assert sorted(c.args[1] for c in fetch.await_args_list) == sorted([CHUNK, _sha(BIG)])
+    uploads = {c.args[0]: c.args[1] for c in sb.aupload_file_bytes.await_args_list if not c.args[0].endswith(".file_sync_marker")}
+    (staged,) = [p for p in uploads if p != RELAY_CHUNK]
+    assert staged.startswith("/workspace/.wsfiles-relay-") and uploads[staged] == BIG
+    assert uploads[RELAY_CHUNK] == A + B
+    (items,) = _pack_calls(restore_db["pull"])
+    big = restore._pull_item(_row("big.bin", BIG, blob=_sha(BIG)), url=None)
+    big.update({"file": staged.removeprefix("/workspace/"), "sha256": _sha(BIG)})
+    assert items == [big, {
+        "kind": "pack", "file": f".wsfiles-relay-{CHUNK}", "sha256": CHUNK, "size": 8,
+        "members": [
+            {"path": "a.txt", "offset": 0, "size": 3, "sha256": _sha(A), "mode": 0o600, "mtime_ns": (NS // 1000) * 1000},
+            {"path": "b.txt", "offset": 3, "size": 5, "sha256": _sha(B), "mode": 0o644, "mtime_ns": (NS // 1000) * 1000},
+        ],
+    }]
+    assert result == {"restored": 3, "errors": 0}
+
+
+@pytest.mark.asyncio
+async def test_relay_mode_never_uploads_members_one_by_one(restore_db):
+    restore_db["pull"].return_value = {"a.txt": {"status": "ok"}, "b.txt": {"status": "ok"}, "big.bin": {"status": "ok"}}
+    sb = _restore_sandbox("docker")
+    fetched = {CHUNK: A + B, _sha(BIG): BIG}
+    fetch = AsyncMock(side_effect=lambda uid, sha: fetched[sha])
+    with (
+        patch.object(restore, "fetch_blob", new=fetch),
+        patch.object(resolve, "fetch_blob", new=fetch),
+        patch.object(resolve, "fetch_blob_range", new=AsyncMock()) as ranged,
+    ):
+        result = await restore.restore_to_sandbox(WS, sb)
+    restore_db["sign"].assert_not_called()
+    ranged.assert_not_awaited()
+    assert fetch.await_count == 2
+    uploads = {c.args[0] for c in sb.aupload_file_bytes.await_args_list}
+    assert RELAY_CHUNK in uploads and "/workspace/.file_sync_marker" in uploads
+    assert "/workspace/big.bin" not in uploads and len(uploads) == 3
+    assert result == {"restored": 3, "errors": 0}
+
+
+@pytest.mark.asyncio
+async def test_relay_mode_counts_a_member_the_runtime_rejects(restore_db):
+    restore_db["rows"].return_value = [_row("a.txt", A, pack=CHUNK, offset=0), _row("b.txt", B, pack=CHUNK, offset=3)]
+    restore_db["pull"].return_value = {"a.txt": {"status": "mismatch", "error": "got sha256=x"}, "b.txt": {"status": "ok"}}
+    sb = _restore_sandbox("docker")
+    with patch.object(restore, "fetch_blob", new=AsyncMock(return_value=A + B)):
+        result = await restore.restore_to_sandbox(WS, sb)
+    assert result == {"restored": 1, "errors": 1}
+    # Raised up front and never cleared: the sandbox is a partial mirror.
+    assert [c.args for c in restore_db["flag"].await_args_list] == [(WS, True)]
+
+
+@pytest.mark.asyncio
+async def test_relay_mode_fails_every_member_when_the_chunk_upload_fails(restore_db):
+    restore_db["rows"].return_value = [_row("a.txt", A, pack=CHUNK, offset=0), _row("b.txt", B, pack=CHUNK, offset=3)]
+    sb = _restore_sandbox("docker")
+    sb.aupload_file_bytes = AsyncMock(return_value=False)
+    with patch.object(restore, "fetch_blob", new=AsyncMock(return_value=A + B)):
+        result = await restore.restore_to_sandbox(WS, sb)
+    restore_db["pull"].assert_not_awaited()
+    assert result == {"restored": 0, "errors": 2}
+
+
+# --- reads --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_reads_a_packed_row_by_range():
+    with patch.object(resolve, "fetch_blob_range", new=AsyncMock(return_value=B)) as ranged:
+        assert await resolve_file_bytes(_row("b.txt", B, pack=CHUNK, offset=3), user_id=USER) == B
+    ranged.assert_awaited_once_with(USER, CHUNK, 3, 5, expected_sha256=_sha(B))
+
+
+@pytest.mark.asyncio
+async def test_resolver_serves_a_zero_length_member_without_a_request():
+    """An empty range is not a valid HTTP range; the store layer answers it locally."""
+    from src.utils.storage import s3_compatible
+
+    with patch.object(s3_compatible, "_get_range_client", side_effect=AssertionError("no request")):
+        assert s3_compatible.get_bytes_range("blobs/x", 0, 0) == b""
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_the_sandbox_could_not_upload_is_relayed_out_of_the_sandbox(db):
+    """The relay's only source for a chunk's bytes is the sandbox's own copy, so
+    the runtime has to keep a chunk whose push failed. Deleting it on every push
+    left the fallback downloading a file that was no longer there."""
+    db["scan"].return_value = _scan(_entry("a.txt", A), _entry("b.txt", B), _entry("big.bin", BIG))
+    db["push"].side_effect = lambda sb, items: {
+        i["sha256"]: {"status": "unreachable" if i["sha256"] == CHUNK else "ok"} for i in items
+    }
+    sb = _sandbox()
+    with (
+        patch.object(blobs, "store_blob", new=AsyncMock()) as store,
+        patch.object(blobs, "unlink_direct", new=AsyncMock(return_value=1)) as unlink,
+    ):
+        result = await backup.sync_to_db(WS, sb)
+    chunk_path = f"_internal/packs/chunk-{CHUNK}"
+    sb.adownload_file_bytes.assert_awaited_once_with(f"/workspace/{chunk_path}")
+    store.assert_awaited_once_with(USER, CHUNK, A + B)
+    # What the runtime kept, the server removes once it has the bytes.
+    unlink.assert_awaited_once_with(sb, [chunk_path])
+    assert _rows(db)["a.txt"]["pack_sha256"] == CHUNK
+    assert result["errors"] == 0
+
+
+@pytest.mark.asyncio
+async def test_relay_rejects_bytes_whose_length_disagrees_with_the_scan(db):
+    """The scan stats before it hashes, so a file that grew in between carries
+    the new digest with the old length. Relay checks both; a row published with
+    a length its blob does not have would fail every later restore of it."""
+    db["scan"].return_value = _scan(_entry("big.bin", BIG))
+    sb = _sandbox("docker")
+    sb.adownload_file_bytes = AsyncMock(return_value=BIG + b"!")
+    with patch.object(blobs, "store_blob", new=AsyncMock()) as store:
+        result = await backup.sync_to_db(WS, sb)
+    store.assert_not_awaited()
+    db["upsert"].assert_not_awaited()
+    assert result["errors"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_the_registry_already_holds_is_removed_without_a_push(db):
+    """Nothing pushes a dedup hit, so nothing downstream would unlink it."""
+    db["scan"].return_value = _scan(_entry("a.txt", A), _entry("b.txt", B))
+    db["registered"].return_value = {CHUNK}
+    sb = _sandbox()
+    with patch.object(blobs, "unlink_direct", new=AsyncMock(return_value=1)) as unlink:
+        await backup.sync_to_db(WS, sb)
+    db["push"].assert_not_awaited()
+    unlink.assert_awaited_once_with(sb, [f"_internal/packs/chunk-{CHUNK}"])
+    assert _rows(db)["a.txt"]["pack_sha256"] == CHUNK
+
+
+@pytest.mark.asyncio
+async def test_relayed_chunks_are_removed_from_the_sandbox(db):
+    """Only the direct push unlinks in the runtime; a relayed chunk needs an explicit removal."""
+    db["scan"].return_value = _scan(_entry("a.txt", A), _entry("b.txt", B))
+    sb = _sandbox("docker")
+    sb.adownload_file_bytes = AsyncMock(return_value=A + B)
+    with (
+        patch.object(blobs, "store_blob", new=AsyncMock()) as store,
+        patch.object(blobs, "unlink_direct", new=AsyncMock(return_value=1)) as unlink,
+    ):
+        await backup.sync_to_db(WS, sb)
+    db["push"].assert_not_awaited()
+    store.assert_awaited_once_with(USER, CHUNK, A + B)
+    unlink.assert_awaited_once_with(sb, [f"_internal/packs/chunk-{CHUNK}"])
+    assert _rows(db)["a.txt"]["pack_sha256"] == CHUNK

--- a/tests/unit/server/services/test_sync_prune_gate.py
+++ b/tests/unit/server/services/test_sync_prune_gate.py
@@ -1,0 +1,380 @@
+"""Contracts for the restore-completeness flag's control over manifest pruning.
+
+``sync_to_db`` treats "in the manifest but not the sandbox" as a user deletion.
+A restore that failed produces the identical signature, so something has to
+tell the two apart, durably and across processes: the worker that observes the
+failed restore is not the one that runs the next sync.
+
+The flag lives in Postgres rather than in the sandbox's ``.file_sync_marker``
+because it is not a fact about the sandbox: a restore usually fails per file on
+something the sandbox is not party to — a blob object storage would not hand
+back — and that sandbox would happily store a marker claiming otherwise. It
+also has to outlive the sandbox, which the marker by design does not.
+
+Verified live before these were written (partial restore, then sync, then
+repair) against a real sandbox and bucket; these pin the decision table.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.server.services.persistence import backup
+from src.server.services.persistence.transfer import ScanEntry, ScanResult
+
+WS = "ws-prune-gate"
+PATH = "reports/gone.txt"
+MTIME_NS = 1_700_000_000_000_000_000
+
+
+CLOCK = datetime(2026, 9, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _clock():
+    with patch("src.server.services.persistence.backup.manifest_clock", new=AsyncMock(return_value=CLOCK)):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _sync_lock():
+    """``sync_to_db`` serializes on a Postgres advisory lock; there is no DB here."""
+
+    @asynccontextmanager
+    async def _lock(_workspace_id):
+        yield None
+
+    with patch.object(backup, "workspace_sync_lock", _lock):
+        yield
+
+
+def _scan(*entries: ScanEntry, errors=None) -> ScanResult:
+    return ScanResult(entries=list(entries), oversized=[], errors=errors or [], hashed=0, reused=len(entries))
+
+
+def _sandbox() -> MagicMock:
+    sandbox = MagicMock()
+    sandbox.working_dir = "/workspace"
+    sandbox.adownload_file_bytes = AsyncMock(return_value=None)
+    return sandbox
+
+
+# --- the empty-listing branch (highest consequence) ------------------------
+
+
+async def _sync_with_empty_sandbox(incomplete):
+    """``incomplete`` is the flag's value, or an exception to raise reading it."""
+    flag = (
+        AsyncMock(side_effect=incomplete)
+        if isinstance(incomplete, Exception)
+        else AsyncMock(return_value=incomplete)
+    )
+    with (
+        patch(
+            "src.server.services.persistence.backup.scan_workspace",
+            new=AsyncMock(return_value=_scan()),
+        ),
+        patch(
+            "src.server.services.persistence.backup.get_file_metadata_for_sync",
+            new=AsyncMock(return_value={}),
+        ),
+        patch("src.server.services.persistence.backup.files_restore_incomplete", new=flag),
+        patch("src.server.services.persistence.backup.workspace_owner", new=AsyncMock(return_value="user-prune")),
+        patch(
+            "src.server.services.persistence.backup.delete_removed_files",
+            new=AsyncMock(return_value=7),
+        ) as deleter,
+    ):
+        result = await backup.sync_to_db(WS, _sandbox())
+    return result, deleter
+
+
+@pytest.mark.asyncio
+async def test_empty_listing_while_flagged_deletes_nothing():
+    """A restore that failed for every file leaves an empty sandbox. Pruning
+    against it erases the entire manifest — the whole file list, not one row."""
+    result, deleter = await _sync_with_empty_sandbox(True)
+    deleter.assert_not_awaited()
+    assert result["deleted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_listing_when_not_flagged_still_prunes():
+    """A user who really did delete everything must still see it reflected."""
+    result, deleter = await _sync_with_empty_sandbox(False)
+    deleter.assert_awaited_once()
+    assert result["deleted"] == 7
+
+
+@pytest.mark.asyncio
+async def test_unreadable_flag_suppresses_pruning():
+    """The read can fail on its own. A stale row is recoverable; a deleted row
+    whose file only existed in the manifest is not."""
+    _, deleter = await _sync_with_empty_sandbox(RuntimeError("db down"))
+    deleter.assert_not_awaited()
+
+
+# --- the populated branch --------------------------------------------------
+
+
+async def _sync_with_one_unchanged_file(incomplete: bool):
+    """One file present and unchanged, one manifest row whose file is gone."""
+    listing = _scan(
+        ScanEntry("keep.txt", "file", 10, MTIME_NS, 0o644, "x", None, None)
+    )
+    existing = {
+        "keep.txt": {
+            "kind": "file",
+            "file_size": 10,
+            "mtime_ns": MTIME_NS,
+            "content_hash": "x",
+            "permissions": "0644",
+        },
+        PATH: {"kind": "file", "file_size": 5, "mtime_ns": MTIME_NS, "content_hash": "y"},
+    }
+    with (
+        patch("src.server.services.persistence.backup.PACK_CUTOFF", -1),
+        patch(
+            "src.server.services.persistence.backup.scan_workspace",
+            new=AsyncMock(return_value=listing),
+        ),
+        patch(
+            "src.server.services.persistence.backup.files_restore_incomplete",
+            new=AsyncMock(return_value=incomplete),
+        ),
+        patch("src.server.services.persistence.backup.workspace_owner", new=AsyncMock(return_value="user-prune")),
+        patch(
+            "src.server.services.persistence.backup.get_file_metadata_for_sync",
+            new=AsyncMock(return_value=existing),
+        ),
+        patch(
+            "src.server.services.persistence.backup.get_workspace_total_size",
+            new=AsyncMock(return_value=10),
+        ),
+        patch(
+            "src.server.services.persistence.backup.delete_removed_files",
+            new=AsyncMock(return_value=1),
+        ) as deleter,
+    ):
+        result = await backup.sync_to_db(WS, _sandbox())
+    return result, deleter
+
+
+@pytest.mark.asyncio
+async def test_flagged_workspace_keeps_the_row_for_a_missing_file():
+    result, deleter = await _sync_with_one_unchanged_file(True)
+    deleter.assert_not_awaited()
+    assert result["deleted"] == 0
+    assert result["skipped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unflagged_workspace_prunes_the_row_for_a_missing_file():
+    result, deleter = await _sync_with_one_unchanged_file(False)
+    deleter.assert_awaited_once()
+    assert deleter.await_args.args[1] == {"keep.txt"}
+    assert result["deleted"] == 1
+
+
+async def _sync_with_one_restamped_file(incomplete: bool, stamp_failure=None):
+    """One file whose bytes match the manifest and whose mode moved."""
+    listing = _scan(
+        ScanEntry("keep.txt", "file", 10, MTIME_NS, 0o600, "x", None, None)
+    )
+    existing = {
+        "keep.txt": {
+            "kind": "file",
+            "file_size": 10,
+            "mtime_ns": MTIME_NS,
+            "content_hash": "x",
+            "permissions": "0644",
+        },
+    }
+    with (
+        patch("src.server.services.persistence.backup.PACK_CUTOFF", -1),
+        patch("src.server.services.persistence.backup.scan_workspace", new=AsyncMock(return_value=listing)),
+        patch("src.server.services.persistence.backup.files_restore_incomplete", new=AsyncMock(return_value=incomplete)),
+        patch("src.server.services.persistence.backup.workspace_owner", new=AsyncMock(return_value="user-prune")),
+        patch("src.server.services.persistence.backup.get_file_metadata_for_sync", new=AsyncMock(return_value=existing)),
+        patch("src.server.services.persistence.backup.get_workspace_total_size", new=AsyncMock(return_value=10)),
+        patch("src.server.services.persistence.backup.bulk_upsert_files", new=AsyncMock(return_value=0)),
+        patch("src.server.services.persistence.backup.bulk_update_file_stamps", new=AsyncMock(side_effect=stamp_failure)) as stamps,
+        patch("src.server.services.persistence.backup.delete_removed_files", new=AsyncMock(return_value=0)),
+    ):
+        result = await backup.sync_to_db(WS, _sandbox())
+    return result, stamps
+
+
+@pytest.mark.asyncio
+async def test_a_stamp_write_that_fails_is_counted_as_an_error():
+    """The moved mode is persisted only by that write. Uncounted, a strict
+    stop reads the backup as clean and tears the sandbox down with the new
+    mode unrecorded."""
+    result, _ = await _sync_with_one_restamped_file(False, RuntimeError("db away"))
+    assert result["errors"] == 1
+
+
+@pytest.mark.asyncio
+async def test_flagged_workspace_leaves_a_moved_stamp_unrecorded():
+    """A restore that placed the file but failed its chmod leaves a moved
+    stamp. Recording it makes the wrong mode the one the retry restores."""
+    result, stamps = await _sync_with_one_restamped_file(True)
+    stamps.assert_not_awaited()
+    assert result["skipped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unflagged_workspace_records_a_moved_stamp():
+    result, stamps = await _sync_with_one_restamped_file(False)
+    stamps.assert_awaited_once()
+    assert stamps.await_args.args[1][0][0] == "keep.txt"
+
+
+# --- the prune fence and the read-error gate --------------------------------
+
+
+async def _sync(listing: ScanResult, incomplete=False):
+    with (
+        patch("src.server.services.persistence.backup.scan_workspace", new=AsyncMock(return_value=listing)),
+        patch("src.server.services.persistence.backup.get_file_metadata_for_sync", new=AsyncMock(return_value={PATH: {"kind": "file", "content_hash": "x", "file_size": 1, "mtime_ns": MTIME_NS}})),
+        patch("src.server.services.persistence.backup.files_restore_incomplete", new=AsyncMock(return_value=incomplete)),
+        patch("src.server.services.persistence.backup.workspace_owner", new=AsyncMock(return_value="user-prune")),
+        patch("src.server.services.persistence.backup.bulk_upsert_files", new=AsyncMock(return_value=0)),
+        patch("src.server.services.persistence.backup.bulk_update_file_stamps", new=AsyncMock()),
+        patch("src.server.services.persistence.backup.get_workspace_total_size", new=AsyncMock(return_value=0)),
+        patch("src.server.services.persistence.backup.delete_removed_files", new=AsyncMock(return_value=1)) as deleter,
+    ):
+        result = await backup.sync_to_db(WS, _sandbox())
+    return result, deleter
+
+
+@pytest.mark.asyncio
+async def test_prune_is_fenced_to_rows_untouched_since_the_scan_began():
+    """An overlapping sync that upserted a row after this scan started must
+    not have that row pruned by this pass, which never saw the file."""
+    result, deleter = await _sync(_scan())
+    deleter.assert_awaited_once()
+    assert deleter.await_args.kwargs["untouched_since"] == CLOCK
+    assert result["deleted"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unreadable_root_does_not_wipe_the_manifest():
+    """A root the scan could not read yields an empty listing, which is the
+    same signature as an emptied workspace. It must keep every row."""
+    result, deleter = await _sync(_scan(errors=[{"path": ".", "error": "EIO"}]))
+    deleter.assert_not_awaited()
+    assert result["deleted"] == 0 and result["errors"] == 1
+
+
+@pytest.mark.asyncio
+async def test_any_scan_read_error_withholds_pruning():
+    entry = ScanEntry(path="reports", kind="dir", size=0, mtime_ns=MTIME_NS, mode=0o755, sha256=None, symlink_target=None, is_binary=None)
+    result, deleter = await _sync(_scan(entry, errors=[{"path": "reports/q3", "error": "EACCES"}]))
+    deleter.assert_not_awaited()
+    assert result["errors"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_file_that_vanished_mid_scan_does_not_withhold_pruning():
+    """ENOENT below the root is a file removed between the listing and the
+    read: absent for the right reason. It is not data at risk either."""
+    result, deleter = await _sync(_scan(errors=[{"path": "reports/q3", "error": "ENOENT", "errno": 2}]))
+    deleter.assert_awaited_once()
+    assert result["errors"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_missing_root_still_withholds_pruning():
+    """ENOENT on the root is not a vanished file; it is the whole workspace
+    unreadable, and the empty listing it yields must not prune anything."""
+    result, deleter = await _sync(_scan(errors=[{"path": ".", "error": "ENOENT", "errno": 2}]))
+    deleter.assert_not_awaited()
+    assert result["deleted"] == 0 and result["errors"] == 1
+
+
+# --- a directory that stopped being one -------------------------------------
+
+
+async def _sync_dir_turned_symlink(incomplete: bool):
+    """``a/`` with a child in the manifest; the sandbox now has symlink ``a``."""
+    listing = _scan(
+        ScanEntry("a", "symlink", 0, MTIME_NS, 0o777, None, "elsewhere", None)
+    )
+    existing = {
+        "a": {"kind": "dir", "file_size": 0, "mtime_ns": MTIME_NS, "permissions": "0755"},
+        "a/child": {"kind": "file", "content_hash": "x", "file_size": 1, "mtime_ns": MTIME_NS},
+        "ab": {"kind": "file", "content_hash": "y", "file_size": 1, "mtime_ns": MTIME_NS},
+    }
+    with (
+        patch("src.server.services.persistence.backup.scan_workspace", new=AsyncMock(return_value=listing)),
+        patch("src.server.services.persistence.backup.get_file_metadata_for_sync", new=AsyncMock(return_value=existing)),
+        patch("src.server.services.persistence.backup.files_restore_incomplete", new=AsyncMock(return_value=incomplete)),
+        patch("src.server.services.persistence.backup.workspace_owner", new=AsyncMock(return_value="user-prune")),
+        patch("src.server.services.persistence.backup.bulk_upsert_files", new=AsyncMock(return_value=1)),
+        patch("src.server.services.persistence.backup.bulk_update_file_stamps", new=AsyncMock()),
+        patch("src.server.services.persistence.backup.get_workspace_total_size", new=AsyncMock(return_value=0)),
+        patch("src.server.services.persistence.backup.delete_file_rows", new=AsyncMock(return_value=1)) as rows_deleter,
+        patch("src.server.services.persistence.backup.delete_removed_files", new=AsyncMock(return_value=1)) as deleter,
+    ):
+        result = await backup.sync_to_db(WS, _sandbox())
+    return result, rows_deleter, deleter
+
+
+@pytest.mark.asyncio
+async def test_a_flagged_workspace_still_drops_children_of_a_decayed_directory():
+    """The withheld prune keeps ``ab`` (absent for an unknown reason) but
+    ``a/child`` cannot exist under a symlink, and a restore that kept it
+    would create a directory where the symlink has to land."""
+    result, rows_deleter, deleter = await _sync_dir_turned_symlink(True)
+    deleter.assert_not_awaited()
+    rows_deleter.assert_awaited_once()
+    assert rows_deleter.await_args.args[1] == ["a/child"]
+    assert result["deleted"] == 1
+
+
+@pytest.mark.asyncio
+async def test_an_unflagged_workspace_counts_both_prunes():
+    result, rows_deleter, deleter = await _sync_dir_turned_symlink(False)
+    rows_deleter.assert_awaited_once()
+    deleter.assert_awaited_once()
+    assert result["deleted"] == 2
+
+
+async def _sync_legacy_child_under_new_symlink():
+    """A manifest written before directories had rows: ``a/child`` exists,
+    ``a`` has no row, and the sandbox now has symlink ``a``."""
+    listing = _scan(
+        ScanEntry("a", "symlink", 0, MTIME_NS, 0o777, None, "elsewhere", None)
+    )
+    existing = {
+        "a/child": {"kind": "file", "content_hash": "x", "file_size": 1, "mtime_ns": MTIME_NS},
+        "a/sub/deep": {"kind": "file", "content_hash": "y", "file_size": 1, "mtime_ns": MTIME_NS},
+        "ab/child": {"kind": "file", "content_hash": "z", "file_size": 1, "mtime_ns": MTIME_NS},
+    }
+    with (
+        patch("src.server.services.persistence.backup.scan_workspace", new=AsyncMock(return_value=listing)),
+        patch("src.server.services.persistence.backup.get_file_metadata_for_sync", new=AsyncMock(return_value=existing)),
+        patch("src.server.services.persistence.backup.files_restore_incomplete", new=AsyncMock(return_value=True)),
+        patch("src.server.services.persistence.backup.workspace_owner", new=AsyncMock(return_value="user-prune")),
+        patch("src.server.services.persistence.backup.bulk_upsert_files", new=AsyncMock(return_value=1)),
+        patch("src.server.services.persistence.backup.bulk_update_file_stamps", new=AsyncMock()),
+        patch("src.server.services.persistence.backup.get_workspace_total_size", new=AsyncMock(return_value=0)),
+        patch("src.server.services.persistence.backup.delete_file_rows", new=AsyncMock(return_value=2)) as rows_deleter,
+        patch("src.server.services.persistence.backup.delete_removed_files", new=AsyncMock(return_value=1)) as deleter,
+    ):
+        result = await backup.sync_to_db(WS, _sandbox())
+    return result, rows_deleter, deleter
+
+
+@pytest.mark.asyncio
+async def test_children_with_no_parent_row_are_still_dropped_under_a_new_symlink():
+    result, rows_deleter, deleter = await _sync_legacy_child_under_new_symlink()
+    deleter.assert_not_awaited()
+    assert sorted(rows_deleter.await_args.args[1]) == ["a/child", "a/sub/deep"]
+    assert result["deleted"] == 2

--- a/tests/unit/server/services/test_sync_serialization.py
+++ b/tests/unit/server/services/test_sync_serialization.py
@@ -1,0 +1,275 @@
+"""Contracts for the per-workspace fence around ``sync_to_db``.
+
+A sync decides what to write from a manifest read taken before the sandbox
+scan, then writes unconditionally minutes later. With ``--workers N`` two syncs
+of one workspace can be in flight on different processes, and without a fence
+the older pass's upsert lands last and reinstates rows the newer pass had
+already superseded. Postgres holds the fence because it is the only thing all
+the workers share.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from psycopg.errors import LockNotAvailable
+
+from src.server.database import workspace_file as wf
+from src.server.services.persistence import backup, restore
+from src.server.services.persistence.transfer import ScanResult
+
+
+class _Cursor:
+    def __init__(self, executed: list, fail_on: str | None, unlock_delay: int = 0) -> None:
+        self._executed = executed
+        self._fail_on = fail_on
+        self._unlock_delay = unlock_delay
+
+    async def execute(self, sql: str, params=None) -> None:
+        flat = " ".join(sql.split())
+        self._executed.append((flat, params))
+        if "pg_advisory_unlock" in flat:
+            for _ in range(self._unlock_delay):
+                await asyncio.sleep(0)
+        if self._fail_on and self._fail_on in flat:
+            if self._fail_on == "pg_advisory_lock":
+                raise LockNotAvailable("canceling statement due to lock timeout")
+            raise RuntimeError(f"statement refused: {self._fail_on}")
+
+    async def fetchone(self):
+        return (True,)
+
+
+class _Conn:
+    """Just enough of a psycopg connection for the lock's two statements."""
+
+    def __init__(self) -> None:
+        self.executed: list = []
+        self.fail_on: str | None = None
+        self.unlock_delay = 0
+        self.closed = False
+
+    @asynccontextmanager
+    async def cursor(self, **_kw):
+        yield _Cursor(self.executed, self.fail_on, self.unlock_delay)
+
+    @asynccontextmanager
+    async def transaction(self):
+        self.executed.append(("BEGIN", None))
+        try:
+            yield
+        except BaseException:
+            self.executed.append(("ROLLBACK", None))
+            raise
+        self.executed.append(("COMMIT", None))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def conn():
+    c = _Conn()
+
+    @asynccontextmanager
+    async def _acquire(existing=None):
+        yield c
+
+    with patch.object(wf, "get_db_connection", _acquire):
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_the_lock_is_taken_and_released_on_one_session(conn):
+    acquire = [
+        "BEGIN",
+        "SET LOCAL lock_timeout = '120s'",
+        "SELECT pg_advisory_lock(hashtextextended(%s, 0))",
+        "COMMIT",
+    ]
+    async with wf.workspace_sync_lock("ws-1") as held:
+        assert held is conn
+        assert [sql for sql, _ in conn.executed] == acquire
+
+    assert [sql for sql, _ in conn.executed] == acquire + [
+        "SELECT pg_advisory_unlock(hashtextextended(%s, 0))",
+    ]
+    # Namespaced and keyed on the workspace, so two workspaces never contend.
+    assert {params for _, params in conn.executed if params} == {
+        ("WSFILES_SYNC:ws-1",)
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_wait_past_the_bound_raises_busy_without_touching_the_lock(conn):
+    """A holder wedged on a dead sandbox would otherwise queue every later
+    sync of the workspace behind it, each one pinning a pool slot forever."""
+    conn.fail_on = "pg_advisory_lock"
+
+    with pytest.raises(wf.WorkspaceSyncBusy, match="120s"):
+        async with wf.workspace_sync_lock("ws-1"):
+            raise AssertionError("body must not run")
+
+    statements = [sql for sql, _ in conn.executed]
+    assert statements[-1] == "ROLLBACK"
+    assert not any("pg_advisory_unlock" in sql for sql in statements)
+    assert conn.closed is False
+
+
+@pytest.mark.asyncio
+async def test_a_failed_sync_still_releases_the_lock(conn):
+    """A session-level lock outlives its transaction, so nothing but the unlock
+    frees it while the connection is alive and back in the pool."""
+    with pytest.raises(RuntimeError):
+        async with wf.workspace_sync_lock("ws-1"):
+            raise RuntimeError("scan blew up")
+
+    assert conn.executed[-1][0] == "SELECT pg_advisory_unlock(hashtextextended(%s, 0))"
+
+
+@pytest.mark.asyncio
+async def test_a_release_survives_cancellation_delivered_at_every_await(conn):
+    """An AnyIO scope re-delivers the cancellation at each await, so a
+    release that waits on the unlock once and then closes would lose the
+    close to the second delivery and pool a session that still holds the
+    lock."""
+    conn.fail_on = "pg_advisory_unlock"
+    conn.unlock_delay = 3
+    started = asyncio.Event()
+
+    async def sync():
+        async with wf.workspace_sync_lock("ws-1"):
+            started.set()
+            await asyncio.sleep(60)
+
+    task = asyncio.create_task(sync())
+    await started.wait()
+    for _ in range(6):
+        task.cancel()
+        await asyncio.sleep(0)
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert conn.executed[-1][0] == "SELECT pg_advisory_unlock(hashtextextended(%s, 0))"
+    assert conn.closed is True
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_sync_still_releases_the_lock_on_the_live_session(conn):
+    """A cancellation delivered at the unlock's own await would otherwise hand
+    the pool a session that still holds the lock, and every later sync of the
+    workspace on any worker would block on it forever."""
+    with pytest.raises(asyncio.CancelledError):
+        async with wf.workspace_sync_lock("ws-1"):
+            raise asyncio.CancelledError()
+
+    assert conn.executed[-1][0] == "SELECT pg_advisory_unlock(hashtextextended(%s, 0))"
+    assert conn.closed is False
+
+
+@pytest.mark.asyncio
+async def test_an_unconfirmed_release_closes_the_session_so_the_lock_dies_with_it(conn):
+    conn.fail_on = "pg_advisory_unlock"
+
+    with pytest.raises(RuntimeError, match="statement refused"):
+        async with wf.workspace_sync_lock("ws-1"):
+            pass
+
+    assert conn.closed is True
+
+
+@pytest.mark.asyncio
+async def test_sync_holds_the_lock_across_the_scan_and_the_writes():
+    """The fence has to span the read, the scan and the write: serializing only
+    the writes still lets the older pass's rows land last."""
+    order: list[str] = []
+
+    @asynccontextmanager
+    async def _lock(workspace_id: str):
+        order.append("lock")
+        try:
+            yield None
+        finally:
+            order.append("unlock")
+
+    async def _scan(*_a, **_kw):
+        order.append("scan")
+        return ScanResult(entries=[], oversized=[], errors=[], hashed=0, reused=0)
+
+    async def _delete(*_a, **_kw):
+        order.append("delete")
+        return 0
+
+    sandbox = MagicMock()
+    sandbox.working_dir = "/workspace"
+
+    with (
+        patch.object(backup, "workspace_sync_lock", _lock),
+        patch.object(backup, "manifest_clock", new=AsyncMock(return_value=None)),
+        patch.object(backup, "get_file_metadata_for_sync", new=AsyncMock(return_value={})),
+        patch.object(backup, "files_restore_incomplete", new=AsyncMock(return_value=False)),
+        patch.object(backup, "scan_workspace", new=_scan),
+        patch.object(backup, "delete_removed_files", new=_delete),
+    ):
+        await backup.sync_to_db("ws-1", sandbox)
+
+    assert order == ["lock", "scan", "delete", "unlock"]
+
+
+@pytest.mark.asyncio
+async def test_restore_holds_the_same_lock_across_the_flag_and_the_transfer():
+    """A sync that scans while a restore is still filling the sandbox, then
+    reads the completeness flag after the restore clears it, prunes every row
+    its stale scan never saw arrive. Restore therefore takes the sync lock for
+    its whole run, and its manifest read and the clearing of the flag ride
+    that session; the flag is raised before the lock is requested, so a wait
+    that times out has already recorded the sandbox as unfilled."""
+    order: list[str] = []
+    seen_conns: list = []
+
+    @asynccontextmanager
+    async def _lock(workspace_id: str):
+        order.append("lock")
+        try:
+            yield "held-conn"
+        finally:
+            order.append("unlock")
+
+    async def _flag(workspace_id, incomplete, *, conn=None, sandbox_id=None):
+        order.append(f"flag={incomplete}")
+        seen_conns.append(conn)
+        return True
+
+    async def _rows(workspace_id, *, include_content=False, all_kinds=False, conn=None):
+        order.append("read")
+        seen_conns.append(conn)
+        return [{"file_path": "d", "kind": "dir", "permissions": "0755"}]
+
+    async def _owner(workspace_id, conn=None):
+        order.append("owner")
+        seen_conns.append(conn)
+        return "user-1"
+
+    async def _pull(sandbox, items, **kw):
+        order.append("pull")
+        return {"d": {"status": "ok"}}
+
+    sandbox = MagicMock()
+    sandbox.working_dir = "/workspace"
+    sandbox.aupload_file_bytes = AsyncMock(return_value=True)
+
+    with (
+        patch.object(restore, "workspace_sync_lock", _lock),
+        patch.object(restore, "set_files_restore_incomplete", _flag),
+        patch.object(restore, "get_files_for_workspace", _rows),
+        patch.object(restore, "workspace_owner", _owner),
+        patch.object(restore, "pull_direct", _pull),
+    ):
+        result = await restore.restore_to_sandbox("ws-1", sandbox)
+
+    assert result == {"restored": 1, "errors": 0}
+    assert order == ["flag=True", "lock", "read", "owner", "pull", "flag=False", "unlock"]
+    assert seen_conns == [None] + ["held-conn"] * 3

--- a/tests/unit/server/services/test_transfer_exclusion_spec.py
+++ b/tests/unit/server/services/test_transfer_exclusion_spec.py
@@ -1,0 +1,33 @@
+"""The scan spec the server hands the runtime: what is reserved, and where."""
+
+from __future__ import annotations
+
+from src.server.services.persistence.transfer import SYNC_MARKER_NAME, exclusion_spec
+
+
+def test_the_sync_marker_is_reserved_at_the_root_only_and_by_exact_name():
+    """A basename exclusion would drop a user's ``results/.file_sync_marker``
+    from every scan, and a prefix would drop a root ``.file_sync_marker.bak``;
+    either way the next sync prunes the row."""
+    spec = exclusion_spec(1)
+    assert spec["exclude_root_basenames"] == [SYNC_MARKER_NAME]
+    assert SYNC_MARKER_NAME not in spec["exclude_basenames"]
+    assert all(not SYNC_MARKER_NAME.startswith(p) for p in spec["exclude_root_basename_prefixes"])
+
+
+def test_the_skill_reconciler_scratch_is_reserved_under_its_own_directory_only():
+    """A global ``.staging`` name would drop ``work/model/.staging`` from
+    every scan and prune its rows."""
+    spec = exclusion_spec(1)
+    assert ".agents/skills/.staging" in spec["exclude_rel_dirs"]
+    assert spec["exclude_rel_dir_prefixes"] == [".agents/skills/.trash-"]
+    assert ".staging" not in spec["exclude_dir_names"]
+    assert "exclude_dir_name_prefixes" not in spec
+
+
+def test_the_reconciler_lock_is_reserved_at_its_own_path_only():
+    """A basename exclusion would drop a user's ``results/.skills-sync.flock``
+    from every scan and prune its row on the next sync."""
+    spec = exclusion_spec(1)
+    assert spec["exclude_rel_files"] == [".agents/skills/.skills-sync.flock"]
+    assert ".skills-sync.flock" not in spec["exclude_basenames"]

--- a/tests/unit/server/services/test_workspace_manager.py
+++ b/tests/unit/server/services/test_workspace_manager.py
@@ -1150,7 +1150,13 @@ class TestSandboxRecovery:
 
     def _make_manager(self):
         config = _make_config()
-        return WorkspaceManager.get_instance(config=config)
+        manager = WorkspaceManager.get_instance(config=config)
+        # Recovery re-provisions through the real restore path; with no DB pool
+        # the completeness guard cannot be raised and provisioning aborts on
+        # purpose. These tests are about the recovery spine, not the restore.
+        manager._restore_files = AsyncMock()
+        manager._maybe_restore_files = AsyncMock()
+        return manager
 
     def _make_failed_session(self, error=None):
         """Create a session whose sandbox has a failed lazy init."""
@@ -3666,3 +3672,114 @@ class TestPlatformSecretWiring:
                 )
 
         assert workspace_id not in manager._sessions
+
+
+class TestRestoreGuard:
+    """A restore that could not raise the completeness flag aborts provisioning.
+
+    Every other restore failure is a warning: the flag it raised first keeps the
+    next backup from pruning. With no flag there is nothing keeping it, so the
+    sandbox must not be bound.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_missing_guard_propagates_out_of_the_restore_wrapper(self):
+        from src.server.services.persistence.file import RestoreGuardUnavailable
+
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        with patch(
+            "src.server.services.workspace_manager.FilePersistenceService.restore_to_sandbox",
+            AsyncMock(side_effect=RestoreGuardUnavailable("ws-1")),
+        ):
+            with pytest.raises(RestoreGuardUnavailable):
+                await manager._restore_files(
+                    "ws-1", MagicMock(), expected_sandbox_id="sb-old"
+                )
+
+    @pytest.mark.asyncio
+    async def test_any_other_restore_failure_is_still_a_warning(self):
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        with patch(
+            "src.server.services.workspace_manager.FilePersistenceService.restore_to_sandbox",
+            AsyncMock(side_effect=RuntimeError("transfer boom")),
+        ):
+            await manager._restore_files(
+                "ws-1", MagicMock(), expected_sandbox_id="sb-old"
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_lost_identity_propagates_too(self):
+        from src.server.services.persistence.file import RestoreIdentityLost
+
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        with patch(
+            "src.server.services.workspace_manager.FilePersistenceService.restore_to_sandbox",
+            AsyncMock(side_effect=RestoreIdentityLost("ws-1")),
+        ) as restore_call:
+            with pytest.raises(RestoreIdentityLost):
+                await manager._restore_files(
+                    "ws-1", MagicMock(), expected_sandbox_id="sb-old"
+                )
+        assert restore_call.await_args.kwargs["expected_sandbox_id"] == "sb-old"
+
+    @pytest.mark.asyncio
+    @patch("src.server.services.workspace_manager.update_workspace_status")
+    @patch("src.server.services.workspace_manager.SessionManager")
+    @patch("src.server.services.workspace_manager.db_get_workspace")
+    async def test_recovery_restores_against_the_sandbox_the_row_still_names(
+        self, mock_get_ws, mock_session_mgr, mock_status
+    ):
+        """The restore's flag and the bind's CAS must expect the same previous
+        sandbox, or a late provisioner could flag a row another has bound."""
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        ws_id = str(uuid.uuid4())
+        workspace = _make_workspace(workspace_id=ws_id, status="running")
+        workspace["sandbox_id"] = "sb-previous"
+        mock_get_ws.return_value = workspace
+        session = _make_mock_session()
+        mock_session_mgr.get_session.return_value = session
+        mock_session_mgr.cleanup_session = AsyncMock()
+        manager._mint_sandbox_tokens = AsyncMock(return_value={})
+        manager._apply_session_mcp = AsyncMock(return_value=None)
+        manager._sync_sandbox_assets = AsyncMock()
+        # Stop at the restore: the rest of the spine needs a live pool.
+        manager._restore_files = AsyncMock(side_effect=RuntimeError("stop here"))
+
+        with pytest.raises(RuntimeError, match="stop here"):
+            await manager._recover_sandbox(ws_id, "user-1", MagicMock())
+
+        assert manager._restore_files.await_args.kwargs["expected_sandbox_id"] == "sb-previous"
+
+    @pytest.mark.asyncio
+    async def test_provision_reconciles_the_flag_after_winning_the_bind(self):
+        """post_init restores into a sandbox the row does not yet name, so its
+        clear cannot land. The reconcile runs once the row names this sandbox,
+        and after the session is published."""
+        manager = WorkspaceManager.get_instance(config=_make_config())
+        session = _make_mock_session()
+        session.sandbox.runtime = MagicMock()
+        workspace = _make_workspace()
+        workspace_id = workspace["workspace_id"]
+        order: list[str] = []
+
+        async def _bind(*_a, **_k):
+            order.append("bind")
+            return workspace
+
+        async def _reconcile(*_a, **_k):
+            order.append("reconcile")
+
+        with (
+            patch.object(manager, "_mint_sandbox_tokens", AsyncMock(return_value={})),
+            patch("src.server.services.workspace_manager.SessionManager") as session_mgr,
+            patch.object(manager, "_apply_session_mcp", AsyncMock(return_value=None)),
+            patch.object(manager, "_sync_sandbox_assets", AsyncMock()),
+            patch("src.server.services.workspace_manager.try_bind_workspace_sandbox", _bind),
+            patch.object(manager, "_maybe_restore_files", _reconcile),
+        ):
+            session_mgr.get_session.return_value = session
+            await manager._provision_sandbox_session(
+                workspace_id, "user-1", ws_version=None, kick_discovery=False, post_init=AsyncMock()
+            )
+
+        assert order == ["bind", "reconcile"]

--- a/tests/unit/utils/storage/test_provider_requires_bucket.py
+++ b/tests/unit/utils/storage/test_provider_requires_bucket.py
@@ -1,0 +1,44 @@
+"""A provider name without a bucket is not a store.
+
+The checked-in config selects "s3" while the bucket lives in .env, so a
+deployment that never filled it in must read as disabled rather than route
+every upload, workspace file backups included, into a store that fails.
+The facade decides at import, so each case loads it in a fresh interpreter.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+# The facade reads agent_config.yaml first, so the checked-in "s3" (or a
+# local edit to "none") would decide these cases instead of the env. The
+# child sees an empty config so the env var under test is what answers.
+_PROBE = (
+    "import yaml; yaml.safe_load = lambda *a, **k: {}; "
+    "from src.utils import storage; "
+    "print(storage.get_provider_id(), storage.is_storage_enabled())"
+)
+_BUCKET_VARS = ("STORAGE_BUCKET_NAME", "S3_BUCKET_NAME", "OSS_BUCKET_NAME")
+
+
+def _probe(**env: str) -> str:
+    clean = {k: v for k, v in os.environ.items() if k not in _BUCKET_VARS}
+    clean.update(env)
+    out = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        env=clean,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+def test_a_provider_without_a_bucket_reads_as_disabled():
+    assert _probe(STORAGE_PROVIDER="s3") == "none False"
+
+
+def test_a_provider_with_a_bucket_stays_enabled():
+    assert _probe(STORAGE_PROVIDER="s3", STORAGE_BUCKET_NAME="b") == "s3 True"

--- a/tests/unit/utils/storage/test_signed_upload.py
+++ b/tests/unit/utils/storage/test_signed_upload.py
@@ -1,0 +1,70 @@
+"""Contracts for the content-bound presigned PUT and the transfer-mode switch.
+
+The presign binds digest, length and type into the signature; that binding is
+what makes a sandbox-held URL safe to use against a shared content-addressed
+prefix. Verified live against an S3-compatible store (a mismatched body is
+rejected with BadDigest) before these were written; they pin the parameters.
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import src.utils.storage as storage
+from src.utils.storage import s3_compatible
+
+SHA = "a" * 64
+
+
+def test_presign_binds_digest_length_and_type():
+    client = MagicMock()
+    client.generate_presigned_url.return_value = "https://store/blobs/x?sig"
+    with patch.object(s3_compatible, "_get_client", return_value=client):
+        out = s3_compatible.get_signed_upload_url(
+            f"blobs/{SHA}", sha256_hex=SHA, content_length=12, content_type="application/octet-stream", expires_in=600
+        )
+    assert out is not None
+    url, headers = out
+    assert url == "https://store/blobs/x?sig"
+    kwargs = client.generate_presigned_url.call_args.kwargs
+    assert client.generate_presigned_url.call_args.args == ("put_object",)
+    params = kwargs["Params"]
+    expected_b64 = base64.b64encode(bytes.fromhex(SHA)).decode()
+    assert params["Key"] == f"blobs/{SHA}"
+    assert params["ContentLength"] == 12
+    assert params["ContentType"] == "application/octet-stream"
+    assert params["ChecksumSHA256"] == expected_b64
+    assert kwargs["ExpiresIn"] == 600
+    # The uploader must send exactly what was signed.
+    assert headers == {"Content-Type": "application/octet-stream", "x-amz-checksum-sha256": expected_b64}
+
+
+def test_presign_failure_returns_none_not_raise():
+    with patch.object(s3_compatible, "_get_client", side_effect=RuntimeError("no creds")):
+        assert s3_compatible.get_signed_upload_url("k", sha256_hex=SHA, content_length=1, content_type="x") is None
+
+
+def test_transfer_mode_auto_is_direct_only_for_daytona_on_s3(monkeypatch):
+    monkeypatch.setattr(storage, "BLOB_TRANSFER_MODE", "auto")
+    monkeypatch.setattr(storage, "STORAGE_PROVIDER", "s3")
+    assert storage.get_blob_transfer_mode("daytona") == "direct"
+    assert storage.get_blob_transfer_mode("docker") == "relay"
+    assert storage.get_blob_transfer_mode(None) == "relay"
+
+
+def test_transfer_mode_relay_for_stores_that_cannot_bind_content(monkeypatch):
+    monkeypatch.setattr(storage, "BLOB_TRANSFER_MODE", "auto")
+    for provider in ("oss", "none"):
+        monkeypatch.setattr(storage, "STORAGE_PROVIDER", provider)
+        assert storage.get_blob_transfer_mode("daytona") == "relay"
+
+
+def test_transfer_mode_explicit_overrides_auto(monkeypatch):
+    monkeypatch.setattr(storage, "STORAGE_PROVIDER", "s3")
+    monkeypatch.setattr(storage, "BLOB_TRANSFER_MODE", "relay")
+    assert storage.get_blob_transfer_mode("daytona") == "relay"
+    monkeypatch.setattr(storage, "BLOB_TRANSFER_MODE", "direct")
+    assert storage.get_blob_transfer_mode("docker") == "direct"
+    monkeypatch.setattr(storage, "BLOB_TRANSFER_MODE", "bogus")
+    assert storage.get_blob_transfer_mode("daytona") == "direct"

--- a/uv.lock
+++ b/uv.lock
@@ -824,7 +824,7 @@ wheels = [
 
 [[package]]
 name = "daytona"
-version = "0.200.1"
+version = "0.210.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -852,14 +852,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "wsproto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/eb/2d2db2068f23697964b2aab383bb8391b618462df1ae6dca1df464f27259/daytona-0.200.1.tar.gz", hash = "sha256:02fc040cdbb54417ba7c1dc6bc1aa7489543bd15fc3fe9aea6968b0516f7ea4b", size = 177604, upload_time = "2026-07-22T12:23:22.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/dd/9ce4820cb05cc2b7f38f9fd076bc575b1190a3236d69a40a0f5a09ebd14c/daytona-0.210.0.tar.gz", hash = "sha256:313fcec07ec4d04a6ccaa91618ce956612ef9ba78484691aeccdaa36d017d6b4", size = 188817, upload_time = "2026-09-03T21:11:01.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/32/87982084d380e6a34aff1b2fac8eb6f8649f831c4f8f39c8d0eb90a0749f/daytona-0.200.1-py3-none-any.whl", hash = "sha256:68029ff267499a8dcc9d946fc71e79b9ea456170c77fb836bf4b0cd3c1e59959", size = 213381, upload_time = "2026-07-22T12:23:23.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/2d/f4c1dec9dc0da86aa79b64a83e6f3c94ff9a25ed78a1bc59c5c2fa3c51db/daytona-0.210.0-py3-none-any.whl", hash = "sha256:0df723203e20a894fd07808e62f13f419e41f6d035016ecdc8f873c50cb32634", size = 226269, upload_time = "2026-09-03T21:11:02.374Z" },
 ]
 
 [[package]]
 name = "daytona-analytics-api-client"
-version = "0.200.1"
+version = "0.210.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -867,14 +867,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/de/9e95c70c792f20ef0c43e157a5a8f56d71d57b716335da2dc7d29ddb082a/daytona_analytics_api_client-0.200.1.tar.gz", hash = "sha256:1624d437cbc50c91f921c4b46567f55f8ddf89894fa80840acf01788daf85a4b", size = 30058, upload_time = "2026-07-22T12:22:47.817Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/2d/76721bf383de06bb16ce6dec473d0f18f2b6853602d7410ce0116e1981f9/daytona_analytics_api_client-0.210.0.tar.gz", hash = "sha256:b4230a0a6afe65e2a1c7b0e9bb49bf905a795b1610256afaad956a3475b8569d", size = 30088, upload_time = "2026-09-03T21:10:27.752Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/34/e17297664a6e8a0a921ad971683e220bce69e57a3c97f37c2815a3f70991/daytona_analytics_api_client-0.200.1-py3-none-any.whl", hash = "sha256:9f8ad5648f0da73b34ce9b13ce3c60173562d48404ddc7f6331eeec4beb2c772", size = 45010, upload_time = "2026-07-22T12:22:48.643Z" },
+    { url = "https://files.pythonhosted.org/packages/45/31/b6ed690257cfb34b37088919b36ee9f87a8d76aaf08ef110b093580de8ac/daytona_analytics_api_client-0.210.0-py3-none-any.whl", hash = "sha256:2e70b15e8c14bb4e88a12bb3644b6e4f4a296305298f111efac4409f3e92ae37", size = 45013, upload_time = "2026-09-03T21:10:30.978Z" },
 ]
 
 [[package]]
 name = "daytona-analytics-api-client-async"
-version = "0.200.1"
+version = "0.210.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -883,14 +883,14 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/ec/e9bd405a74382f97b1a16376686bf90ed9c3b183718897d519eb8ced73d9/daytona_analytics_api_client_async-0.200.1.tar.gz", hash = "sha256:f5edc0b1a6590ae802490d97789f21f94d3bf73c53a4d984c980d89cc0eca132", size = 30071, upload_time = "2026-07-22T12:22:39.053Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/72/a0d2ced3b786624b95d3059d0fe7641736064e6470018ff023e46ba3c4f4/daytona_analytics_api_client_async-0.210.0.tar.gz", hash = "sha256:762f19d4e8d9eb74b3d5e3cdeec0ebeddae623d7b6a764e6c97a7f5cafa8f8c9", size = 30130, upload_time = "2026-09-03T21:10:35.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/c5/2979f438def31f26dc98b3e23a9e8787570d2bb95019f85596fa7eafb8a6/daytona_analytics_api_client_async-0.200.1-py3-none-any.whl", hash = "sha256:637106455f9498d6785efb51be9d589a2ecd3f257e2a3d9f1c7b6bd8c461721a", size = 45283, upload_time = "2026-07-22T12:22:39.882Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a7/8ee5f1fa221c30914aa6f0a9a5a66c7d176d109c3feae3bf61a7b571ac5c/daytona_analytics_api_client_async-0.210.0-py3-none-any.whl", hash = "sha256:258af338e3a95c4a02b3e5c84c8283c0aad1e14151cd2ab4f575700cc200b48a", size = 45284, upload_time = "2026-09-03T21:10:36.483Z" },
 ]
 
 [[package]]
 name = "daytona-api-client"
-version = "0.200.1"
+version = "0.210.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -898,14 +898,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/be/9e604a59ea3b3dc5a120b9dd216b1db12f4da2e6b8601e7d4f49b1874c96/daytona_api_client-0.200.1.tar.gz", hash = "sha256:fcf17e051eb7e0a9b8a38d02ef74f7ed67f84c3b4d150c8dd76c8c942f521fa9", size = 124815, upload_time = "2026-07-22T12:22:56.725Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/fb/3f577dea27c04937ad2cea314877346d2ac5cdf44925bd09eb2b6de2e6f5/daytona_api_client-0.210.0.tar.gz", hash = "sha256:1aea806ca4fe86f0f59b66c043b849d1acf61d9b7db240ec13b7c0678f955590", size = 141803, upload_time = "2026-09-03T21:10:27.399Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/1a/094725c4f495eba4411666a12307f885cead3aa29917eccf72f3630f36ff/daytona_api_client-0.200.1-py3-none-any.whl", hash = "sha256:7d7c41d7c5b601d9df908bd0ab0f0f567ade2913edf2eb087f65cfc6fcbe73a0", size = 316076, upload_time = "2026-07-22T12:22:57.798Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bf/7b6e062bf754707c0a29c5e65de2c98fb1a04b2f298fbceba9ab513b88ea/daytona_api_client-0.210.0-py3-none-any.whl", hash = "sha256:c55f42d13fc8da84380fbdc5bc010c67dca7f9b9d399546ab54e8810c5dc1c38", size = 356132, upload_time = "2026-09-03T21:10:28.713Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.200.1"
+version = "0.210.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -914,14 +914,14 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/dc/132b3ac1f44434ef4115abe99761542da9ac025a20f011fc081638148245/daytona_api_client_async-0.200.1.tar.gz", hash = "sha256:269874af7f97368531a08762639590a59f0ece95e194fa6ebe998fbf8258d4dd", size = 125346, upload_time = "2026-07-22T12:22:39.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/f4/6707985e647280d34a87de4ed24fd501bbe4999c0165b4c9b374490b773b/daytona_api_client_async-0.210.0.tar.gz", hash = "sha256:0b597f289f992572e776e3616cf5aae89a9b623dbbc911213e69c2d193bfe302", size = 142201, upload_time = "2026-09-03T21:10:31.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/47/ea80967ccdcc4fbabbf628a1b162f0f500edd75eebffc55fea88ada41ea8/daytona_api_client_async-0.200.1-py3-none-any.whl", hash = "sha256:df80d0aeb52c82a4660d746464842bdb6c8a2e0203b0cdc6374037b164c47824", size = 318668, upload_time = "2026-07-22T12:22:41.49Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/47/7ef49573074d5956578f8c899b528a8107e0dfc9fe0d953c32859d968dc0/daytona_api_client_async-0.210.0-py3-none-any.whl", hash = "sha256:6da7dc68915b216d1a7a821e8dbe3c832b63c63c0e8701cda1216d5c38080e59", size = 358962, upload_time = "2026-09-03T21:10:33.482Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.200.1"
+version = "0.210.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -929,14 +929,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/d8/650c9b70734931ac369dc5369d4168bc81e65fca244d19afb6d77b496bd9/daytona_toolbox_api_client-0.200.1.tar.gz", hash = "sha256:c5c74b390c20396494a3a70e843a5da70187ba5d197b26fe98be366e2a1a81da", size = 86312, upload_time = "2026-07-22T12:22:49.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/16/83d9b090d8107a95f871ed0154392732918ee6b0606b7117444353b29412/daytona_toolbox_api_client-0.210.0.tar.gz", hash = "sha256:f816c60d01bbd8de4649caa6e6a05bd025a8096e17d6096cbc8b537db900fa9a", size = 88114, upload_time = "2026-09-03T21:10:27.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/a2/329d03f4898e3b768bf285b3353f3db347e6946f8f7a3b7587325f7e6468/daytona_toolbox_api_client-0.200.1-py3-none-any.whl", hash = "sha256:7baaebf323d663e669db6dbbba816fccd7facca101d6cffa86959dee06593ce3", size = 247064, upload_time = "2026-07-22T12:22:50.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/43/5810261a1d57c4eff93960a1848767ca14a2d5fb543d1f32aab74954fdbd/daytona_toolbox_api_client-0.210.0-py3-none-any.whl", hash = "sha256:f346fbfc7db3ad5201dfe35610fd068d3992f8ae5e3bc5a312d1214da528dddb", size = 252413, upload_time = "2026-09-03T21:10:29.504Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.200.1"
+version = "0.210.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -945,9 +945,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/ad/92aa88099f210e2ff73cebfa0ca08538f05068e6c5c25a3e565eb9438d75/daytona_toolbox_api_client_async-0.200.1.tar.gz", hash = "sha256:ffe6c6bd9289b56a448a7e0f1f36a295fda431e0d73fc74c53cfb9492f590174", size = 80178, upload_time = "2026-07-22T12:22:39.642Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/b9/419fcacbf90f22679da6f73a2ba6c8dae3c7054e81546589dca28f5c2c0e/daytona_toolbox_api_client_async-0.210.0.tar.gz", hash = "sha256:82e1b0c9cc5db0484be061e39a9810bc7df1e8c0ca0aeb0cd9a3dd6d5eb1101a", size = 82027, upload_time = "2026-09-03T21:10:32.399Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/00/b3f5b3e40a37af8b883590d78a7d6935a464e74364129732daa322c4bd37/daytona_toolbox_api_client_async-0.200.1-py3-none-any.whl", hash = "sha256:fc953a1ee1d9967900b21c5eb6188c54617b1d66d5ad6b737e457a9e76a4fb4a", size = 245534, upload_time = "2026-07-22T12:22:40.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/57/1d2bef2d66f6d212155aeb2ca09e2f817b7eea84df759cd1fab10b4b1f7b/daytona_toolbox_api_client_async-0.210.0-py3-none-any.whl", hash = "sha256:cf4a1c9b64f3a7f8fc8d2d46b5c577824bb43452744fcc4b3874a25e04f52a05", size = 250905, upload_time = "2026-09-03T21:10:34.217Z" },
 ]
 
 [[package]]
@@ -2002,7 +2002,7 @@ requires-dist = [
     { name = "certifi", specifier = ">=2026.1.4" },
     { name = "charset-normalizer", specifier = ">=3.4.0" },
     { name = "croniter", specifier = ">=2.0.0" },
-    { name = "daytona", specifier = ">=0.200.1" },
+    { name = "daytona", specifier = ">=0.210.0" },
     { name = "deepagents", specifier = ">=0.6.11,<0.8" },
     { name = "edgartools", specifier = ">=5.7.2" },
     { name = "exchange-calendars", specifier = ">=4.13.2" },


### PR DESCRIPTION
## Summary

Workspace file bytes move out of Postgres into content-addressed object storage. A manifest row per path stays in `workspace_files`; the bytes live at `blobs/{user_id}/{sha256}`, with files at or under 256 KiB packed together so a workspace of thousands of small files costs a handful of objects. Keys are scoped to the owning user, so a workspace can only ever reference objects its owner uploaded; dedup and forks work within a user, which is where they happen. Bytes travel straight between the sandbox and storage over presigned URLs, with the server relaying only when the sandbox cannot reach storage. Orphaned objects are condemned after a grace period and reaped by a background sweep.

## Overview

| Category | Files | +LOC | −LOC |
|---|---:|---:|---:|
| Modified | 20 | 915 | 961 |
| New | 15 | 5057 | 0 |
| Tests (excluded) | 25 | 5328 | 81 |
| **Net (excl. tests)** | 35 | **+5972** | **−961** |

### `src/utils/storage/` (net +228)
- `__init__.py` (+57 / −9): `STORAGE_BLOB_TRANSFER` / `storage.blob_transfer` setting (`auto` | `direct` | `relay`); the facade grows `get_signed_upload_url`. A provider selected without a bucket now reads as disabled: the checked-in config names `s3` while the bucket lives in `.env`, and a build that never filled it in keeps its bytes inline rather than failing every upload.
- `s3_compatible.py` (+140 / −11): presigned PUT and GET, a per-call `max_size` override so blob uploads can exceed the general facade cap, ranged reads for pack members.
- `oss_uploader.py` (+56 / −5): the same surface for the OSS provider.

### `src/server/database/` (net +603)
- `blob_keys.py` (new): the digest regex, the `blobs/{user_id}/{sha256}` key format, size caps, and the SQL fragments (`REGISTER_SQL`, `CLAIM_SQL`, `REFERENCED_SQL`) shared by the service and the ops scripts, kept import-free so scripts can use them without loading the app.
- `workspace_file_blobs.py` (new): store, fetch, ranged fetch, registry lookups keyed by `(user_id, sha256)`, and the condemn / reap garbage collection with the object delete awaited to settlement so a cancellation cannot orphan a row lock. The sweep's session lock is released through `release_session_lock`, including when the cancellation lands between the grant and its reply.
- `session_lock.py` (new): `release_session_lock`, the one release both session-level advisory locks use: it runs the unlock as its own task, awaits it through every cancellation delivery, and closes the connection when the unlock cannot be confirmed, so a lock never goes back to the pool with its holder. `await_settled` is that wait on its own, reused wherever a task must finish before its caller's cancellation is honored.
- `workspace_file.py` (+151 / −160): rows carry `blob_sha256`, `pack_sha256`, `pack_offset`, `kind`, `mode`, `link_target`, and `sandbox_modified_ns`; `workspace_sync_lock` serializes one sync per workspace on a session-level advisory lock, waits at most `SYNC_LOCK_WAIT` (120 s) before raising `WorkspaceSyncBusy`, and releases through `release_session_lock`, also when the acquisition itself is cancelled after the grant; `delete_file_rows` removes named rows without the prune fence, for a caller with positive evidence they are gone; `delete_removed_files` requires an `untouched_since` clock so a concurrent write cannot be pruned. `bulk_update_file_stamps` raises on a failed write, and the sync counts the batch as errors, since a mode or mtime change on unchanged bytes is recorded nowhere else.
- `workspace.py`: `files_restore_incomplete_at`, the flag that withholds pruning after a partial restore, read on the lock-owning session, and `workspace_owner`, read once per sync or restore. Both writes to it name the sandbox the row is expected to hold, `NULL` included, and land only while it does: a raise names the sandbox the identity CAS will replace, a clear names the sandbox it vouches for. `ANY_SANDBOX` skips the check for a runtime with no id. The write reports whether it landed.

### `migrations/` (net +241)
- `039_workspace_file_blobs.py` (new): the `workspace_file_blobs` registry keyed by `(user_id, sha256)`, the new manifest columns (`symlink_target` is `TEXT`, since a target is bound by the sandbox's path limit, not by 1024) and their CHECKs, the partial indexes. Index builds run concurrently in an autocommit block. The downgrade takes an exclusive lock on both tables before it counts, and holds it through the DDL in the same transaction, so a still-running worker cannot publish a blob-backed row between the check and the column drop. It refuses to run while any row keeps its bytes in storage, naming the `--reverse` backfill that pulls them back inline, or while any workspace has an incomplete restore recorded, since that flag is the only prune gate such a workspace has left. The manifest carries no foreign key into the registry: a single-column key cannot reference the composite one, and reference integrity rests on the GC row-lock protocol.

### `src/ptc_agent/core/sandbox/` (net +1148)
- `wsfiles_transfer_runtime.py` (new): a stdlib-only script uploaded into the sandbox. It scans the workspace with mtime and mode stamps, hashes changed files and classifies them as text only when every byte is strict UTF-8 and none is a NUL, neither read from a leading window, PUTs and GETs presigned URLs with a pooled TLS session, builds and unpacks pack chunks, and applies modes and symlinks on restore. It reports per-object status so the server can fall back per file. Only a 2xx counts as a successful transfer, so a redirect never registers a missing object, and a file's recorded size is the length of the bytes that were hashed. A direct PUT sends exactly that many bytes and rejects the upload as changed if the file held more or no longer stats at that length: `http.client` streams a file object to EOF whatever Content-Length says, so a file appended to during its own PUT would otherwise be stored, and verified, as the prefix it was scanned as, while the tail arrived at the head of the next request on the pooled connection. Every transient file it or the relay writes sits at the workspace root under `.wsfiles-`, and the sync marker sits there too; the scan skips the `.wsfiles-` prefix and the marker's exact name at the root only, so a user's own `sub/.wsfiles-notes`, `results/.file_sync_marker` or root `.file_sync_marker.bak` is a file like any other; the pull op removes any such root entry no item claims, which is what an upload the file API cut short leaves behind. The skill reconciler's scratch is reserved by workspace-relative path (`.agents/skills/.staging`, `.agents/skills/.trash-*`), never by bare name. A seed directory (`data`, `results`, `work`) that the manifest now names as a file or symlink yields to it, but only once the bytes are verified, immediately before the rename into place: a pull that fails leaves the seed standing.
- `_shared.py` (+9): the runtime ships through the hashed sandbox asset manifest, so a warm sandbox receives a new copy whenever the file changes.
- `providers/daytona_secrets.py` (+5 / −4): the SDK's error envelope attribute is now `code`; only a string counts as one.
- `providers/docker.py` (+26): tar entries built for an upload carry the container user's uid and gid, read once per runtime. `put_archive` extracts with the ownership the entry states, and an entry defaults to root, so a placed file the container's own user did not own could be read but never `chmod`'d or `utime`'d, which is what restoring a workspace file has to do. An unreadable lookup falls back to root, which is what it was before.

### `src/server/services/persistence/` (net +1578)
- `transfer.py` (new): the server side of the runtime protocol: one exec per operation, result parsing, timeouts sized by byte count; the scan result drops a root marker entry itself, so a sandbox still running an older runtime cannot record one. The skill reconciler's lock file is reserved at its one path (`EXCLUDE_REL_FILES`), so a user's own `results/.skills-sync.flock` is scanned like any file. An uploaded spec is removed by the runtime once read, and a rerun after a runtime upload reuses the same name.
- `backup.py` (new): `sync_to_db` under the workspace lock; a stamp prefilter so unchanged files are never re-hashed; pruning gated on restore completeness, and while a restore is incomplete a moved mode or mtime on an unchanged entry is left unrecorded, since it may be the failed restore's own doing. The rows under any scanned file or symlink are dropped regardless of the gate: the parent's kind proves they cannot exist, and a restore that kept them would create a directory where the symlink has to land. Keyed on the scan alone, since a manifest written before directories had rows holds the children with no parent row.
- `blobs.py` (new): direct push with the registry dedup, relay fallback for whatever the sandbox could not reach, pack assembly for small files, inline rows when no storage is configured. `_push_direct` returns a `DirectPush` outcome and `_persist_blobs` alone decides what to relay. Relay verifies both digest and length before a row is written. Presigning runs for every missing digest at once, since each signature is local work on its own thread.
- `restore.py` (new): restore under the same workspace lock as backup, from packs and objects with presigned pulls, relay for unsigned or unreachable entries, modes and symlinks. Relayed files land through a staging name the runtime verifies and renames into place, against the digest and length of the bytes the server actually sent rather than the row's own columns: the check asks whether the upload arrived whole, and a row whose recorded size came from a stat rather than from the content can state a length its own bytes disagree with. A row that cannot reproduce its own `content_hash` is placed and logged. Directory modes are applied once after every file is in. The incomplete flag is raised before the sync lock is requested and cleared, after the marker, as a completing restore's last write on the lock connection: both callers swallow `WorkspaceSyncBusy` and start the empty sandbox anyway, and this ordering means a worker whose wait timed out can never overwrite a restore another worker completed meanwhile. A flag found standing beside a marker on start is cleared, since the marker is only ever written by a completed restore. A flag that cannot be raised at all aborts the restore with `RestoreGuardUnavailable`, which the workspace manager lets unwind provisioning rather than bind a sandbox nothing protects. Provisioning restores into a sandbox the row does not yet name, so the clear waits for the bind: the manager reconciles once more after winning the sandbox CAS, and a losing provisioner's clear never lands on the winner's row. A raise that lands nowhere, because another provisioner has already bound, aborts with `RestoreIdentityLost` before the lock, so a slow provisioner cannot leave a flag standing on the winner's sandbox. `maybe_restore` lets `RestoreGuardUnavailable` reach its caller: on the lazy-start and reconnect paths it is the only restore, and a swallowed guard would publish an empty, unflagged sandbox. A manifest read that fails there is the same hazard and raises the same error.
- `resolve.py` (new): the one resolver every read path uses: inline columns, then pack range, then object; `FileBytesUnavailable` for a transient storage failure.
- `restore.py` (new, cont.): a completeness-flag clear that fails all its attempts logs and returns rather than raising. The sandbox on that path is complete and the marker is present, so the next cold start reconciles again from it; failing provisioning there would destroy a healthy sandbox because the database was briefly unreachable.
- `_rows.py` (new): row builders and the stamp / content predicates the modules share. A NUL anywhere in the content classifies a file as binary, not a NUL in a leading window: text goes to a column that cannot hold one, so a NUL further in is dropped on the way to the row and the stored bytes stop hashing to the row's own digest.
- `file.py` (+71 / −645): the facade, accessors, and re-exports. `prior_from_meta` is public, since a route reads it.

### `src/server/services/` and `src/server/app/` (net +168)
- `workspace_file_gc.py` (new): the lifespan-owned sweep that condemns and reaps orphan blobs; wired in `setup.py`.
- `workspace_files/_shared.py`, `crud.py`, `serve.py`, `public.py`: read through the resolver. Authenticated reads answer 503 on a transient storage failure; the unauthenticated share routes fall through to a warm sandbox in the worker when the resolver answers absent, and keep their uniform 404 when there is none. The backup status route counts file rows only, so a stopped workspace reports the same population a running one does.

### `scripts/ops/` (net +785)
- `backfill_workspace_file_blobs.py` (new): moves inline rows into storage, dry-run by default, `--reverse` pulls bytes back inline. Every write is a compare-and-set on the full row identity, including both pointer columns, and every fetched object is verified against its digest. Rows whose owner has a non-UUID id are left inline unless `--include-legacy-owners` is passed: a platform login re-keys such an account, and objects keyed by the old id would not follow it.
- `report_orphan_blobs.py` (new): read-only orphan count and byte total, with the GC backlog counters taken over the same orphan predicate, so a referenced blob past the grace period is never reported as condemnable.
- `_db.py` (new): `build_db_uri`, shared with `scrub_nul_checkpoint.py`.

### Config
- `.env.example`, `agent_config.yaml`: the `blob_transfer` setting with its three values documented, and the rule that the public URL base serves only the keys the app links to directly, never `blobs/` or `memo/`; `pyproject.toml` / `uv.lock`: Daytona SDK 0.210.0.

**What this introduces:** workspace files persist as content-addressed objects with the database holding only the manifest, forks share bytes instead of copying them, and stop / restore move bytes directly between the sandbox and storage.

## Behavior changes worth knowing

- A restore that fails partway no longer writes the completion marker. The workspace is flagged and the next backup prunes nothing until a restore completes with zero errors.
- A strict backup (spec recreate, config migration) raises when any file failed, so a sandbox is never torn down over a partial snapshot.
- NUL bytes in text files now round-trip wherever the NUL sits. A file carrying one takes the binary path, so the row reproduces its own `content_hash` whether the bytes are inline or in an object; previously the text column stripped the NUL while the hash still described the original.
- Empty files, symlinks, directories, and executable bits restore as they were.
- With `STORAGE_PROVIDER=none` the inline columns keep working unchanged.

## Verification

- Live stop / restore cycles against a running stack with a real S3-compatible bucket: a 2.5k-entry workspace restores byte-exact, marker written, flag cleared, and a follow-up backup moves nothing.
- Fault injection with presigned PUTs refused: backup relays the chunk and objects with zero errors. With GETs refused: restore relays everything, byte-exact. An injected failure mid-restore leaves the flag set and the next sync prunes nothing.
- Destroy-and-recreate restore through the container path is identical to the in-process one.
- Backfill: dry run mutates nothing, apply then `--reverse` round-trips, reruns are idempotent.
- Fault injection with a 307 on PUT served from inside the sandbox: every object reports failed, no row is written, the chunk is kept, and the next real backup recovers with zero errors.
- A 0555 directory holding a packed and a standalone file backs up, restores in relay mode with both children byte-exact and the mode intact, and survives a second restore over the existing read-only directory.
- A digest registered under one user is a miss for another, and a fetch under the other user's key fails.
- A registered blob key fetched through the store's public URL base answers 404.
- On the live Postgres, a second session waiting on the sync lock is cancelled at the bound, and the session lock survives the transaction that set it.
- A relay upload the file API cut short with a 502 left a partial staging file at the workspace root; the next restore removes it and the file it stood in for restores at its full size.
- A user file named `.wsfiles-notes` inside a subdirectory, a text file whose only bad UTF-8 sequence sits after 64 KiB, and a symlink with a 1023-byte target (the sandbox overlay's ceiling) back up, restore byte-exact with no temp file beside any target or at the root, and a follow-up backup moves nothing.
- With the sync lock held by a foreign session for the whole start: the backup on stop and the restore on start both give up at the bound, the workspace is flagged, the backup of the empty sandbox that follows keeps every absent row, and the next start restores all 2556 entries with zero errors, marker written and flag cleared.
- The downgrade against the live stack's database takes its lock, reports the blob-backed rows, and leaves the schema at 039.
- With the flag raised and no directory rows in the manifest, two child rows under a path that came back as a symlink are dropped and the symlink recorded.
- A user file at `results/.file_sync_marker` backs up as a row, the root marker does not, and removing it prunes the row on the next sync. A root `.file_sync_marker.bak` and a `work/model/.staging/results.csv` back up and restore, on a warm sandbox running the previous runtime and on a fresh one, while `.agents/skills/.staging` stays out.
- With the restore flag raised: a directory with two nested children replaced by a symlink and a sibling directory replaced by a file back up with the four child rows dropped and an unrelated missing file kept; after the flag clears, a stop, SDK deletion and start restore all 328 entries identical, symlink and file in place, marker written, zero errors.
- A fresh interpreter with the provider set and no bucket reports storage disabled; with a bucket it stays enabled.
- With the flag write failing on start, the restore aborts before the sync lock, no marker is written, and provisioning unwinds. A raise naming a sandbox the row no longer holds updates nothing on the live Postgres and the restore aborts as identity lost.
- A stamp update that fails is counted in the sync's error count, so a strict stop refuses to tear the sandbox down over it.
- A user file `results/.skills-sync.flock` backs up as a row and the reconciler's own lock does not; a backup that uploads a spec leaves nothing behind in the sandbox's transfer directory.
- A root `results` directory replaced by a symlink backs up as one, and after a stop, SDK deletion and start the symlink is in place over the seeded directory, every entry identical, marker written and flag cleared. A stop, SDK deletion and start after the change restores every entry identical, and the flag is cleared by the post-bind reconcile with the marker present.
- Merge-prep pass at the final head, against the running stack and the real bucket: a fresh 2464-row workspace backs up with every digest matching and a second backup moving nothing; a file rewritten continuously during backup converges once writes stop; a stop, SDK deletion and start restores every entry identical; a deleted and a corrupted object both serve 503 while stopped, the restore that follows leaves the flag raised and no marker, the backup of that incomplete sandbox prunes nothing, and after the objects are put back a restart is identical; 332 files come back byte-identical from the store while stopped (the one miss is a name with a trailing space, which the route's path normalisation strips on `main` as well); deleting half the tree before a stop is recorded as the user's deletions.
- Relay fallback at the final head: with presigned PUTs refused the backup relays the pack and the objects with zero errors; with GETs refused the restore relays everything byte-exact; an injected restore failure leaves the flag set, the sync while flagged prunes nothing, and a real restore clears it (15 checks).
- Blob GC interleavings at the final head: condemn after grace, touch and reference protection, revive on register, a writer blocked behind the reap's row lock landing live with its object, a claimed row outside the reap predicate, a failed object delete leaving the row condemned, and the advisory lock skipping a concurrent sweep (15 checks).
- Backfill at the final head on 246 inline rows: apply moves every row and registers every digest, a file serves while stopped, a rerun moves nothing, `--reverse` restores every row, and the per-row digest of path, hash and content is identical before and after.
- Duplicate at the final head: the copy holds the same 331 rows with identical pointers, the registry and the bucket gain no rows or objects, and the copy's sandbox restores identical with marker written and flag cleared.
- Two workers: `server.py --workers 2` in the backend container; after an SDK deletion, two simultaneous starts three times over both answer 200, one sandbox is bound, the flag is cleared, the marker is present, the tree is identical, and no sandbox is leaked; the stops went through the other server process.
- A registered blob key fetched through the store's public URL base answers 404 at the final head; the orphan report runs against the live registry.
- The self-hoster shape, end to end: with `storage.provider: none` on a 676-entry workspace, backup writes 664 inline rows and a second backup moves nothing; a stop, sandbox deletion and start restore the tree identical with the marker written and the flag cleared; 15 files serve byte-identical while stopped; a duplicate copies all 664 rows with identical content and adds no objects; the backfill refuses to run with no store configured and the GC does not start.
- The same workspace on the docker sandbox provider: 667 rows backed up, restored 667 / 0 errors after the container is replaced, every file owned by the container's own user with modes and mtimes intact, and 15 files serve while stopped. Before the tar ownership fix every one of the 530 files failed placement with `EPERM` on the `chmod` that follows the rename.
- A text file whose only NUL sits past 64 KiB: before the classifier fix its row stored the NUL-stripped bytes and restore refused it on the digest, leaving the workspace flagged with no marker; after, the row is binary, carries the true bytes and its own digest, and the cycle is identical over 664 entries.
- A manifest row whose recorded size disagrees with its own stored bytes: five rows skewed by +12345, −1000, −150000, +7 and +64 (and a second pass down to a negative recorded size) were all refused before the fix, with no marker and the flag left standing; after, all five are placed with their true bytes, the marker is written, the flag clears, and the next ordinary backup rewrites the five rows, since the stamp prefilter compares recorded size too. Run in both transfer modes, since a row carrying inline bytes relays either way.
- A fresh interpreter reports the storage provider from the environment alone, so a build whose checked-in config names a different provider does not decide the probe.
- A file appended to between its scan and its own direct PUT: the store answers 200, since the bytes it was framed to read are the prefix that was hashed and signed, and the runtime reports `changed` instead of `ok`, which the sync counts as an error so a strict backup refuses to tear the sandbox down. The object holds exactly the scanned prefix, so the pooled connection is not left carrying bytes the next request would read as its own status line.
- The rebuilt runtime on a live sandbox: 45 fresh files, 4 direct PUTs from 260 KiB to 14 MB plus 41 packed, every row's size and digest matching the file; a stop, sandbox deletion and start restore all 45 identical with the marker written and the flag cleared; a file grown between two syncs re-syncs to its new size and digest.
- Unit suite: 9994 passed. `make lint` clean.

## Deferred

- The sync lock holder still takes additional pool connections for registry work (`registered_blobs`, `register_blobs`, `store_blob`). With a pool of two, one backup can hold the lock while another occupies the second connection waiting for it. A follow-up threads the held connection through those calls.
- An upload that succeeds and then dies before its registry row is written leaves an object neither the sweep nor the orphan report can see.
- Pack rewrite amplification: any change to the small-file set repacks the whole set. The orphan report measures what that costs before a smarter packer is designed.
- `_resolve_under_root` follows existing parent symlinks inside the workspace root.
- Staging entries sit at the workspace root under the reserved `.wsfiles-` prefix, in the same class as `_internal`, `.system` and the root sync marker: a user entry under a reserved name is not persisted. Moving staging into one private root directory would reserve a single name instead of a prefix family.
- The OSS storage client is built per call with no connection reuse or explicit timeouts, unlike the S3 client in this PR; OSS deployments route blob transfer through relay, so the restore fetch path would benefit from the same cached, timeout-bounded client.
- The relay restore path bounds in-flight rows by count (16), and by the 1 GB workspace cap in bytes. A byte-weighted budget would let large-file workspaces restore with less resident memory.
- `migrate_user_id` moves a legacy account's workspaces but not its objects, which stay keyed by the old id. The backfill leaves such owners inline by default; the migration itself is unchanged.


