### PR TITLE
fix(web): settle a hidden tab's streaming animations on the first frame back

### DIFF
--- a/web/src/components/ui/__tests__/animated-text.stop.test.ts
+++ b/web/src/components/ui/__tests__/animated-text.stop.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// framer's stop() runs one last tick at the wall clock before tearing down, so
+// a chain older than its duration finishes inside stop() and fires onComplete
+// synchronously, and a stop() on an already finished animation fires it
+// again (JSAnimation.tick treats state "finished" as done). Routine in a
+// hidden tab, where the effect re-runs once a second. This mock reproduces
+// exactly that, with a clock the test advances by hand.
+type Opts = { duration: number; onUpdate: (v: number) => void; onComplete: () => void };
+let clock = 0;
+const live = new Set<object>();
+vi.mock('framer-motion', () => ({
+  animate: (from: number, to: number, opts: Opts) => {
+    const createdAt = clock;
+    let finished = false;
+    const controls = {
+      stop: () => {
+        live.delete(controls);
+        const elapsed = (clock - createdAt) / 1000;
+        if (finished || elapsed >= opts.duration) {
+          finished = true;
+          opts.onUpdate(to);
+          opts.onComplete();
+        } else {
+          opts.onUpdate(from + (to - from) * (elapsed / opts.duration));
+        }
+      },
+    };
+    live.add(controls);
+    return controls;
+  },
+}));
+
+import { useAnimatedText } from '../animated-text';
+
+const words = (n: number) => Array.from({ length: n }, (_, i) => `w${i}`).join(' ') + ' ';
+
+describe('useAnimatedText chain ownership', () => {
+  afterEach(() => {
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+  });
+
+  it('a chain finished by its own stop() never starts a sibling', () => {
+    const { result, rerender } = renderHook(({ text }) => useAnimatedText(text, { enabled: true }), {
+      initialProps: { text: 'seed ' },
+    });
+    // Hidden, seconds between updates (Chrome wakes a hidden tab once a second
+    // at best, once a minute under intensive throttling), more than a snap's
+    // worth of text in each: the cleanup stop finishes the chain, then the
+    // backlog snap stops it again after the target has moved on. That second
+    // stop used to spawn a sibling chain aimed at the old target.
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+    let text = 'seed ';
+    for (let i = 0; i < 6; i++) {
+      clock += 3000;
+      text += words(170); // ~740 chars, over CATCH_UP_CHARS
+      act(() => rerender({ text }));
+      expect(live.size).toBe(1);
+    }
+    expect(text.startsWith(result.current)).toBe(true);
+  });
+});

--- a/web/src/components/ui/animated-text.ts
+++ b/web/src/components/ui/animated-text.ts
@@ -51,6 +51,19 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
   const lastUpdateTimeRef = useRef(0); // throttle onUpdate to ~30fps
   const arrivalRef = useRef({ at: 0, cps: 0 }); // filtered arrival rate, chars/s
   const finishingRef = useRef(false);
+  const chainRef = useRef(0);        // generation of the chain allowed to write state
+
+  // A superseded chain must never touch state again. framer's stop() runs one
+  // last tick at the wall clock before it tears down, so a chain older than
+  // its duration (routine in a hidden tab, where timers fire once a second)
+  // finishes synchronously inside stop() and its onComplete would start a
+  // sibling the effect no longer tracks: two cursors typing the same text.
+  const stopChain = useCallback(() => {
+    chainRef.current++;
+    controlsRef.current?.stop();
+    controlsRef.current = null;
+    animatingRef.current = false;
+  }, []);
 
   const noteArrival = useCallback((chars: number) => {
     const now = performance.now();
@@ -75,6 +88,7 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
     }
 
     animatingRef.current = true;
+    const chain = ++chainRef.current;
 
     const segment = target.slice(from, to);
     const wordCount = segment.split(/\s+/).filter(Boolean).length || 1;
@@ -94,6 +108,7 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
       duration,
       ease: 'linear',
       onUpdate(latest) {
+        if (chain !== chainRef.current) return;
         const idx = Math.round(latest);
         cursorRef.current = idx;
         const now = Date.now();
@@ -102,6 +117,7 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
         setDisplayText(target.slice(0, idx));
       },
       onComplete() {
+        if (chain !== chainRef.current) return;
         cursorRef.current = to;
         setDisplayText(target.slice(0, to));
 
@@ -126,12 +142,10 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
         // The stream ended with text still hidden: type the rest out quickly
         // rather than popping it in whole.
         finishingRef.current = true;
-        controlsRef.current?.stop();
-        animatingRef.current = false;
+        stopChain();
         startChain();
         return () => {
-          controlsRef.current?.stop();
-          animatingRef.current = false;
+          stopChain();
         };
       }
       setDisplayText(text);
@@ -159,9 +173,8 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
 
     // If text was replaced (new message / component remount), reset
     if (!text.startsWith(targetRef.current.slice(0, cursorRef.current))) {
-      controlsRef.current?.stop();
+      stopChain();
       cursorRef.current = 0;
-      animatingRef.current = false;
       arrivalRef.current = { at: 0, cps: 0 };
     }
 
@@ -172,8 +185,7 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
     finishingRef.current = false;
 
     if ((arrivedAtOnce || document.hidden) && text.length - cursorRef.current > CATCH_UP_CHARS) {
-      controlsRef.current?.stop();
-      animatingRef.current = false;
+      stopChain();
       cursorRef.current = text.length - LIVE_TAIL_CHARS;
       setDisplayText(text.slice(0, cursorRef.current));
     }
@@ -187,8 +199,7 @@ export function useAnimatedText(text: string, { enabled = false }: UseAnimatedTe
     }
 
     return () => {
-      controlsRef.current?.stop();
-      animatingRef.current = false;
+      stopChain();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [text, enabled]);

--- a/web/src/lib/hiddenTabMotion.ts
+++ b/web/src/lib/hiddenTabMotion.ts
@@ -1,0 +1,25 @@
+/**
+ * Make every framer-motion animation instant while the tab is hidden.
+ *
+ * A hidden tab runs no animation frames, and framer schedules everything,
+ * even an instant animation, on its frame loop. So an animation created while
+ * the tab is away sits at its first keyframe until the tab returns, then
+ * starts its clock from that frame and plays in full. A streaming transcript
+ * accumulates dozens of them (rows folding out of the live zone at height 0,
+ * new rows unfolding from it, the accordion growing), and the return becomes
+ * a burst of collapses and expansions layered over a scroll pin that already
+ * landed. Marking the animations instant at creation makes the first painted
+ * frame after the return the settled layout. An animation already in flight
+ * at hide time needs nothing: its first tick back reads the wall clock and
+ * finishes it in that same frame.
+ */
+import { MotionGlobalConfig } from 'framer-motion';
+
+function apply(): void {
+  MotionGlobalConfig.skipAnimations = document.hidden;
+}
+
+if (typeof document !== 'undefined') {
+  apply();
+  document.addEventListener('visibilitychange', apply);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,6 +10,9 @@ import './index.css'
 // Side-effect import: the modality listeners have to be running before the
 // first click, not from whichever overlay happens to load first.
 import './lib/inputModality'
+// Side-effect import: animations created in a hidden tab must be instant from
+// the first render, so the flag has to be set before anything mounts.
+import './lib/hiddenTabMotion'
 import { Toaster } from './components/ui/toaster'
 import { StaleBuildBoundary } from './components/StaleBuildBoundary'
 

--- a/web/src/pages/ChatAgent/components/chatView/useChatScroll.ts
+++ b/web/src/pages/ChatAgent/components/chatView/useChatScroll.ts
@@ -123,6 +123,7 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
   // yanking a now-stale view.
   const streamFollowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const entryRestoreRafRef = useRef<number | null>(null);
+  const visibilityRafRef = useRef<number | null>(null);
 
   // Jump-to-latest pill.
   const messagesLenRef = useRef(0);
@@ -387,13 +388,40 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
       });
       ro.observe(getScrollContent(c));
     }
+    // Timers are throttled to once a second in a hidden tab, so the follow
+    // above can trail the transcript by that much when the tab returns. Close
+    // the remaining gap in one instant jump, only for a reader who was
+    // following: a user who scrolled up keeps their place. The jump is made
+    // twice: at the event, and again inside the first frame, after the
+    // animations the hidden tab queued have applied their final layout
+    // (see lib/hiddenTabMotion) but before that frame paints.
+    const handleVisibility = () => {
+      if (document.visibilityState !== 'visible' || !isMain) return;
+      const jump = () => {
+        if (pinTargetRef.current || !nearBottomRef.current) return;
+        if (c.scrollHeight - c.scrollTop - c.clientHeight <= 1) return;
+        withProgrammaticScroll(() => c.scrollTo({ top: c.scrollHeight }), 'auto');
+      };
+      jump();
+      if (visibilityRafRef.current != null) cancelAnimationFrame(visibilityRafRef.current);
+      visibilityRafRef.current = requestAnimationFrame(() => {
+        visibilityRafRef.current = null;
+        jump();
+      });
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
     return () => {
       c.removeEventListener('scroll', handleScroll);
       c.removeEventListener('wheel', handleUserIntent);
       c.removeEventListener('touchstart', handleUserIntent);
+      document.removeEventListener('visibilitychange', handleVisibility);
+      if (visibilityRafRef.current != null) {
+        cancelAnimationFrame(visibilityRafRef.current);
+        visibilityRafRef.current = null;
+      }
       ro?.disconnect();
     };
-  }, [activeAgentId, getScrollContainer, getScrollContent, reapplyPin, clearSettleTimers]);
+  }, [activeAgentId, getScrollContainer, getScrollContent, reapplyPin, clearSettleTimers, withProgrammaticScroll]);
 
   // Auto-scroll main chat to bottom when messages change, but only if the user is
   // near the bottom and the pin controller isn't currently owning the scroll.
@@ -423,7 +451,11 @@ export function useChatScroll({ activeAgentId, messages, isActive, isActiveRef, 
       if (pinTargetRef.current || !isNearBottomRef.current) return;
       const el = getScrollContainer(scrollAreaRef);
       if (!el) return;
-      withProgrammaticScroll(() => el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' }), 'smooth');
+      // A hidden tab runs no smooth-scroll animation, so the view would sit
+      // still while the transcript grows and the first follow after the tab
+      // returns would sweep the whole gap. Jump instantly while hidden.
+      const behavior = document.hidden ? 'auto' : 'smooth';
+      withProgrammaticScroll(() => el.scrollTo({ top: el.scrollHeight, behavior }), behavior);
     }, 0);
     return () => {
       if (streamFollowTimerRef.current) {


### PR DESCRIPTION
## Summary

Returning to a streaming chat after a tab switch no longer shows the catch-up glitch. Before, the first frames back were a burst of live rows collapsing, a scroll sweep across the whole gap, and reasoning text that re-typed itself. After, the first painted frame is the settled layout, in place, with one cursor.

### What a user sees

| Before | After |
|---|---|
| Switch tabs mid-reasoning, come back: every row that folded while away collapses in front of you, one after another. | The rows are already folded in the first frame back. |
| The view slides from where it was to the new bottom over a second or so. | The view is at the bottom in the first frame back. |
| The reasoning text flip-flops by a few hundred characters for several seconds, as if two cursors were typing the same row. | One cursor, monotonic text. |

### Root causes

Three, all in the web client, all verified over raw CDP on real Chrome against the live stack (a Playwright page never reports hidden; the CDP script drives a second real tab).

- **framer queues animations in a hidden tab.** Its frameloop is rAF-driven, so an animation created while hidden sits at its first keyframe and plays in full on the first frame back. A streaming transcript queues dozens.
- **framer's `stop()` can complete synchronously.** `JSAnimation.stop()` ticks the wall clock before tearing down; a chain older than its duration (routine when a hidden tab's effects run once a second) finishes inside `stop()` and its `onComplete` starts a sibling typewriter chain the hook no longer tracks.
- **The follow scroll trailed the transcript** with a smooth `scrollTo` that a hidden tab never animates, so the first follow after return swept the whole gap.

### How

- `lib/hiddenTabMotion.ts` sets `MotionGlobalConfig.skipAnimations = document.hidden` on every visibility change, so animations created while hidden are instant. In-flight animations at hide time need nothing: their first tick back reads the wall clock and finishes them in that frame.
- `useAnimatedText` stamps each chain with a generation (`chainRef`); a superseded chain's `onUpdate` and `onComplete` return without touching state.
- `useChatScroll` jumps instantly while hidden and re-pins on `visibilitychange`, once synchronously and once on the next frame, after the instant animations have applied.

### Measured

Same live turn, tab hidden for 12 s mid-reasoning, sampled per DOM mutation after return:

| | main | this branch |
|---|---|---|
| non-monotonic transcript mutations after return | 53 | 0 |
| queued row collapses played on return | dozens | 0 |

The regression test `animated-text.stop.test.ts` drives the hook under a hidden document with a clock-based framer mock and asserts one live chain; it fails on main with two.

## Overview

| | Files | Added | Removed |
|---|---|---|---|
| Modified | 3 | 49 | 12 |
| New | 2 | 88 | 0 |
| Total | 5 | 137 | 12 |
| Net excluding tests | 4 | 74 | 12 |

- **Web, animation**: `lib/hiddenTabMotion.ts` (new, the skipAnimations toggle), `main.tsx` (side-effect import), `components/ui/animated-text.ts` (chain generation guard).
- **Web, scroll**: `pages/ChatAgent/components/chatView/useChatScroll.ts` (instant follow while hidden, first-frame re-pin on return).
- **Tests**: `components/ui/__tests__/animated-text.stop.test.ts` (new).

## Risk

- `skipAnimations` is global to framer. Any animation created while the tab is hidden, anywhere in the app, is instant. Nothing visible is painting then, so nothing is lost.
- The re-pin on return only fires when the reader was near the bottom and no pin owns the position.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791179002&installation_model_id=432753&pr_number=395&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F395&signature=5aa3d55d55c27253368ee771c8ef9e8accaaed2585097cc12b376e8773eb160b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Animations now complete instantly when the app is opened or updated in a hidden browser tab.
  - Chat transcripts automatically catch up to the latest content when returning to the tab, while preserving the position of users who have scrolled away.
  - Streaming chat content uses instant scrolling in hidden tabs and smooth scrolling when visible.

- **Bug Fixes**
  - Prevented animated text from duplicating or restarting unexpectedly during rapid updates and tab visibility changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->