### PR TITLE
fix(llms): surface Qwen reasoning and DashScope stream failures

### DIFF
--- a/src/llms/__init__.py
+++ b/src/llms/__init__.py
@@ -1,5 +1,10 @@
 from src.llms.patches import _patch_langchain_anthropic_usage_metadata
+from src.llms.extension.dashscope import _install_responses_stream_bridge
 _patch_langchain_anthropic_usage_metadata()
+# Here rather than at first client construction: the bridge rewrites a module
+# global, so installing it lazily would let two workers disagree about whether
+# a Responses stream reports its reasoning and names its failures.
+_install_responses_stream_bridge()
 
 from .llm import LLM, ModelConfig, create_llm, get_llm_by_type, get_configured_llm_models, get_input_modalities, should_enable_caching
 from .api_call import (

--- a/src/llms/error_classification.py
+++ b/src/llms/error_classification.py
@@ -52,6 +52,20 @@ def extract_status_code(exc: BaseException) -> int | None:
     return None
 
 
+def is_mid_stream_error(exc: BaseException) -> bool:
+    """Whether the failure was reported inside an already-established stream.
+
+    A provider that answers HTTP 200 and then reports failure as a stream event
+    sets ``mid_stream`` on its exception. Duck-typed rather than keyed to a
+    provider's exception class, so this module stays provider-agnostic and the
+    alternative, matching error prose, never has to be written.
+    """
+    return any(
+        getattr(current, "mid_stream", False) is True
+        for current in _iter_exception_chain(exc)
+    )
+
+
 def is_retryable_error(exc: BaseException, status_code: int | None = None) -> bool:
     """Whether retrying the same model could plausibly succeed.
 

--- a/src/llms/extension/__init__.py
+++ b/src/llms/extension/__init__.py
@@ -1,4 +1,5 @@
 from .codex import ChatCodexOpenAI
 from .anthropic_oauth import ChatAnthropicOAuth
+from .dashscope import ChatDashScope, ResponsesStreamFailedError
 
-__all__ = ["ChatCodexOpenAI", "ChatAnthropicOAuth"]
+__all__ = ["ChatCodexOpenAI", "ChatAnthropicOAuth", "ChatDashScope", "ResponsesStreamFailedError"]

--- a/src/llms/extension/dashscope.py
+++ b/src/llms/extension/dashscope.py
@@ -1,0 +1,188 @@
+"""ChatOpenAI subclass for DashScope (Qwen) Responses backends.
+
+DashScope speaks the Responses API but uses two event shapes langchain-openai's
+converter has no branch for, so both fall through its final ``else`` and vanish:
+``response.reasoning_text.*`` carries the thinking tokens, and
+``response.failed`` carries the reason a stream died. The bridge below rescues
+both, which is the difference between a Qwen turn that shows its reasoning and
+names its own failures, and one that silently returns nothing.
+"""
+
+import logging
+
+from langchain_openai import ChatOpenAI
+
+logger = logging.getLogger(__name__)
+
+# The provider writes this text, and it lands in a log line and in an exception
+# a user can see, so a newline in it would forge a second log entry.
+_MAX_PROVIDER_TEXT = 500
+
+
+def _one_line(value) -> str | None:
+    if value is None:
+        return None
+    return str(value)[:_MAX_PROVIDER_TEXT].replace("\r", "\\r").replace("\n", "\\n")
+
+
+class ChatDashScope(ChatOpenAI):
+    """ChatOpenAI under a DashScope name, carrying no request-side behavior.
+
+    DashScope accepts the standard Responses payload, and replaying a prior
+    turn's reasoning item back to it round-trips, so there is nothing to
+    override yet. The subclass earns its place by giving the route a name: the
+    manifest's ``sdk`` says DashScope, the factory hands back a class that says
+    DashScope, and anything provider-specific that shows up later has a home
+    that is not an ``if`` in the shared OpenAI path. It does not scope the
+    bridge below, which is process-wide.
+    """
+
+
+class ResponsesStreamFailedError(RuntimeError):
+    """A Responses stream ended in ``response.failed``, quoting the provider.
+
+    ``status_code`` is what the adapter concluded the failure is, and it is
+    read ahead of the message: ``src.llms.error_classification`` prefers this
+    attribute and only falls back to regex-matching a bare 4xx/5xx out of the
+    text. Leaving it ``None`` is therefore how an adapter says "I do not know",
+    which restores exactly that older guess rather than asserting a wrong one.
+    """
+
+    # Reported inside an established stream, so the model-resilience middleware
+    # skips the reasoning-strip escalation: that repair answers a request being
+    # rejected before it runs, which by definition is not what happened here.
+    mid_stream = True
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+
+
+# Message tokens that make a coarse ``server_error`` permanent. DashScope
+# reports an input-filter block with the same code it uses for real transient
+# faults, so the code alone would send a turn through the full retry ladder for
+# a verdict that will never change.
+_TERMINAL_SERVER_ERROR_TOKENS = ("DataInspectionFailed",)
+
+
+def _status_for(code: str | None, message: str) -> int | None:
+    """What a DashScope failure code means, as an HTTP status, or None if unknown.
+
+    Neither field decides this alone: the code says ``server_error`` for a
+    permanent content block, and the message carries no status at all for an
+    unsupported model. Returning None leaves the older message-regex guess in
+    place, so an unrecognised code behaves exactly as it did before.
+    """
+    if code == "InvalidParameter":
+        return 400
+    if code == "server_error":
+        if any(token in message for token in _TERMINAL_SERVER_ERROR_TOKENS):
+            return 400
+        return None
+    # Not observed from this provider, but a rate limit must never be decided by
+    # a number that happens to sit in its own message ("quota is 400 tokens").
+    if code == "rate_limit_exceeded":
+        return 429
+    return None
+
+
+def _install_responses_stream_bridge() -> None:
+    """Rescue the two event families langchain-openai's Responses converter drops.
+
+    The hook is a module global, so this is process-wide and keyed on event
+    type rather than on provider: any Responses backend that emits these two
+    frames gets the same treatment, which is what makes it a fix to the
+    converter's blind spot rather than a DashScope special case. One installer
+    wrapping it once, not two, since a second would stack in import order and
+    collide on the idempotence flag.
+    """
+    try:
+        import langchain_openai.chat_models.base as base
+        from openai.types.responses import ResponseReasoningSummaryTextDeltaEvent
+
+        original_fn = base._convert_responses_chunk_to_generation_chunk
+    except (ImportError, AttributeError):
+        # langchain_openai internals moved. Degrade to no bridge rather than
+        # breaking module import, which would take down all of DashScope.
+        logger.warning(
+            "Responses stream bridge not installed: "
+            "langchain_openai._convert_responses_chunk_to_generation_chunk is gone; "
+            "Qwen turns will stream without reasoning and fail without a reason"
+        )
+        return
+
+    if getattr(original_fn, "_is_patched", False):
+        return
+
+    _warned_unbridgeable = False
+
+    def _as_summary_delta(chunk):
+        """Rewrite a raw-reasoning delta as the summary event upstream understands.
+
+        Translating the event rather than the output is what keeps this from
+        rotting: block shape, index bookkeeping and the v0 downgrade all stay
+        upstream's. ``content_index`` becomes ``summary_index`` because both
+        number the thought section, which the SSE layer reads to space sections
+        apart. The ``done`` event is deliberately still dropped, since the
+        deltas already aggregate to the same text.
+        """
+        try:
+            return ResponseReasoningSummaryTextDeltaEvent(
+                type="response.reasoning_summary_text.delta",
+                delta=chunk.delta,
+                item_id=chunk.item_id,
+                output_index=chunk.output_index,
+                summary_index=chunk.content_index,
+                sequence_number=chunk.sequence_number,
+            )
+        except Exception as e:
+            # A shape we cannot translate is still better delivered as the
+            # original chunk, which upstream drops, than as a dead turn. Warn
+            # once: this fires per reasoning token, so a drifted shape would
+            # otherwise write one record per token of every thought.
+            nonlocal _warned_unbridgeable
+            if not _warned_unbridgeable:
+                _warned_unbridgeable = True
+                logger.warning("Could not bridge a reasoning delta: %s", e)
+            return chunk
+
+    def _raise_if_failed(chunk) -> None:
+        """Surface a mid-stream failure that both layers below us let through.
+
+        The OpenAI SDK only raises for a top-level ``error`` key, and
+        ``response.failed`` nests its own at ``response.error``, so the frame
+        arrives here intact and langchain then discards it. The event type is
+        the whole signal and a missing ``error`` payload does not soften it:
+        returning here would hand back whatever the stream had already
+        accumulated as a successful generation, which for an agent turn can be
+        a tool call it then executes.
+        """
+        error = getattr(getattr(chunk, "response", None), "error", None)
+        code = _one_line(getattr(error, "code", None))
+        message = _one_line(getattr(error, "message", None)) or "no reason given"
+        logger.warning("Responses stream failed: %s: %s", code, message)
+        raise ResponsesStreamFailedError(
+            f"Responses stream failed ({code}): {message}",
+            code=code,
+            status_code=_status_for(code, message),
+        )
+
+    def _patched(chunk, *args, **kwargs):
+        chunk_type = getattr(chunk, "type", None)
+        if chunk_type == "response.reasoning_text.delta":
+            chunk = _as_summary_delta(chunk)
+        elif chunk_type == "response.failed":
+            _raise_if_failed(chunk)
+
+        return original_fn(chunk, *args, **kwargs)
+
+    _patched._is_patched = True
+    base._convert_responses_chunk_to_generation_chunk = _patched
+    logger.debug("Bridged the raw-reasoning and response.failed events upstream drops")

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -477,7 +477,7 @@ class LLM:
             if spec.use_response_api_override is None
             else spec.use_response_api_override
         )
-        self.use_response_api = bool(response_api) and self.sdk in ("openai", "codex")
+        self.use_response_api = bool(response_api) and self.sdk in ("openai", "codex", "dashscope")
         self.use_previous_response_id = self.provider_info.get("use_previous_response_id", False) if self.sdk == "openai" else False
         # prompt_cache_key: opt-in for sdk="openai"; codex applies it always-on.
         self.prompt_cache_key_enabled = (
@@ -574,6 +574,8 @@ class LLM:
             client = self._get_openai_llm(cache_key=effective_cache_key)
         elif self.sdk == "codex":
             client = self._get_codex_llm(cache_key=effective_cache_key)
+        elif self.sdk == "dashscope":
+            client = self._get_dashscope_llm(cache_key=effective_cache_key)
         elif self.sdk == "deepseek":
             client = self._get_deepseek_llm()
         elif self.sdk == "glm":
@@ -677,8 +679,12 @@ class LLM:
             url = url.replace("{HOST_IP}", HOST_IP)
         return {param_name: url}
 
-    def _get_openai_llm(self, cache_key: str | None = None):
-        """Get OpenAI or OpenAI-compatible LLM."""
+    def _build_openai_params(self, cache_key: str | None = None) -> dict:
+        """Build the constructor kwargs every OpenAI-SDK chat client shares.
+
+        Split out so a provider that needs its own ChatOpenAI subclass differs
+        by the class alone, not by a second copy of this that drifts.
+        """
         params = {
             "model": self.model,
             "api_key": self._resolve_api_key(),
@@ -722,7 +728,17 @@ class LLM:
             existing_mk = params.get("model_kwargs") or {}
             params["model_kwargs"] = {**existing_mk, "prompt_cache_key": cache_key}
 
-        return ChatOpenAI(**params)
+        return params
+
+    def _get_openai_llm(self, cache_key: str | None = None):
+        """Get OpenAI or OpenAI-compatible LLM."""
+        return ChatOpenAI(**self._build_openai_params(cache_key))
+
+    def _get_dashscope_llm(self, cache_key: str | None = None):
+        """Get DashScope (Qwen) LLM via ``ChatDashScope`` (streamed reasoning bridge)."""
+        from src.llms.extension import ChatDashScope
+
+        return ChatDashScope(**self._build_openai_params(cache_key))
 
     def _get_codex_llm(self, cache_key: str | None = None):
         """Get Codex OAuth LLM (store=false, stateless)."""

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -948,7 +948,7 @@
       "display_name": "DashScope (Qwen)",
       "variants": {
         "dashscope": {
-          "sdk": "openai",
+          "sdk": "dashscope",
           "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
           "use_response_api": true,
           "default_headers": {
@@ -956,7 +956,7 @@
           }
         },
         "dashscope-intl": {
-          "sdk": "openai",
+          "sdk": "dashscope",
           "base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
           "env_key": "DASHSCOPE_API_KEY_INT",
           "use_response_api": true,

--- a/src/ptc_agent/agent/middleware/model_resilience.py
+++ b/src/ptc_agent/agent/middleware/model_resilience.py
@@ -29,7 +29,11 @@ from langchain.agents.middleware.types import (
     ModelResponse,
 )
 
-from src.llms.error_classification import extract_status_code, is_retryable_error
+from src.llms.error_classification import (
+    extract_status_code,
+    is_mid_stream_error,
+    is_retryable_error,
+)
 from src.llms.reasoning_payload import strip_all_reasoning
 
 if TYPE_CHECKING:
@@ -273,21 +277,29 @@ class ModelResilienceMiddleware(AgentMiddleware):
     def _decide(
         self, exc: Exception, attempts: int, req: ModelRequest, *, escalated: bool
     ) -> tuple[int | None, _Recovery | None]:
-        """What to do about a failed attempt — shared by the sync and async loops.
+        """What to do about a failed attempt, shared by the sync and async loops.
 
         ``None`` means give up on this candidate. A reasoning-payload 400 is the
         one non-retryable status worth another call: the provider rejected the
         history's reasoning blocks, and the same request without them can
-        succeed. Detected structurally — a 400 plus "we did send reasoning" —
+        succeed. Detected structurally, a 400 plus "we did send reasoning",
         rather than by matching provider error prose, which drifts between API
         versions and fails silently when it does. The cost is one wasted call
         when an unrelated 400 coincides with reasoning in history, on a turn that
         is already failing anyway.
+
+        A mid-stream failure is excluded because that repair cannot apply to it.
+        Stripping reasoning answers a request rejected during validation, before
+        it ran; a provider that accepted the request, opened the stream and only
+        then reported failure has already judged the payload fine, and re-sending
+        bills the tokens it emitted a second time. Content rejected by an input
+        filter is the case that made this concrete: every attempt is refused
+        identically, so the call is pure latency before the fallback that works.
         """
         status, retryable = self._classify(exc)
         if retryable and attempts <= self.max_retries:
             return status, _Recovery(delay=self._calculate_delay(attempts - 1))
-        if not escalated and status == 400:
+        if not escalated and status == 400 and not is_mid_stream_error(exc):
             stripped = self._escalate_reasoning(req)
             if stripped is not None:
                 return status, _Recovery(request=stripped)

--- a/src/server/services/llm/clients.py
+++ b/src/server/services/llm/clients.py
@@ -143,6 +143,13 @@ async def _walk_byok_candidates(
     return None, None
 
 
+# SDKs that speak the OpenAI wire shape, so the ``"openai"`` a custom provider
+# derives by default already reaches them. A parent on this list is skipped by
+# ``_inherit_custom_provider_sdk`` below; anything added here must be routable
+# by a plain ``ChatOpenAI`` against a third-party gateway.
+_OPENAI_SHAPED_SDKS = (None, "openai", "dashscope")
+
+
 def _inherit_custom_provider_sdk(custom_config, parent_provider, provider_def, mc):
     """Make a custom provider inherit its manifest parent's SDK/headers (#221).
 
@@ -152,14 +159,14 @@ def _inherit_custom_provider_sdk(custom_config, parent_provider, provider_def, m
     (``/chat/completions`` vs ``/v1/messages``). Rewriting ``provider`` to the
     manifest parent fixes the SDK and ``default_headers``.
 
-    Skip the rewrite for openai parents: the default already yields
-    ``sdk="openai"``, and inheriting the manifest openai entry would force
-    ``use_response_api`` / ``prompt_cache_key`` onto OpenAI-compatible gateways
-    (vLLM/LiteLLM/OpenRouter) that only speak ``/chat/completions``. The custom
-    provider's own ``use_response_api`` opt-in is honoured either way.
+    Skip the rewrite for OpenAI-shaped parents: the default already reaches
+    them, and inheriting the manifest entry would force ``use_response_api`` /
+    ``prompt_cache_key`` onto OpenAI-compatible gateways (vLLM/LiteLLM/
+    OpenRouter) that only speak ``/chat/completions``. The custom provider's own
+    ``use_response_api`` opt-in is honoured either way.
     """
     updates: dict = {}
-    if mc.get_provider_info(parent_provider).get("sdk") not in (None, "openai"):
+    if mc.get_provider_info(parent_provider).get("sdk") not in _OPENAI_SHAPED_SDKS:
         updates["provider"] = parent_provider
     if provider_def.get("use_response_api"):
         updates["_use_response_api"] = True

--- a/src/server/services/runs/sse_producer.py
+++ b/src/server/services/runs/sse_producer.py
@@ -176,6 +176,9 @@ _UPSTREAM_MODULE_PREFIXES: tuple[str, ...] = (
     "google.generativeai",
     "cohere",
     "httpx",
+    # Our own wrappers around a provider stream. They quote the provider and
+    # are raised fresh rather than chained, so nothing below would match them.
+    "src.llms.extension",
     # LangChain wrappers — their exceptions may not chain through the raw SDK
     # when the wrapper normalizes errors, so match them directly.
     "langchain_openai",

--- a/tests/unit/llms/test_error_classification.py
+++ b/tests/unit/llms/test_error_classification.py
@@ -89,3 +89,65 @@ class TestIsRetryableError:
         # must not matter.
         exc = Exception("Error code: 500")
         assert is_retryable_error(exc, status_code=400) is False
+
+
+class TestDashScopeFailureStatus:
+    """The adapter's verdict, and the message-regex it is there to pre-empt.
+
+    Every payload below is verbatim from the live provider. Two fields are
+    needed to read them: the code says ``server_error`` for a permanent content
+    block, and the message carries no status at all for an unsupported model.
+    """
+
+    LIVE_TERMINAL = [
+        (
+            "server_error",
+            "<400> InternalError.Algo.DataInspectionFailed: Input text data "
+            "may contain inappropriate content.",
+        ),
+        ("InvalidParameter", "Unsupported model: 'qwen-does-not-exist'"),
+        (
+            "InvalidParameter",
+            "<400> InternalError.Algo.InvalidParameter: The provided URL does "
+            "not appear to be valid.",
+        ),
+    ]
+
+    @staticmethod
+    def _error(code, message):
+        from src.llms.extension.dashscope import ResponsesStreamFailedError, _status_for
+
+        return ResponsesStreamFailedError(
+            f"Responses stream failed ({code}): {message}",
+            code=code,
+            status_code=_status_for(code, message),
+        )
+
+    @pytest.mark.parametrize("code,message", LIVE_TERMINAL)
+    def test_live_terminal_failures_are_not_retried(self, code, message):
+        assert is_retryable_error(self._error(code, message)) is False
+
+    def test_unsupported_model_needs_the_code_not_the_message(self):
+        # The message has no status token, so the regex alone reads this as
+        # retryable and spends the full ladder on a model that cannot exist.
+        code, message = "InvalidParameter", "Unsupported model: 'qwen-does-not-exist'"
+        assert extract_status_code(Exception(message)) is None
+        assert extract_status_code(self._error(code, message)) == 400
+
+    def test_rate_limit_is_not_decided_by_a_number_in_its_own_message(self):
+        exc = self._error("rate_limit_exceeded", "Request quota is 400 tokens per minute")
+        assert extract_status_code(exc) == 429
+        assert is_retryable_error(exc) is True
+
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            ("server_error", "upstream temporarily unavailable"),
+            ("SomethingUnrecognised", "no digits here"),
+        ],
+    )
+    def test_unknown_verdict_falls_back_to_the_message(self, code, message):
+        # None means "I do not know", which must leave the older guess intact
+        # rather than assert a wrong status.
+        assert self._error(code, message).status_code is None
+        assert is_retryable_error(self._error(code, message)) is True

--- a/tests/unit/middleware/test_model_resilience.py
+++ b/tests/unit/middleware/test_model_resilience.py
@@ -445,6 +445,53 @@ class TestReasoningPayloadEscalation:
         assert seen[1] == ["text"]
 
     @pytest.mark.asyncio
+    async def test_mid_stream_400_never_escalates(self, events):
+        """A failure reported inside an open stream skips the reasoning repair.
+
+        The repair answers a request rejected during validation. A provider that
+        accepted the request, opened the stream and only then reported failure
+        has already judged the payload fine, so the extra call is pure latency
+        before the fallback, and re-sending bills whatever the stream emitted a
+        second time. DashScope reporting an input-filter block as
+        ``response.failed`` over HTTP 200 is the case this was measured on.
+        """
+        from src.llms.extension import ResponsesStreamFailedError
+
+        # Verbatim from the live provider: the structured code says
+        # ``server_error`` even though the block is permanent, and only the
+        # message names the real cause. Do not "correct" the code to match the
+        # message.
+        exc = ResponsesStreamFailedError(
+            "Responses stream failed (server_error): <400> "
+            "InternalError.Algo.DataInspectionFailed: Input text data may "
+            "contain inappropriate content.",
+            code="server_error",
+        )
+        client = _FakeModel("primary-model", thinking={"type": "enabled"})
+        mw = _make_middleware(client, fallbacks=[("fallback-model", _FakeModel("fallback-model"))])
+        calls = []
+
+        async def handler(req):
+            calls.append(self._block_types(req))
+            if len(calls) == 1:
+                raise exc
+            return "ok"
+
+        result = await mw.awrap_model_call(
+            _FakeRequest(client, self._history()), handler
+        )
+        assert result == "ok"
+        # Two calls either way, so the count alone proves nothing: an escalation
+        # would also answer on its second call. What separates them is which
+        # call it is. The fallback re-sends the history intact; a stripped retry
+        # would arrive here with the thinking block removed.
+        assert len(calls) == 2, calls
+        assert "thinking" in calls[0]
+        assert "thinking" in calls[1], calls
+        assert [p["to_model"] for p in _fallback_props(events)] == ["fallback-model"]
+        assert [e["type"] for e in events if e["type"] == "model_retry"] == []
+
+    @pytest.mark.asyncio
     async def test_escalates_at_most_once_per_candidate(self, events):
         client = _FakeModel("primary-model")
         fallback = _FakeModel("fallback-a")

--- a/tests/unit/server/handlers/chat/test_custom_provider_sdk_inheritance.py
+++ b/tests/unit/server/handlers/chat/test_custom_provider_sdk_inheritance.py
@@ -97,6 +97,28 @@ async def test_openai_parent_does_not_rewrite_or_force_response_api():
 
 
 @pytest.mark.asyncio
+async def test_dashscope_parent_does_not_rewrite_or_force_response_api():
+    """A DashScope parent is OpenAI-shaped, so it gets the gateway treatment too.
+
+    DashScope's manifest entry declares ``sdk: "dashscope"`` to route built-in
+    Qwen models at their own client, but a custom provider under that parent is
+    still someone's own endpoint. Rewriting it would inherit the manifest's
+    ``use_response_api`` and session-cache header, putting a gateway that only
+    speaks ``/chat/completions`` onto ``/responses`` with no way to opt out.
+    """
+    provider_def = {"name": "my-qwen-gw", "parent_provider": "vendor-parent"}
+    custom_model = {"name": "eval-model", "model_id": "some-model", "provider": "my-qwen-gw"}
+    mc = _mock_mc("dashscope", parent_extra={"use_response_api": True})
+
+    p1, p2, p3 = _patches(provider_def)
+    with p1, p2, p3:
+        byok, base_url, out = await _resolve_custom_model_byok("u", "eval-model", dict(custom_model), mc)
+
+    assert out["provider"] == "my-qwen-gw"
+    assert "_use_response_api" not in out
+
+
+@pytest.mark.asyncio
 async def test_custom_provider_explicit_use_response_api_opt_in_preserved():
     """A custom provider that explicitly opts into the Responses API still gets
     the ``_use_response_api`` flag, regardless of parent SDK."""

--- a/web/src/components/model/types.ts
+++ b/web/src/components/model/types.ts
@@ -15,7 +15,7 @@ export interface ByokProvider {
   use_response_api?: boolean;
 }
 
-export type SdkType = 'openai' | 'anthropic' | 'gemini' | 'codex' | 'deepseek' | 'qwq';
+export type SdkType = 'openai' | 'anthropic' | 'gemini' | 'codex' | 'deepseek' | 'qwq' | 'dashscope';
 
 export interface RegionVariant {
   provider: string;

--- a/web/src/pages/Setup/steps/connectStep/shared.tsx
+++ b/web/src/pages/Setup/steps/connectStep/shared.tsx
@@ -47,6 +47,7 @@ export function getApiFormatKey(sdk?: string | null, useResponseApi?: boolean): 
     case 'gemini':
       return 'setup.apiFormatGemini';
     case 'openai':
+    case 'dashscope':
       return useResponseApi ? 'setup.apiFormatOpenaiResponses' : 'setup.apiFormatOpenaiCompletions';
     case 'codex':
       return 'setup.apiFormatCodex';


### PR DESCRIPTION
## Summary

Qwen turns on DashScope streamed no reasoning, and when the provider killed a stream they reported no error either. Both come from one blind spot in langchain-openai's Responses converter: its final `else` silently discards any event family it has no branch for. `response.reasoning_text.*` carries the thinking tokens and `response.failed` carries the reason a stream died, and both land there.

This gives DashScope its own `dashscope` SDK route with a `ChatDashScope` client and a bridge that rescues both event families, then makes the failure that now surfaces classify correctly instead of being retried three times.

## Overview

**What this introduces**

- Qwen reasoning reaches the UI instead of being dropped between the provider and the stream.
- A stream the provider kills now raises instead of returning a partial success. For an agent turn that partial could be a tool call the agent then executes.
- A permanent DashScope failure (input-filter block, unsupported model) falls straight through to the fallback model instead of burning three full-prompt retries first.

**Totals**

| | files | + | - |
|---|---|---|---|
| All | 14 | 396 | 18 |
| Net (excl. tests) | 11 | 265 | 18 |
| Tests | 3 | 131 | 0 |
| New files | 1 | 188 | 0 |

**By module**

*Backend, LLM layer*
- `src/llms/extension/dashscope.py` **(new, +188)**: `ChatDashScope`, `ResponsesStreamFailedError`, `_status_for`, and the converter bridge.
- `src/llms/__init__.py` (+5): installs the bridge at package import.
- `src/llms/llm.py` (+20/-4): `_build_openai_params` extracted out of `_get_openai_llm`; `dashscope` added to the response-API check and the client factory.
- `src/llms/manifest/providers.json` (+2/-2): both DashScope variants move `sdk` from `openai` to `dashscope`.
- `src/llms/extension/__init__.py` (+2/-1): exports.
- `src/llms/error_classification.py` (+14): `is_mid_stream_error`, duck-typed on a `mid_stream` attribute.

*Backend, agent and server*
- `src/ptc_agent/agent/middleware/model_resilience.py` (+16/-4): the reasoning-strip repair now skips mid-stream failures.
- `src/server/services/llm/clients.py` (+13/-6): `_OPENAI_SHAPED_SDKS`, so a custom provider parented to DashScope keeps its own routing.
- `src/server/services/runs/sse_producer.py` (+3): `src.llms.extension` counted as an upstream module prefix.

*Frontend*
- `web/src/components/model/types.ts`, `web/src/pages/Setup/steps/connectStep/shared.tsx` (+2/-1): the connect wizard names the API format for the new `sdk` value instead of falling through to a blank.

*Tests*
- `tests/unit/llms/test_error_classification.py` (+62), `tests/unit/middleware/test_model_resilience.py` (+47), `tests/unit/server/handlers/chat/test_custom_provider_sdk_inheritance.py` (+22).

## Why this way

**Bridge the event, not the output.** A raw-reasoning delta is rewritten into the `reasoning_summary_text.delta` event upstream already understands, so block shape, index bookkeeping and the v0 downgrade all stay upstream's. Rewriting the output instead would fork all three and drift.

**The bridge is keyed on event type, not on provider.** It rewrites a module global, so it is process-wide by construction, and any Responses backend emitting these frames gets the same treatment. That makes it a fix to the converter's blind spot rather than a DashScope special case. It installs at `src/llms` import rather than at first client construction, because a lazy install would let two workers disagree about whether a stream reports its reasoning.

**`response.failed` raises unconditionally**, even when the frame carries no error payload. The event type is the whole signal, and returning would hand back whatever the stream had accumulated as a successful generation.

**Retryability reads both `code` and `message`, because neither decides alone.** Probing the provider directly:

| case | `code` | `message` |
|---|---|---|
| input-filter block | `server_error` | `<400> InternalError.Algo.DataInspectionFailed: ...` |
| unsupported model | `InvalidParameter` | `Unsupported model: '...'` |
| malformed image | `InvalidParameter` | `<400> InternalError.Algo.InvalidParameter: ...` |

The code lies: a permanent block reports the same `server_error` used for real transient faults. The message is incomplete: an unsupported model carries no status token at all, so the existing regex finds nothing and the turn stays retryable. Two failures sharing the `server_error` code take opposite verdicts, decided by whether the prose names `DataInspectionFailed`: the filter block is permanent, a genuine server fault is not.

`_status_for` returns `None` for anything it does not recognise, and `error_classification` only prefers `status_code` when it is an `int`. So an unrecognised code falls back to exactly the message-regex guess it used before, rather than asserting a wrong answer. This is the cheap first cut: a provider-specific rule that needs no change to the shared classifier.

**The mid-stream guard is duck-typed** on a `mid_stream` attribute rather than an exception class, so `error_classification` stays provider-agnostic and never has to match error prose. Stripping reasoning answers a request rejected during validation, before it ran. A provider that accepted the request, opened the stream and only then reported failure has already judged the payload fine.

## Verification

- **Live provider.** Probed DashScope directly for all three failure shapes above. Confirmed the pre-branch behavior (unsupported model gives status `None`, stays retryable, and burns three full-prompt retries) and that the branch ends it. Reasoning confirmed streaming end to end through the running backend. That end-to-end run predates the last round of review fixes; those are covered by unit tests and the container check below, not by a repeat live turn.
- **Backend suite:** 9724 passed, 23 skipped, 1 xfailed (594 deselected by the project's default scope). The one xfail-marked test, `test_delta_channel_ordering.py::test_fan_out_reconstruction_preserves_live_order`, xpassed on one earlier run of this branch and xfailed on the next two, which matches its own reason describing it as roughly 50/50 nondeterministic. It is untouched by this branch.
- **Frontend suite:** 3526 passed across 325 files, `tsc --noEmit` clean, eslint 0 errors (106 advisory warnings, not gated).
- **Gates:** `ruff check src/` clean, which is the project's lint target. The three touched test files are clean too; `tests/` is not gated and carries 63 pre-existing findings across 28 other files, untouched here.
- **Container:** backend restarts healthy with the bridge installed and the Qwen model resolving to `ChatDashScope`.
- **Bisect:** all three commits import cleanly and pass the affected unit subsets (1785, 1785, 1794 as the tests land).

## Risk and deferred

- If a provider ever emitted both raw-reasoning and summary-reasoning events for the same item, the two would share a `summary_index` and could collide. Not observed on DashScope, and the bridge only translates the raw family.
- A mid-stream failure still gets the normal retry budget, so a retried turn re-sends the whole prompt and spends the tokens the killed stream already emitted a second time. Changing that budget is a separate call, not part of this bug.
- `mid_stream` is read through the exception chain, so a wrapper chaining a mid-stream error under an unrelated 400 would also skip the reasoning-strip repair. That costs a lost optimization, not a failure.
- Replaying a prior turn's reasoning item back to the provider round-trips, verified by hand, not pinned by a test.
- The classifier covers the codes observed from this provider. Extending the same shape to other providers is deliberately left to a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791185067&installation_model_id=432753&pr_number=396&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F396&signature=a7b41e2b55b290376c3b6343d67b0c7f472c4e9f570f4e719f641e98b9b19980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for DashScope (Qwen) models, including Responses API streaming.
  - DashScope streams now display reasoning updates and surface provider failures with clearer error details.
  - Added DashScope as a selectable SDK and supported API format in setup and model configuration.
- **Bug Fixes**
  - Improved handling of mid-stream provider failures to avoid inappropriate retries or reasoning-payload changes.
  - Preserved custom provider settings when using DashScope-based configurations.
- **Tests**
  - Added coverage for DashScope failures, streaming behavior, resilience handling, and custom provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->