### PR TITLE
fix(workspace): name the workspace from its row, not from agent.md

### DIFF
--- a/src/ptc_agent/agent/agent.py
+++ b/src/ptc_agent/agent/agent.py
@@ -432,6 +432,8 @@ class PTCAgent:
         user_profile: dict | None = None,
         plan_mode: bool = False,
         thread_id: str | None = None,
+        workspace_name: str = "",
+        workspace_description: str = "",
         on_agent_md_write: Any | None = None,
         store: Any | None = None,
         on_signed_url: Any | None = None,
@@ -833,7 +835,13 @@ class PTCAgent:
         # Workspace context middleware (agent.md injection — main agent only)
         workspace_context_middleware: list[Any] = []
         if session is not None:
-            workspace_context_middleware = [WorkspaceContextMiddleware(session=session)]
+            workspace_context_middleware = [
+                WorkspaceContextMiddleware(
+                    session=session,
+                    name=workspace_name,
+                    description=workspace_description,
+                )
+            ]
 
         # Positioned after the prompt-cache breakpoint (innermost) so dynamic
         # content doesn't invalidate the cached prefix.

--- a/src/ptc_agent/agent/graph.py
+++ b/src/ptc_agent/agent/graph.py
@@ -126,6 +126,23 @@ class SessionProvider(Protocol):
         ...
 
 
+async def _read_workspace_naming(workspace_id: str) -> tuple[str, str]:
+    """The workspace's name and description for the prompt's `<workspace>` block.
+
+    Read once here rather than inside the model call, so the values are bound
+    when the turn's agent is built: the model never sees the name change under
+    it mid-answer, and a rename lands on the very next turn.
+    """
+    try:
+        from src.server.database.workspace import get_workspace_name_and_description
+
+        row = await get_workspace_name_and_description(workspace_id) or {}
+        return (row.get("name") or "").strip(), (row.get("description") or "").strip()
+    except Exception as e:
+        logger.warning(f"Failed to read the name of workspace {workspace_id}: {e}")
+        return "", ""
+
+
 async def build_ptc_graph(
     conversation_id: str,
     config: AgentConfig,
@@ -153,9 +170,10 @@ async def build_ptc_graph(
             f"Failed to initialize session for conversation {conversation_id}"
         )
 
-    ptc_agent, user_data_counts = await asyncio.gather(
+    ptc_agent, user_data_counts, (workspace_name, workspace_description) = await asyncio.gather(
         asyncio.to_thread(PTCAgent, config),
         fetch_user_data_counts(user_id),
+        _read_workspace_naming(conversation_id),
     )
 
     inner_agent = ptc_agent.create_agent(
@@ -167,6 +185,8 @@ async def build_ptc_graph(
         background_registry=background_registry,
         # session gives workspace-tier memory a real namespace.
         session=session,
+        workspace_name=workspace_name,
+        workspace_description=workspace_description,
         store=store,
         on_signed_url=on_signed_url,
         user_id=user_id,
@@ -208,17 +228,26 @@ async def build_ptc_graph_with_session(
         )
 
     if user_id:
-        user_profile, user_data_counts, ptc_agent = await asyncio.gather(
+        (
+            user_profile,
+            user_data_counts,
+            ptc_agent,
+            (workspace_name, workspace_description),
+        ) = await asyncio.gather(
             get_user_profile_for_prompt(user_id),
             fetch_user_data_counts(user_id),
             asyncio.to_thread(PTCAgent, config),
+            _read_workspace_naming(workspace_id),
         )
         if user_profile:
             logger.debug(f"Loaded user profile for {user_id}: {user_profile}")
     else:
         user_profile = None
         user_data_counts = None
-        ptc_agent = await asyncio.to_thread(PTCAgent, config)
+        ptc_agent, (workspace_name, workspace_description) = await asyncio.gather(
+            asyncio.to_thread(PTCAgent, config),
+            _read_workspace_naming(workspace_id),
+        )
 
     vault_secrets = getattr(session.sandbox, "vault_secrets", None)
 
@@ -235,6 +264,8 @@ async def build_ptc_graph_with_session(
         plan_mode=plan_mode,
         session=session,
         thread_id=thread_id,
+        workspace_name=workspace_name,
+        workspace_description=workspace_description,
         on_agent_md_write=session.invalidate_agent_md,
         store=store,
         on_signed_url=on_signed_url,

--- a/src/ptc_agent/agent/middleware/file_operations/sse_middleware.py
+++ b/src/ptc_agent/agent/middleware/file_operations/sse_middleware.py
@@ -31,6 +31,8 @@ from langchain.agents.middleware import AgentMiddleware, AgentState
 from typing_extensions import NotRequired
 from langgraph.config import get_stream_writer
 
+from ptc_agent.core.paths import workspace_relative_path
+
 logger = logging.getLogger(__name__)
 
 
@@ -66,7 +68,7 @@ class FileOperationMiddleware(AgentMiddleware):
     ) -> None:
         super().__init__()
         self._on_agent_md_write = on_agent_md_write
-        self._work_dir_prefix = work_dir.rstrip("/") + "/"
+        self._work_dir = work_dir
 
     @staticmethod
     def _count_lines(text: str) -> int:
@@ -122,12 +124,7 @@ class FileOperationMiddleware(AgentMiddleware):
         try:
             result = await handler(request)
 
-            # removeprefix (not lstrip) — lstrip eats a leading "." from paths
-            # like ".agents/user/memory/memory.md".
-            normalized = file_path or ""
-            if normalized.startswith(self._work_dir_prefix):
-                normalized = normalized[len(self._work_dir_prefix):]
-            normalized = normalized.removeprefix("./")
+            normalized = workspace_relative_path(file_path, self._work_dir)
 
             # Invalidate agent.md cache when agent.md is written or edited
             if self._on_agent_md_write and normalized == "agent.md":

--- a/src/ptc_agent/agent/middleware/image_capture.py
+++ b/src/ptc_agent/agent/middleware/image_capture.py
@@ -41,15 +41,12 @@ IMAGE_MD_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 _CAPTURE_TIMEOUT_SECONDS = 30.0
 
 
-def is_sandbox_image_path(path: str, work_dir: str = "/home/workspace") -> bool:
+def is_sandbox_image_path(path: str) -> bool:
     """Check if path is a sandbox-relative image (not an external URL)."""
     if path.startswith(("http://", "https://", "//", "data:")):
         return False
-    work_dir_prefix = work_dir.rstrip("/") + "/"
-    normalized = (
-        path.replace(work_dir_prefix, "") if path.startswith(work_dir_prefix) else path
-    )
-    ext = normalized.rsplit(".", 1)[-1].lower() if "." in normalized else ""
+    basename = path.rsplit("/", 1)[-1]
+    ext = basename.rsplit(".", 1)[-1].lower() if "." in basename else ""
     return ext in IMAGE_EXTS
 
 
@@ -66,22 +63,20 @@ async def capture_sandbox_images(
 
     Per-path captures run concurrently; each failure is logged and simply
     absent from the returned map (callers leave unmapped paths untouched).
+
+    Paths go to ``normalize_path`` exactly as the agent wrote them: it already
+    resolves every spelling, and it is the only thing that knows an absolute
+    path may name an allowed root outside the work dir (``/tmp``, matplotlib's
+    default savefig target). Folding to a work-dir-relative form first would
+    re-root those under the work dir and the image would vanish.
     """
-    work_dir_prefix = sandbox.working_dir.rstrip("/") + "/"
 
     async def _capture_one(path: str) -> tuple[str, str] | None:
         try:
-            normalized = (
-                path.replace(work_dir_prefix, "")
-                if path.startswith(work_dir_prefix)
-                else path
-            )
-            content = await sandbox.adownload_file_bytes(
-                sandbox.normalize_path(normalized)
-            )
+            content = await sandbox.adownload_file_bytes(sandbox.normalize_path(path))
             if not content:
                 return None
-            basename = normalized.rsplit("/", 1)[-1]
+            basename = path.rsplit("/", 1)[-1]
             key = image_storage_key(
                 thread_id, hashlib.sha256(content).hexdigest(), basename
             )
@@ -110,11 +105,11 @@ def rewrite_image_paths(text: str, url_map: dict[str, str]) -> str:
     return IMAGE_MD_RE.sub(replacer, text)
 
 
-def _collect_sandbox_paths(messages: list[Any], work_dir: str) -> set[str]:
+def _collect_sandbox_paths(messages: list[Any]) -> set[str]:
     paths: set[str] = set()
     for text in _iter_text_segments(messages):
         for match in IMAGE_MD_RE.finditer(text):
-            if is_sandbox_image_path(match.group(2), work_dir):
+            if is_sandbox_image_path(match.group(2)):
                 paths.add(match.group(2))
     return paths
 
@@ -202,7 +197,7 @@ class ImageCaptureMiddleware(AgentMiddleware):
         sandbox = getattr(self._session, "sandbox", None)
         if sandbox is None or not is_storage_enabled():
             return None
-        paths = _collect_sandbox_paths(messages, sandbox.working_dir)
+        paths = _collect_sandbox_paths(messages)
         if not paths:
             return None
 

--- a/src/ptc_agent/agent/middleware/workspace_context.py
+++ b/src/ptc_agent/agent/middleware/workspace_context.py
@@ -1,17 +1,17 @@
-"""Middleware for dynamically injecting workspace context (agent.md) into system prompt.
+"""Injects the workspace's identity and its agent.md into the system prompt.
 
-Reads agent.md from the sandbox on every model call, ensuring the agent always
-sees the latest workspace context — even after it creates or updates agent.md
-mid-conversation. The content is appended as the last content block in the
-system message, after skills and all other injections.
+The name and description are read when the turn's agent is built and held for
+that turn, so what the model is told is what the user last set. agent.md is read
+from the sandbox on every model call, so an edit the agent makes mid-conversation
+is visible to the call after it.
 
-When the YAML front matter in agent.md changes (e.g. agent updates
-workspace_name or description), the middleware syncs those changes back to
-the workspace record in the database.
+Both blocks land after the prompt-cache breakpoint (whichever of the provider
+caching middlewares is live pins the static prefix earlier in the stack), so
+neither costs a cache miss when it changes.
 """
 
-import asyncio
 from collections.abc import Awaitable, Callable
+from html import escape
 from typing import Any
 
 import structlog
@@ -22,29 +22,14 @@ logger = structlog.get_logger(__name__)
 
 MAX_AGENT_MD_SIZE = 8192
 
-
-def _parse_yaml_front_matter(content: str) -> dict[str, str] | None:
-    """Extract YAML front matter from markdown content.
-
-    Returns a dict of key-value pairs, or None if no front matter found.
-    Only handles simple `key: value` lines (no nested structures).
-    """
-    if not content.startswith("---\n"):
-        return None
-    end = content.find("\n---", 3)
-    if end == -1:
-        return None
-    # Start after first newline (handles "---\n" = 4 chars)
-    start = content.index("\n") + 1
-    block = content[start:end]
-    result = {}
-    for line in block.splitlines():
-        line = line.strip()
-        if not line or ":" not in line:
-            continue
-        key, _, value = line.partition(":")
-        result[key.strip()] = value.strip()
-    return result
+_NO_AGENT_MD_BLOCK = (
+    '<agentmd path="/agent.md">\n'
+    "No agent.md exists yet. Create /agent.md at the workspace root with:\n"
+    "- Workspace purpose based on the user's query\n"
+    "- Initial goals and planned artifacts\n"
+    "- Section stubs for Thread Index, Key Findings, File Index\n"
+    "</agentmd>"
+)
 
 
 def _append_content_block(system_message: SystemMessage | None, text: str) -> SystemMessage:
@@ -58,88 +43,42 @@ def _append_content_block(system_message: SystemMessage | None, text: str) -> Sy
 
 
 class WorkspaceContextMiddleware(AgentMiddleware):
-    """Dynamically injects agent.md content into the system prompt on every model call.
-
-    This ensures:
-    1. agent.md is always the LAST content block (after skills)
-    2. Changes to agent.md mid-conversation are reflected immediately
-    3. YAML front matter changes are synced back to the workspace DB
+    """Injects the workspace block and agent.md on every model call.
 
     Args:
         session: The Session object (has get_agent_md() with caching/invalidation).
+        name: The workspace's name, as its row had it when this agent was built.
+        description: The workspace's description, from the same read.
     """
 
-    def __init__(self, *, session: Any) -> None:
+    def __init__(self, *, session: Any, name: str = "", description: str = "") -> None:
         self._session = session
-        # Cache last-seen front matter to detect changes
-        self._last_front_matter: dict[str, str] | None = None
+        self._name = (name or "").strip()
+        self._description = (description or "").strip()
 
-    @property
-    def _workspace_id(self) -> str | None:
-        return getattr(self._session, "conversation_id", None)
+    def _workspace_block(self) -> str:
+        """What the workspace is called, as element text.
 
-    async def _sync_front_matter_to_db(
-        self, front_matter: dict[str, str], *, prev: dict[str, str] | None = None
-    ) -> None:
-        """Sync changed YAML front matter fields back to the workspace DB record."""
-        if not self._workspace_id:
-            return
+        Text rather than attributes: a name is free text the user typed, and as
+        text an escape of `<` and `&` is the whole obligation — no quoting rule
+        to get wrong, and an apostrophe survives as an apostrophe.
+        """
+        if not self._name:
+            return ""
+        lines = [f"Name: {escape(self._name, quote=False)}"]
+        if self._description:
+            lines.append(f"Description: {escape(self._description, quote=False)}")
+        body = "\n".join(lines)
+        return f"<workspace>\n{body}\n</workspace>"
 
-        updates: dict[str, str] = {}
-        prev = prev or {}
-
-        for key, db_field in (
-            ("workspace_name", "name"),
-            ("description", "description"),
-        ):
-            new_val = front_matter.get(key, "")
-            old_val = prev.get(key, "")
-            if new_val and new_val != old_val:
-                updates[db_field] = new_val
-
-        if not updates:
-            return
-
-        try:
-            from src.server.database.workspace import update_workspace
-
-            await update_workspace(workspace_id=self._workspace_id, **updates)
-            logger.debug(
-                "Synced agent.md front matter to workspace DB",
-                workspace_id=self._workspace_id,
-                updates=list(updates.keys()),
-            )
-        except Exception as e:
-            logger.warning(
-                "Failed to sync agent.md front matter to DB",
-                workspace_id=self._workspace_id,
-                error=str(e),
-            )
-
-    async def _get_workspace_context_block(self) -> str:
+    async def _get_agent_md_block(self) -> str:
         """Build the workspace context block from agent.md."""
-        agent_md = await self._session.get_agent_md()
-        if agent_md:
-            # Check for front matter changes and sync to DB
-            front_matter = _parse_yaml_front_matter(agent_md)
-            if front_matter is not None and front_matter != self._last_front_matter:
-                # Capture prev before overwriting — task runs async after this line
-                prev = self._last_front_matter
-                self._last_front_matter = front_matter
-                # Fire-and-forget — don't block the model call
-                asyncio.create_task(self._sync_front_matter_to_db(front_matter, prev=prev))
-
-            if len(agent_md) > MAX_AGENT_MD_SIZE:
-                agent_md = agent_md[:MAX_AGENT_MD_SIZE] + "\n\n[... truncated ...]"
-            return f'<agentmd path="/agent.md">\n{agent_md}\n</agentmd>'
-        return (
-            '<agentmd path="/agent.md">\n'
-            "No agent.md exists yet. Create /agent.md at the workspace root with:\n"
-            "- Workspace purpose based on the user's query\n"
-            "- Initial goals and planned artifacts\n"
-            "- Section stubs for Thread Index, Key Findings, File Index\n"
-            "</agentmd>"
-        )
+        content = await self._session.get_agent_md()
+        if not content:
+            return _NO_AGENT_MD_BLOCK
+        if len(content) > MAX_AGENT_MD_SIZE:
+            content = content[:MAX_AGENT_MD_SIZE] + "\n\n[... truncated ...]"
+        return f'<agentmd path="/agent.md">\n{content}\n</agentmd>'
 
     def wrap_model_call(
         self,
@@ -154,8 +93,10 @@ class WorkspaceContextMiddleware(AgentMiddleware):
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        """Inject latest agent.md into system message before each model call."""
-        context_block = await self._get_workspace_context_block()
-        new_system_message = _append_content_block(request.system_message, context_block)
+        """Inject the workspace block and the latest agent.md before each call."""
+        workspace = self._workspace_block()
+        agent_md = await self._get_agent_md_block()
+        blocks = "\n\n".join(b for b in (workspace, agent_md) if b)
+        new_system_message = _append_content_block(request.system_message, blocks)
         modified_request = request.override(system_message=new_system_message)
         return await handler(modified_request)

--- a/src/ptc_agent/agent/prompts/templates/components/workspace_context.md.j2
+++ b/src/ptc_agent/agent/prompts/templates/components/workspace_context.md.j2
@@ -2,6 +2,8 @@
 
 `agent.md` is your persistent notebook for this workspace — an index of work done here across threads. It is injected into every conversation automatically.
 
+The workspace's current name and description are in the `<workspace>` block, and that is the only place they are authoritative. Older notebooks may still open with a `---` header block or a title naming the workspace; both are stale leftovers, so trust the block and feel free to correct them as you work.
+
 Keep it under ~2000 words. Read the current content and merge before writing; never overwrite.
 {% if guidance | default("detailed") == "detailed" %}
 

--- a/src/ptc_agent/core/paths.py
+++ b/src/ptc_agent/core/paths.py
@@ -1,8 +1,11 @@
-"""Canonical workspace path constants shared across server, CLI, and sandbox.
+"""Canonical workspace paths shared across server, CLI, and sandbox.
 
 All Python consumers (server, CLI, sandbox) import from here and derive their
 own format (trailing ``/``, bare names, etc.).  The frontend (JS) keeps its own
 copy in ``FilePanel.jsx`` with a comment pointing back to this file.
+
+Pure string constants and folding — no sandbox handle, no I/O — so both the
+agent library and the server can import it without pulling either in.
 """
 
 from __future__ import annotations
@@ -107,3 +110,26 @@ ALWAYS_HIDDEN_BASENAMES: tuple[str, ...] = (
     ".profile",
 )
 ALWAYS_HIDDEN_SUFFIXES: tuple[str, ...] = (".pyc",)
+
+
+# ---------------------------------------------------------------------------
+# Path folding
+# ---------------------------------------------------------------------------
+
+
+def workspace_relative_path(path: str | None, work_dir: str) -> str:
+    """Fold the many spellings of a workspace file into one comparable form.
+
+    The agent is shown these files at the workspace root and writes them as
+    "/agent.md" as readily as "agent.md" or the fully-qualified sandbox path.
+    All three name the same file, so any caller keying off the result must see
+    them as equal.
+
+    ``removeprefix``, never ``lstrip``: lstrip would eat the leading dot that
+    makes ".agents/user/memory/memory.md" a hidden directory.
+    """
+    normalized = path or ""
+    prefix = work_dir.rstrip("/") + "/"
+    if normalized.startswith(prefix):
+        normalized = normalized[len(prefix) :]
+    return normalized.removeprefix("./").removeprefix("/")

--- a/src/ptc_agent/core/session.py
+++ b/src/ptc_agent/core/session.py
@@ -103,25 +103,31 @@ class Session:
         """Read agent.md from sandbox, with session-level caching.
 
         Returns cached content unless invalidated by invalidate_agent_md().
+
+        A failed read keeps the previous value and stays dirty. Caching the
+        failure as None would conflate "the workspace has no notes" with "the
+        sandbox did not answer", handing the model the no-agent.md placeholder
+        and inviting it to recreate a file that already exists.
         """
         if self._agent_md_dirty:
-            if self.sandbox:
-                try:
-                    self._agent_md_cache = await self.sandbox.aread_file_text(
-                        self.sandbox.normalize_path("agent.md")
-                    )
-                except Exception:
-                    # A missing agent.md is a silent None from aread_file_text;
-                    # reaching here means the read itself failed.
-                    logger.warning(
-                        "Failed to read agent.md",
-                        conversation_id=self.conversation_id,
-                        exc_info=True,
-                    )
-                    self._agent_md_cache = None
+            try:
+                content = (
+                    await self.sandbox.aread_file_text(self.sandbox.normalize_path("agent.md"))
+                    if self.sandbox
+                    else None
+                )
+            except Exception:
+                # A missing agent.md is a silent None from aread_file_text;
+                # reaching here means the read itself failed, so fall through
+                # holding the last good value and stay dirty for a retry.
+                logger.warning(
+                    "Failed to read agent.md",
+                    conversation_id=self.conversation_id,
+                    exc_info=True,
+                )
             else:
-                self._agent_md_cache = None
-            self._agent_md_dirty = False
+                self._agent_md_cache = content
+                self._agent_md_dirty = False
         return self._agent_md_cache
 
     def invalidate_agent_md(self) -> None:

--- a/src/server/database/workspace.py
+++ b/src/server/database/workspace.py
@@ -234,6 +234,35 @@ async def get_workspace_identity(workspace_id: str) -> Optional[Dict[str, Any]]:
         raise
 
 
+async def get_workspace_name_and_description(workspace_id: str) -> Optional[Dict[str, Any]]:
+    """Read only ``name`` + ``description`` — what the agent's prompt calls it.
+
+    Narrow for the same reason as ``get_workspace_identity``: this runs once per
+    agent turn, and ``get_workspace`` would pull the JSONB ``config``/``artifacts``
+    columns to hand back two short strings.
+    """
+    workspace_id = normalize_uuid(workspace_id)
+    if workspace_id is None:
+        return None
+
+    try:
+        async with _ws_cursor() as cur:
+            await cur.execute(
+                """
+                SELECT name, description
+                FROM workspaces
+                WHERE workspace_id = %s AND status != 'deleted'
+                """,
+                (workspace_id,),
+            )
+            result = await cur.fetchone()
+        return dict(result) if result else None
+
+    except Exception as e:
+        logger.error(f"Error reading the name of workspace {workspace_id}: {e}")
+        raise
+
+
 async def get_workspaces_for_user(
     user_id: str,
     limit: int = 20,

--- a/src/server/services/persistence/image_capture.py
+++ b/src/server/services/persistence/image_capture.py
@@ -34,8 +34,6 @@ async def capture_and_rewrite_images(
     if not is_storage_enabled() or not sse_events:
         return 0
 
-    work_dir = sandbox.working_dir
-
     # Collect all unique sandbox image paths from text message_chunks
     image_paths: set[str] = set()
     for evt in sse_events:
@@ -46,7 +44,7 @@ async def capture_and_rewrite_images(
             continue
         content = data.get("content", "")
         for match in IMAGE_MD_RE.finditer(content):
-            if is_sandbox_image_path(match.group(2), work_dir):
+            if is_sandbox_image_path(match.group(2)):
                 image_paths.add(match.group(2))
 
     if not image_paths:

--- a/src/server/services/workspace_manager.py
+++ b/src/server/services/workspace_manager.py
@@ -67,6 +67,21 @@ from src.server.services.workspace_status_pubsub import (
 logger = logging.getLogger(__name__)
 
 
+_SEEDED_AGENT_MD = """# Workspace Notes
+
+<!--
+This is a starter template. Replace these comments with real content
+as you work. The system prompt has full guidelines on what to maintain.
+-->
+
+## Thread Index
+
+## Key Findings
+
+## File Index
+"""
+
+
 class WorkspaceManager(WorkspaceEntitlementsMixin):
     """Singleton that owns in-process session cache and workspace lifecycle (DB + sandbox)."""
 
@@ -976,48 +991,17 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
         )
 
     @staticmethod
-    async def _seed_agent_md(
-        sandbox: Any,
-        name: str,
-        description: Optional[str] = None,
-    ) -> None:
-        """Write a default agent.md with workspace metadata and update instructions.
+    async def _seed_agent_md(sandbox: Any, name: str) -> None:
+        """Write the starter agent.md.
 
-        Uses YAML front matter so the agent (and future tooling) can parse
-        workspace identity from the file. Includes inline instructions so
-        the agent knows how to maintain this file without detection logic.
+        The template carries no workspace name. The row is the only place the
+        name lives, and the prompt injects it from there on every turn, so a
+        copy written here could only ever go stale after a rename.
         """
         if not sandbox:
             return
 
-        desc = (
-            description
-            or "Brief 1-2 sentence description — update based on the first conversation."
-        )
-        lines = [
-            "---",
-            f"workspace_name: {name}",
-            f"description: {desc}",
-            "---",
-            "",
-            f"# {name}",
-            "",
-        ]
-        lines += [
-            "<!--",
-            "This is a starter template. Replace these comments with real content",
-            "as you work. The system prompt has full guidelines on what to maintain.",
-            "-->",
-            "",
-            "## Thread Index",
-            "",
-            "## Key Findings",
-            "",
-            "## File Index",
-            "",
-        ]
-
-        content = "\n".join(lines)
+        content = _SEEDED_AGENT_MD
         try:
             # Pass relative path — awrite_file_text calls normalize_path internally
             written = await sandbox.awrite_file_text("agent.md", content)
@@ -1641,7 +1625,7 @@ class WorkspaceManager(WorkspaceEntitlementsMixin):
                 # (ws_version=0, no discovery to kick). Seed a default agent.md as
                 # the provisioning post-init step.
                 async def _post_init(session: Session) -> None:
-                    await self._seed_agent_md(session.sandbox, name, description)
+                    await self._seed_agent_md(session.sandbox, name)
 
                 _session, workspace = await self._provision_sandbox_session(
                     workspace_id,

--- a/tests/unit/core/test_session_agent_md_cache.py
+++ b/tests/unit/core/test_session_agent_md_cache.py
@@ -1,0 +1,60 @@
+"""Session's agent.md cache must not turn a failed read into "no notes".
+
+``get_agent_md`` used to cache a read failure as None and clear its dirty flag,
+so one unanswered sandbox call told the rest of the turn the workspace had no
+agent.md at all — and the prompt then invites the agent to create a file that
+already exists.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ptc_agent.core.session import Session
+
+AGENT_MD = "---\nworkspace_name: Scratch\n---\n\n# Scratch\n"
+
+
+def _make_session() -> Session:
+    config = MagicMock()
+    config.mcp = MagicMock()
+    config.mcp.servers = []
+    session = Session("ws-1", config)
+    session.sandbox = MagicMock()
+    session.sandbox.normalize_path = lambda p: f"/work/{p}"
+    return session
+
+
+class TestAFailedReadKeepsTheLastGoodContent:
+    @pytest.mark.asyncio
+    async def test_a_read_failure_does_not_cache_absence(self):
+        session = _make_session()
+        session.sandbox.aread_file_text = AsyncMock(return_value=AGENT_MD)
+        assert await session.get_agent_md() == AGENT_MD
+
+        session.invalidate_agent_md()
+        session.sandbox.aread_file_text = AsyncMock(side_effect=RuntimeError("gone"))
+
+        # The previous content stands rather than becoming "no agent.md".
+        assert await session.get_agent_md() == AGENT_MD
+
+    @pytest.mark.asyncio
+    async def test_a_read_failure_stays_dirty_so_the_next_call_retries(self):
+        session = _make_session()
+        session.sandbox.aread_file_text = AsyncMock(side_effect=RuntimeError("gone"))
+        assert await session.get_agent_md() is None
+
+        session.sandbox.aread_file_text = AsyncMock(return_value=AGENT_MD)
+        # No explicit invalidate: the failure must not have cleared the flag.
+        assert await session.get_agent_md() == AGENT_MD
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_absent_file_is_still_cached(self):
+        # aread_file_text returns None (not raises) when the file is missing;
+        # that answer is real and must not force a re-read every model call.
+        session = _make_session()
+        reader = AsyncMock(return_value=None)
+        session.sandbox.aread_file_text = reader
+        assert await session.get_agent_md() is None
+        assert await session.get_agent_md() is None
+        reader.assert_awaited_once()

--- a/tests/unit/middleware/test_agent_md_write_invalidation.py
+++ b/tests/unit/middleware/test_agent_md_write_invalidation.py
@@ -1,0 +1,64 @@
+"""Every spelling of agent.md's path must invalidate the session cache.
+
+The agent is shown these files at the workspace root and writes them as
+"/agent.md" as readily as "agent.md". Only the bare form used to match, so an
+edit through the absolute path left the cache holding the pre-edit text: the
+rest of the turn read the old front matter, the reconcile filed no change, and
+an agent rename never reached the workspace row.
+"""
+
+import pytest
+
+from ptc_agent.agent.middleware.file_operations.sse_middleware import FileOperationMiddleware
+from ptc_agent.core.paths import workspace_relative_path
+
+
+def _normalize(path: str, work_dir: str = "/home/workspace") -> str:
+    """Fold a path exactly as the middleware does, via its own helper.
+
+    Reached through the middleware's configured work_dir rather than a literal
+    so a change to how that is stored shows up here too.
+    """
+    mw = FileOperationMiddleware(on_agent_md_write=lambda: None, work_dir=work_dir)
+    return workspace_relative_path(path, mw._work_dir)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "agent.md",
+        "/agent.md",
+        "./agent.md",
+        "/home/workspace/agent.md",
+    ],
+)
+def test_every_spelling_of_the_workspace_root_file_matches(path):
+    assert _normalize(path) == "agent.md"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "notes/agent.md",
+        "/etc/agent.md",
+        "agent.md.bak",
+    ],
+)
+def test_a_different_file_does_not_match(path):
+    assert _normalize(path) != "agent.md"
+
+
+def test_a_dotted_directory_keeps_its_leading_dot():
+    # removeprefix("./") rather than lstrip(".") — lstrip would eat the dot
+    # that makes this a hidden directory.
+    assert _normalize(".agents/user/memory/memory.md") == ".agents/user/memory/memory.md"
+
+
+def test_a_directory_mirroring_the_work_dir_keeps_its_segments():
+    # removeprefix, not replace: replace strips every occurrence, so a
+    # directory named after the work dir had its name spliced out of the
+    # middle and ".../mirror/home/workspace/c.png" became "mirrorc.png".
+    assert (
+        _normalize("/home/workspace/mirror/home/workspace/c.png")
+        == "mirror/home/workspace/c.png"
+    )

--- a/tests/unit/middleware/test_workspace_context.py
+++ b/tests/unit/middleware/test_workspace_context.py
@@ -1,10 +1,10 @@
 """Tests for the WorkspaceContextMiddleware.
 
-Covers YAML front matter parsing, content block appending, agent.md
-injection into system messages, and truncation of large agent.md content.
+Covers the workspace block, agent.md injection into the system message, and
+truncation of large agent.md content.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from langchain_core.messages import SystemMessage
@@ -13,52 +13,7 @@ from ptc_agent.agent.middleware.workspace_context import (
     MAX_AGENT_MD_SIZE,
     WorkspaceContextMiddleware,
     _append_content_block,
-    _parse_yaml_front_matter,
 )
-
-
-# ---------------------------------------------------------------------------
-# Tests for _parse_yaml_front_matter
-# ---------------------------------------------------------------------------
-
-
-class TestParseYamlFrontMatter:
-    """Tests for _parse_yaml_front_matter."""
-
-    def test_valid_front_matter(self):
-        content = "---\nworkspace_name: My Workspace\ndescription: A test\n---\n# Body"
-        result = _parse_yaml_front_matter(content)
-        assert result is not None
-        assert result["workspace_name"] == "My Workspace"
-        assert result["description"] == "A test"
-
-    def test_no_front_matter(self):
-        content = "# Just a heading\nSome text"
-        result = _parse_yaml_front_matter(content)
-        assert result is None
-
-    def test_missing_closing_delimiter(self):
-        content = "---\nkey: value\nno closing"
-        result = _parse_yaml_front_matter(content)
-        assert result is None
-
-    def test_empty_front_matter(self):
-        content = "---\n---\n# Body"
-        result = _parse_yaml_front_matter(content)
-        assert result is not None
-        assert result == {}
-
-    def test_front_matter_with_empty_lines(self):
-        content = "---\nkey: value\n\nanother: data\n---\n# Body"
-        result = _parse_yaml_front_matter(content)
-        assert result is not None
-        assert result["key"] == "value"
-        assert result["another"] == "data"
-
-
-# ---------------------------------------------------------------------------
-# Tests for _append_content_block
-# ---------------------------------------------------------------------------
 
 
 class TestAppendContentBlock:
@@ -72,9 +27,12 @@ class TestAppendContentBlock:
         existing = SystemMessage(content="initial")
         result = _append_content_block(existing, "appended")
         assert isinstance(result, SystemMessage)
-        # Content blocks should contain the appended text
         blocks = result.content
-        assert any("appended" in str(b) for b in blocks) if isinstance(blocks, list) else "appended" in str(blocks)
+        assert (
+            any("appended" in str(b) for b in blocks)
+            if isinstance(blocks, list)
+            else "appended" in str(blocks)
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -84,20 +42,65 @@ class TestAppendContentBlock:
 
 def _make_session(agent_md: str | None = None, conversation_id: str = "ws-123") -> MagicMock:
     """Create a mock Session object."""
-    session = MagicMock()
+    session = MagicMock(spec_set=["get_agent_md", "invalidate_agent_md", "conversation_id"])
     session.get_agent_md = AsyncMock(return_value=agent_md)
     session.conversation_id = conversation_id
     return session
 
 
-class TestGetWorkspaceContextBlock:
-    """Tests for _get_workspace_context_block."""
+class TestTheWorkspaceBlock:
+    """The row is the only place the workspace's name lives.
+
+    agent.md used to carry a copy in front matter, which meant a rename had two
+    places to reach and a whole reconcile to get it there. The name now arrives
+    from the row when the turn's agent is built, so the prompt is right by
+    construction.
+    """
+
+    def test_the_name_and_description_are_what_the_caller_was_given(self):
+        mw = WorkspaceContextMiddleware(
+            session=_make_session(), name="Q3 Semis", description="Chip supply chain."
+        )
+        assert mw._workspace_block() == (
+            "<workspace>\nName: Q3 Semis\nDescription: Chip supply chain.\n</workspace>"
+        )
+
+    def test_a_workspace_with_no_description_still_gets_its_name(self):
+        mw = WorkspaceContextMiddleware(session=_make_session(), name="Scratch", description="")
+        assert mw._workspace_block() == "<workspace>\nName: Scratch\n</workspace>"
+
+    def test_markup_in_the_name_cannot_read_as_a_tag(self):
+        mw = WorkspaceContextMiddleware(
+            session=_make_session(), name="A <b> & C", description="</workspace>"
+        )
+        block = mw._workspace_block()
+        assert block == (
+            "<workspace>\nName: A &lt;b&gt; &amp; C\n"
+            "Description: &lt;/workspace&gt;\n</workspace>"
+        )
+
+    def test_an_apostrophe_survives_as_an_apostrophe(self):
+        # html.escape's quote=True would render this "O&#x27;Brien" at the
+        # model. Nothing here is quoted, so nothing needs that.
+        mw = WorkspaceContextMiddleware(session=_make_session(), name="O'Brien Desk")
+        assert "Name: O'Brien Desk" in mw._workspace_block()
+
+    def test_surrounding_whitespace_is_dropped(self):
+        mw = WorkspaceContextMiddleware(session=_make_session(), name="  Scratch  ")
+        assert mw._workspace_block() == "<workspace>\nName: Scratch\n</workspace>"
+
+    def test_a_workspace_with_no_name_produces_no_block(self):
+        assert WorkspaceContextMiddleware(session=_make_session())._workspace_block() == ""
+
+
+class TestTheAgentMdBlock:
+    """Tests for _get_agent_md_block."""
 
     @pytest.mark.asyncio
     async def test_returns_agentmd_content(self):
         session = _make_session(agent_md="# My workspace\nSome notes")
         mw = WorkspaceContextMiddleware(session=session)
-        block = await mw._get_workspace_context_block()
+        block = await mw._get_agent_md_block()
         assert "<agentmd" in block
         assert "My workspace" in block
 
@@ -105,7 +108,7 @@ class TestGetWorkspaceContextBlock:
     async def test_returns_placeholder_when_no_agentmd(self):
         session = _make_session(agent_md=None)
         mw = WorkspaceContextMiddleware(session=session)
-        block = await mw._get_workspace_context_block()
+        block = await mw._get_agent_md_block()
         assert "No agent.md exists yet" in block
 
     @pytest.mark.asyncio
@@ -113,73 +116,59 @@ class TestGetWorkspaceContextBlock:
         large_content = "x" * (MAX_AGENT_MD_SIZE + 1000)
         session = _make_session(agent_md=large_content)
         mw = WorkspaceContextMiddleware(session=session)
-        block = await mw._get_workspace_context_block()
+        block = await mw._get_agent_md_block()
         assert "[... truncated ...]" in block
 
     @pytest.mark.asyncio
-    async def test_front_matter_change_triggers_sync(self):
-        agent_md = "---\nworkspace_name: Updated\n---\n# Content"
+    async def test_a_legacy_front_matter_block_is_passed_through_untouched(self):
+        # Nothing parses or rewrites it any more. The prompt tells the model
+        # the <workspace> block is authoritative, so a stale copy in an old
+        # notebook is text, not a second source of truth.
+        agent_md = "---\nworkspace_name: Old Name\n---\n\n# Old Name\n"
         session = _make_session(agent_md=agent_md)
         mw = WorkspaceContextMiddleware(session=session)
-
-        def _close_coro(coro):
-            """Prevent 'coroutine was never awaited' by closing it."""
-            coro.close()
-            return MagicMock()
-
-        with patch(
-            "ptc_agent.agent.middleware.workspace_context.asyncio.create_task",
-            side_effect=_close_coro,
-        ) as mock_task:
-            await mw._get_workspace_context_block()
-            mock_task.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_same_front_matter_does_not_retrigger_sync(self):
-        agent_md = "---\nworkspace_name: Same\n---\n# Content"
-        session = _make_session(agent_md=agent_md)
-        mw = WorkspaceContextMiddleware(session=session)
-
-        def _close_coro(coro):
-            """Prevent 'coroutine was never awaited' by closing it."""
-            coro.close()
-            return MagicMock()
-
-        with patch(
-            "ptc_agent.agent.middleware.workspace_context.asyncio.create_task",
-            side_effect=_close_coro,
-        ) as mock_task:
-            # First call triggers sync
-            await mw._get_workspace_context_block()
-            assert mock_task.call_count == 1
-            # Second call with same content should not trigger
-            await mw._get_workspace_context_block()
-            assert mock_task.call_count == 1
+        assert agent_md in await mw._get_agent_md_block()
 
 
 class TestAwrapModelCall:
     """Tests for awrap_model_call system message injection."""
 
     @pytest.mark.asyncio
-    async def test_injects_context_into_system_message(self):
+    async def test_injects_both_blocks_into_the_system_message(self):
         session = _make_session(agent_md="# Workspace notes")
-        mw = WorkspaceContextMiddleware(session=session)
+        mw = WorkspaceContextMiddleware(session=session, name="Q3 Semis")
 
-        # Create a mock request with override method
         mock_request = MagicMock()
         modified_request = MagicMock()
         mock_request.override = MagicMock(return_value=modified_request)
         mock_request.system_message = None
 
         handler = AsyncMock(return_value="model_response")
-        result = await mw.awrap_model_call(mock_request, handler)
+        await mw.awrap_model_call(mock_request, handler)
 
-        # override should have been called with a new system message
         mock_request.override.assert_called_once()
-        call_kwargs = mock_request.override.call_args
-        assert "system_message" in call_kwargs.kwargs
-        new_sys = call_kwargs.kwargs["system_message"]
+        new_sys = mock_request.override.call_args.kwargs["system_message"]
         assert isinstance(new_sys, SystemMessage)
 
-        # handler should have been called with modified request
+        text = str(new_sys.content)
+        assert "Q3 Semis" in text
+        # The workspace block first, so the name labels the notes after it.
+        assert text.index("<workspace") < text.index("<agentmd")
+
         handler.assert_called_once_with(modified_request)
+
+    @pytest.mark.asyncio
+    async def test_a_workspace_with_no_name_still_gets_its_notes(self):
+        session = _make_session(agent_md="# Workspace notes")
+        mw = WorkspaceContextMiddleware(session=session)
+
+        mock_request = MagicMock()
+        mock_request.override = MagicMock(return_value=MagicMock())
+        mock_request.system_message = None
+
+        await mw.awrap_model_call(mock_request, AsyncMock())
+
+        text = str(mock_request.override.call_args.kwargs["system_message"].content)
+        assert "<agentmd" in text
+        # No empty tag left behind where the identity block would have been.
+        assert "<workspace" not in text

--- a/tests/unit/ptc_agent/agent/middleware/test_image_capture.py
+++ b/tests/unit/ptc_agent/agent/middleware/test_image_capture.py
@@ -9,6 +9,7 @@ unexpected exception) degrades to leaving the sandbox path in place.
 from __future__ import annotations
 
 import hashlib
+from pathlib import PurePosixPath
 
 import pytest
 from langchain.agents.middleware.types import ModelResponse
@@ -26,14 +27,31 @@ PNG_SHA16 = hashlib.sha256(PNG).hexdigest()[:16]
 
 
 class _FakeSandbox:
+    """Stands in for the sandbox, mirroring ``core.sandbox.files.normalize_path``.
+
+    The allowed-roots passthrough is the part that matters: an absolute path
+    under an allowed root is a real location, not a virtual one, so it must not
+    be re-rooted under the work dir. A fake that always prepends the work dir
+    silently agrees with a caller that folds the path first.
+    """
+
     working_dir = "/home/workspace"
+    allowed_directories = ("/home/workspace", "/tmp")
 
     def __init__(self, files: dict[str, bytes] | None = None):
         self.files = files if files is not None else {}
         self.downloads: list[str] = []
 
     def normalize_path(self, path: str) -> str:
-        return f"{self.working_dir}/{path}"
+        if path in ("", ".", "/"):
+            return self.working_dir
+        path = path.strip()
+        for allowed in self.allowed_directories:
+            if path.startswith(allowed):
+                return str(PurePosixPath(path))
+        if path.startswith("/"):
+            return str(PurePosixPath(f"{self.working_dir}{path}"))
+        return str(PurePosixPath(f"{self.working_dir}/{path}"))
 
     async def adownload_file_bytes(self, filepath: str) -> bytes | None:
         self.downloads.append(filepath)
@@ -221,6 +239,39 @@ def test_is_sandbox_image_path():
     assert not is_sandbox_image_path("https://example.com/a.png")
     assert not is_sandbox_image_path("data:image/png;base64,xxx")
     assert not is_sandbox_image_path("work/notes.txt")
+
+
+@pytest.mark.asyncio
+async def test_an_image_under_an_allowed_root_outside_the_work_dir_is_captured(storage):
+    # /tmp is an allowed_directories default and matplotlib's savefig target, so
+    # this is the ordinary case, not an exotic one. Folding the path to a
+    # work-dir-relative form before normalize_path re-rooted it under the work
+    # dir: the download missed, and the markdown silently kept a sandbox path
+    # the browser cannot load.
+    sandbox = _FakeSandbox({"/tmp/chart.png": PNG})
+    msg = AIMessage(content="![chart](/tmp/chart.png)")
+
+    out = await _run(_mw(sandbox), _response(msg))
+
+    assert sandbox.downloads == ["/tmp/chart.png"]
+    assert (
+        f"https://cdn.test/response-images/{PNG_SHA16}/chart.png"
+        in out.result[0].content
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_path_that_repeats_the_work_dir_keeps_its_segments(storage):
+    # A directory that mirrors the work dir must not have its name spliced out
+    # of the middle: ".../mirror/home/workspace/c.png" once collapsed to
+    # "mirrorc.png" under a str.replace that stripped every occurrence.
+    path = "/home/workspace/mirror/home/workspace/c.png"
+    sandbox = _FakeSandbox({path: PNG})
+
+    out = await _run(_mw(sandbox), _response(AIMessage(content=f"![c]({path})")))
+
+    assert sandbox.downloads == [path]
+    assert f"https://cdn.test/response-images/{PNG_SHA16}/c.png" in out.result[0].content
 
 
 def test_image_storage_key_thread_scoping():

--- a/tests/unit/ptc_agent/agent/test_workspace_naming.py
+++ b/tests/unit/ptc_agent/agent/test_workspace_naming.py
@@ -1,0 +1,62 @@
+"""The `<workspace>` block's name comes from the row, read once per turn.
+
+Reading it where the turn's agent is built (rather than inside the model call)
+is what makes it a per-turn value: the model never sees the name change under
+it mid-answer, and there is no cache to invalidate on a rename.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ptc_agent.agent.graph import _read_workspace_naming
+
+WS = "a0000001-0000-4000-8000-000000000001"
+
+
+def _patched_row(row=None, error=None):
+    mock = AsyncMock(side_effect=error) if error else AsyncMock(return_value=row)
+    return patch(
+        "src.server.database.workspace.get_workspace_name_and_description", mock
+    ), mock
+
+
+@pytest.mark.asyncio
+async def test_the_name_and_description_come_from_the_row():
+    ctx, _ = _patched_row({"name": "Q3 Semis", "description": "Chip supply chain."})
+    with ctx:
+        assert await _read_workspace_naming(WS) == ("Q3 Semis", "Chip supply chain.")
+
+
+@pytest.mark.asyncio
+async def test_null_columns_read_as_empty_not_as_the_string_none():
+    ctx, _ = _patched_row({"name": "Scratch", "description": None})
+    with ctx:
+        assert await _read_workspace_naming(WS) == ("Scratch", "")
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_row_costs_the_block_not_the_turn():
+    # The prompt is worth less than the answer: a database that will not
+    # answer must not take the turn down with it.
+    ctx, _ = _patched_row(error=RuntimeError("db down"))
+    with ctx:
+        assert await _read_workspace_naming(WS) == ("", "")
+
+
+@pytest.mark.asyncio
+async def test_a_missing_row_yields_no_name():
+    ctx, _ = _patched_row(None)
+    with ctx:
+        assert await _read_workspace_naming(WS) == ("", "")
+
+
+@pytest.mark.asyncio
+async def test_the_narrow_reader_is_used_not_the_whole_row():
+    # get_workspace pulls the JSONB config/artifacts columns; this runs once
+    # per turn to produce two short strings.
+    ctx, mock = _patched_row({"name": "Scratch", "description": ""})
+    with ctx, patch("src.server.database.workspace.get_workspace") as whole_row:
+        await _read_workspace_naming(WS)
+    mock.assert_awaited_once_with(WS)
+    whole_row.assert_not_called()

--- a/tests/unit/server/services/test_workspace_manager.py
+++ b/tests/unit/server/services/test_workspace_manager.py
@@ -993,14 +993,26 @@ class TestSeedAgentMd:
         sandbox = AsyncMock()
         sandbox.awrite_file_text = AsyncMock(return_value=True)
 
-        await WorkspaceManager._seed_agent_md(sandbox, "My Workspace", "A description")
+        await WorkspaceManager._seed_agent_md(sandbox, "My Workspace")
 
         sandbox.awrite_file_text.assert_awaited_once()
         call_args = sandbox.awrite_file_text.call_args
         assert call_args[0][0] == "agent.md"
-        content = call_args[0][1]
-        assert "My Workspace" in content
-        assert "A description" in content
+        assert "## Thread Index" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_the_template_does_not_name_the_workspace(self):
+        # The row is the only place the name lives, and the prompt injects it
+        # from there each turn. A copy written here could only go stale, which
+        # is the whole bug the front-matter block used to cause.
+        sandbox = AsyncMock()
+        sandbox.awrite_file_text = AsyncMock(return_value=True)
+
+        await WorkspaceManager._seed_agent_md(sandbox, "My Workspace")
+
+        content = sandbox.awrite_file_text.call_args[0][1]
+        assert "My Workspace" not in content
+        assert not content.startswith("---")
 
     @pytest.mark.asyncio
     async def test_seed_agent_md_none_sandbox_noop(self):

--- a/web/e2e/workspace-rename.spec.js
+++ b/web/e2e/workspace-rename.spec.js
@@ -1,0 +1,82 @@
+/**
+ * E2E for renaming a workspace while a chat is open.
+ *
+ * The chat header used to hold a copy of the name taken when the view mounted,
+ * so a rename landed in the sidebar and left the header on the old name for as
+ * long as that view stayed cached.
+ */
+import { configureSSE, resetMockServer, mockAPI, test, expect } from './fixtures.js';
+import { sampleWorkspace, sampleThread, sseEvents } from './helpers/mockResponses.js';
+
+const WS_ID = 'a0000001-0000-4000-8000-000000000001';
+const TH_ID = 'b0000001-0000-4000-8000-000000000001';
+// Not a name any fixture ships: `sampleWorkspace()` and the default
+// `GET /workspaces/*` are both 'Research', so renaming to that would let the
+// "after" assertion pass on a default response that never saw the PUT.
+const NEW_NAME = 'Retitled Desk QA';
+
+const json = (route, body) => route.fulfill({
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify(body),
+});
+
+test.describe('workspace rename', () => {
+  test.beforeEach(async () => {
+    await resetMockServer();
+  });
+
+  test('the open chat header follows the new name without a reload', async ({ page }) => {
+    // Server-side name, flipped by the PUT the rename issues. The workspace
+    // routes are functions rather than literals so they read `name` at request
+    // time — mockAPI hands the route to a function response.
+    let name = 'Scratch';
+    const ws = () => sampleWorkspace({ name });
+    const th = sampleThread();
+
+    await mockAPI(page, {
+      'GET /threads': { threads: [th], total: 1 },
+      [`GET /threads/${TH_ID}`]: th,
+      'GET /workspaces': (route) => json(route, { workspaces: [ws()], total: 1, limit: 20, offset: 0 }),
+      'GET /workspaces/*': (route) => json(route, ws()),
+      'PUT /workspaces/*': (route) => {
+        name = JSON.parse(route.request().postData() || '{}').name || name;
+        return json(route, ws());
+      },
+      [`GET /workspaces/${WS_ID}/files`]: { files: [] },
+    });
+
+    await configureSSE({
+      method: 'GET',
+      path: `/api/v1/threads/${TH_ID}/messages/replay`,
+      events: [sseEvents.userMessage('hi', 0), sseEvents.finishStop(), sseEvents.replayDone()],
+      delay: 10,
+    });
+
+    await page.goto(`/chat/t/${TH_ID}`);
+    await expect(page.locator('h1').filter({ hasText: 'Scratch' }).first())
+      .toBeVisible({ timeout: 15000 });
+
+    // Rename from the sidebar tree — the path the report came from. Anchored
+    // on the row that owns the Options button rather than on DOM order: the
+    // header carries the same text, so .last() would be a layout accident.
+    const row = page.locator('.nav-panel-row').filter({ hasText: 'Scratch' }).first();
+    await row.hover();
+    await row.getByRole('button', { name: 'Options', exact: true }).click();
+    await page.getByRole('menuitem', { name: 'Rename', exact: true }).click();
+    const input = page.getByLabel('Rename');
+    // Armed before the submit so a rename that never reaches the network fails
+    // as "the PUT never fired" instead of as a header that stayed on 'Scratch'.
+    const renamePut = page.waitForRequest(
+      (req) => req.method() === 'PUT' && new URL(req.url()).pathname === `/api/v1/workspaces/${WS_ID}`,
+      { timeout: 10000 },
+    );
+    await input.fill(NEW_NAME);
+    await input.press('Enter');
+    await renamePut;
+
+    await expect(page.locator('h1').filter({ hasText: NEW_NAME }).first())
+      .toBeVisible({ timeout: 10000 });
+    await expect(page.locator('h1').filter({ hasText: 'Scratch' })).toHaveCount(0);
+  });
+});

--- a/web/src/components/ui/chat-input.types.ts
+++ b/web/src/components/ui/chat-input.types.ts
@@ -49,8 +49,4 @@ export interface ReadyAttachment {
   preview: string | null;
 }
 
-export interface Workspace {
-  workspace_id: string;
-  name: string;
-  [key: string]: unknown;
-}
+export type { Workspace } from '@/types/api';

--- a/web/src/hooks/useWorkspace.ts
+++ b/web/src/hooks/useWorkspace.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import { queryKeys } from '../lib/queryKeys';
 import { getWorkspace } from '../pages/ChatAgent/utils/api';
 import type { Workspace, WorkspacesResponse } from '../types/api';
@@ -6,8 +6,16 @@ import type { Workspace, WorkspacesResponse } from '../types/api';
 /**
  * Shared hook for a single workspace's details.
  * Derives initialData from cached workspace lists to avoid redundant fetches.
+ *
+ * The return type is written out because react-query infers the wrong one: any
+ * `initialData` function at all selects its "defined" overload, which promises
+ * `data` is never undefined. Ours returns undefined whenever no cached list
+ * holds this workspace, and the query is disabled without an id, so callers
+ * genuinely have to null-check.
  */
-export function useWorkspace(workspaceId: string | null | undefined) {
+export function useWorkspace(
+  workspaceId: string | null | undefined,
+): UseQueryResult<Workspace, Error> {
   const queryClient = useQueryClient();
 
   return useQuery({

--- a/web/src/hooks/useWorkspaces.ts
+++ b/web/src/hooks/useWorkspaces.ts
@@ -8,6 +8,9 @@ interface UseWorkspacesOptions {
   sortBy?: string;
   includeFlash?: boolean;
   enabled?: boolean;
+  /** 'always' forces a fetch on mount even inside the staleTime window, for a
+   *  consumer that has to decide something against the current list. */
+  refetchOnMount?: boolean | 'always';
 }
 
 /**
@@ -15,13 +18,14 @@ interface UseWorkspacesOptions {
  * Uses keepPreviousData for smooth pagination transitions.
  * All consumers with the same params share one cached entry.
  */
-export function useWorkspaces({ limit = 20, offset = 0, sortBy = 'custom', includeFlash = false, enabled = true }: UseWorkspacesOptions = {}) {
+export function useWorkspaces({ limit = 20, offset = 0, sortBy = 'custom', includeFlash = false, enabled = true, refetchOnMount }: UseWorkspacesOptions = {}) {
   const params = { limit, offset, sortBy, includeFlash };
   return useQuery({
     queryKey: queryKeys.workspaces.list(params),
     queryFn: () => getWorkspaces(limit, offset, sortBy, includeFlash),
     enabled,
     staleTime: 30_000,
+    refetchOnMount,
     placeholderData: keepPreviousData,
   });
 }

--- a/web/src/pages/Automations/components/AutomationInlineForm.tsx
+++ b/web/src/pages/Automations/components/AutomationInlineForm.tsx
@@ -205,7 +205,7 @@ export default function AutomationInlineForm({
   });
 
   const { data: wsData } = useWorkspaces({ limit: 100 });
-  const workspaces = (wsData as { workspaces?: WorkspaceOption[] })?.workspaces ?? [];
+  const workspaces: WorkspaceOption[] = wsData?.workspaces ?? [];
 
   const set = (key: keyof FormState) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement> | string) =>
     setForm((f) => ({ ...f, [key]: typeof e === 'string' ? e : e.target.value }));

--- a/web/src/pages/ChatAgent/components/ChatView.tsx
+++ b/web/src/pages/ChatAgent/components/ChatView.tsx
@@ -14,7 +14,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
 import { modelPrefs } from '@/lib/modelPreferences';
 import { updateCurrentUser } from '../../Dashboard/utils/api';
-import { getWorkspace, summarizeThread, offloadThread, getThreadShareStatus, updateThreadSharing, cancelSubagentTask } from '../utils/api';
+import { summarizeThread, offloadThread, getThreadShareStatus, updateThreadSharing, cancelSubagentTask } from '../utils/api';
 import { buildSharedServeUrl, buildWsfilesUrl } from './viewers/html/wsfilesUrl';
 import ShareReportLinkModal from './ShareReportLinkModal';
 import { toast } from '@/components/ui/use-toast';
@@ -24,6 +24,7 @@ import { saveChatSession, getChatSession, clearChatSession } from '../hooks/util
 import type { PreviewData } from '../hooks/utils/types';
 import { useCardState } from '../hooks/useCardState';
 import { useWorkspaceFiles } from '../hooks/useWorkspaceFiles';
+import { useWorkspace } from '@/hooks/useWorkspace';
 import { classifyAgentPath } from '../utils/agentPaths';
 import { taskIdFromAgentId } from '../utils/agentId';
 import {
@@ -68,7 +69,7 @@ const PreviewViewer = React.lazy(() => import('./viewers/PreviewViewer'));
 import {
   type MessageRecord, type LocationState,
   type SubagentMessage, type SlashCommand, type ModelOptions, type ActionCommand,
-  type MsgSelectionTooltipData, type WorkspaceRecord, type ChatViewProps,
+  type MsgSelectionTooltipData, type ChatViewProps,
 } from './chatView/types';
 import SubagentStatusIndicator from './chatView/SubagentStatusIndicator';
 import { ModelStatusPill } from './chatView/ModelStatusPill';
@@ -93,10 +94,32 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const marketWatchEnabled = useFeatureEnabled('market_watch');
   const queryClient = useQueryClient();
   const initialMessageSentRef = useRef(false);
-  // Determine agent mode: flash workspaces use flash mode, otherwise ptc
   const state = location.state as LocationState | null;
-  const [agentMode, setAgentMode] = useState(state?.agentMode || 'ptc');
-  const isFlashMode = agentMode === 'flash' || state?.workspaceStatus === 'flash';
+  // The workspace row drives the header title and the flash-mode fallback. It
+  // has to come from the shared detail query rather than a mount-time snapshot:
+  // a rename invalidates that key, and this view outlives the rename (it is
+  // kept mounted by the ChatView LRU, whose own copy of the name never
+  // refreshes). The prop is only the pre-fetch seed.
+  const { data: workspaceRecord } = useWorkspace(workspaceId);
+  const workspaceName = workspaceRecord?.name || initialWorkspaceName || '';
+
+  // Agent mode: what the navigation asked for, else what the workspace row
+  // says — direct URL navigation carries no route state, so the row is the
+  // only thing left that names a flash workspace.
+  //
+  // Both route-state reads are captured at mount. ChatAgent keeps up to five
+  // ChatViews rendered at once (display:none, not unmounted) and they all read
+  // the same current location, so a live read would hand every background view
+  // the mode of whatever thread the user just opened. `workspaceStatus` needs
+  // the same freeze and cannot simply be dropped: three navigations set it
+  // without an `agentMode` beside it (the sidebar's workspace-home jump, the
+  // archive fallback, and the gallery hops that inherit state).
+  const navModeRef = useRef({
+    agentMode: state?.agentMode,
+    isFlash: state?.workspaceStatus === 'flash',
+  });
+  const agentMode = navModeRef.current.agentMode || (workspaceRecord?.status === 'flash' ? 'flash' : 'ptc');
+  const isFlashMode = agentMode === 'flash' || navModeRef.current.isFlash;
 
   // The mode's currently-configured model — fallback initializer for the
   // suggestion pill's nextSendModel, mirroring ChatInput's own modePreferredModel.
@@ -106,7 +129,6 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
     : ((modelPreference.preferred_model as string | undefined) || null);
   // Live model selection reported by ChatInput (null until it reports in).
   const [inputModel, setInputModel] = useState<string | null>(null);
-  const [workspaceName, setWorkspaceName] = useState(initialWorkspaceName || '');
   // Cross-workspace file panel: in flash mode, files live in PTC workspaces.
   // This tracks which workspace the file panel should fetch from.
   const [filePanelWorkspaceId, setFilePanelWorkspaceId] = useState<string | null>(null);
@@ -148,22 +170,6 @@ function ChatView({ workspaceId, threadId, initialTaskId, onBack, workspaceName:
   const resolvedThreadIdRef = useRef(threadId);
 
 
-
-  // Direct URL navigation fallback: detect flash workspace and resolve name from API
-  const wsFetchedRef = useRef<string | null>(null); // tracks workspaceId we already fetched for
-  useEffect(() => {
-    if (!workspaceId) return;
-    if (state?.agentMode && workspaceName) return;
-    if (wsFetchedRef.current === workspaceId) return;
-    wsFetchedRef.current = workspaceId;
-    let cancelled = false;
-    getWorkspace(workspaceId).then((ws: WorkspaceRecord) => {
-      if (cancelled) return;
-      if (ws?.status === 'flash' && !state?.agentMode) setAgentMode('flash');
-      if (ws?.name && !workspaceName) setWorkspaceName(ws.name);
-    }).catch(() => {});
-    return () => { cancelled = true; };
-  }, [workspaceId, state?.agentMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Floating cards management - extracted to custom hook for better encapsulation
   // Must be called before useChatMessages since updateTodoListCard and updateSubagentCard are passed to it

--- a/web/src/pages/ChatAgent/components/MemoPanel.tsx
+++ b/web/src/pages/ChatAgent/components/MemoPanel.tsx
@@ -389,7 +389,7 @@ export default function MemoPanel({ targetKey, onTargetHandled, onOpenFile }: Me
   });
   const workspaceNameById = useMemo(() => {
     const map = new Map<string, string>();
-    const items = (wsData as { workspaces?: { workspace_id: string; name?: string }[] } | undefined)?.workspaces;
+    const items = wsData?.workspaces;
     for (const ws of items ?? []) {
       if (ws.workspace_id && ws.name) map.set(ws.workspace_id, ws.name);
     }

--- a/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
+++ b/web/src/pages/ChatAgent/components/WorkspaceGallery.tsx
@@ -367,7 +367,7 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
 
   // Derive workspace list from query data
   const workspaces = useMemo((): WorkspaceRecord[] => {
-    const list = (wsData as any)?.workspaces || []; // TODO: type properly
+    const list = wsData?.workspaces || [];
     // Prepend flash workspace on first page when not searching
     if (flashWs && isFirstPage && !isSearching) {
       return [flashWs as WorkspaceRecord, ...list];
@@ -375,13 +375,13 @@ function WorkspaceGallery({ onWorkspaceSelect, prefetchThreads }: WorkspaceGalle
     return list;
   }, [wsData, flashWs, isFirstPage, isSearching]);
 
-  const totalWorkspaces = (wsData as any)?.total || 0; // TODO: type properly
+  const totalWorkspaces = wsData?.total || 0;
   const totalPages = Math.ceil((totalWorkspaces + 1) / pageSize);
 
   // Sync allWorkspaces state from query data when in reorder mode
   useEffect(() => {
-    if (isReorderMode && (allWsData as any)?.workspaces) {
-      const list = (allWsData as any).workspaces;
+    if (isReorderMode && allWsData?.workspaces) {
+      const list = allWsData.workspaces;
       setAllWorkspaces(flashWs ? [flashWs as WorkspaceRecord, ...list] : list);
     }
   }, [isReorderMode, allWsData, flashWs]);

--- a/web/src/pages/ChatAgent/components/chatView/types.ts
+++ b/web/src/pages/ChatAgent/components/chatView/types.ts
@@ -154,12 +154,6 @@ export interface MsgSelectionTooltipData {
   text: string;
 }
 
-export interface WorkspaceRecord {
-  status?: string;
-  name?: string;
-  [key: string]: unknown;
-}
-
 export interface ChatViewProps {
   workspaceId: string;
   threadId: string;

--- a/web/src/pages/ChatAgent/hooks/useNavigationData.ts
+++ b/web/src/pages/ChatAgent/hooks/useNavigationData.ts
@@ -12,7 +12,7 @@ import {
   type ThreadRecord,
   type ThreadsData,
 } from '@/lib/navThreadsStore';
-import type { ResourceTier } from '@/types/api';
+import type { ResourceTier, WorkspacesResponse } from '@/types/api';
 import { getWorkspaces, getWorkspaceThreads, reorderWorkspaces, updateThread } from '../utils/api';
 import { pinWorkspaceRow, renameWorkspaceRow } from './workspaceRowActions';
 import { useNavPrefs } from '../utils/navPrefs';
@@ -36,11 +36,6 @@ export interface NavWorkspace {
 // Re-exported so nav-tree consumers keep importing the hook's row types from
 // the hook rather than reaching into the store module.
 export type { ThreadRecord, ThreadsData } from '@/lib/navThreadsStore';
-
-interface WorkspacesResponse {
-  workspaces: NavWorkspace[];
-  total: number;
-}
 
 interface ThreadsResponse {
   threads: ThreadRecord[];
@@ -246,10 +241,10 @@ export function useNavigationData(currentWorkspaceId: string, { enabled = true }
   // Memoized so the `|| []` fallback doesn't hand every dependent memo/callback
   // a fresh array identity on each render.
   const allFetched = useMemo<NavWorkspace[]>(
-    () => (wsData as WorkspacesResponse | undefined)?.workspaces || [],
+    () => wsData?.workspaces || [],
     [wsData],
   );
-  const totalCount = (wsData as WorkspacesResponse | undefined)?.total || 0;
+  const totalCount = wsData?.total || 0;
 
   // Loaded thread lists, read from the session-global shared store so every
   // cached panel sees the same data (see lib/navThreadsStore). Writes go
@@ -275,10 +270,8 @@ export function useNavigationData(currentWorkspaceId: string, { enabled = true }
     if (wsFetchRef.current.inflight || wsFetchRef.current.failed) return;
     wsFetchRef.current.inflight = true;
     getWorkspaces(100, allFetched.length, orderBy, true)
-      .then((data: unknown) => {
-        const page = data as WorkspacesResponse;
-        queryClient.setQueryData(queryKeys.workspaces.list({ ...NAV_WS_PARAMS, sortBy: orderBy, offset: 0 }), (old: unknown) => {
-          const oldData = old as WorkspacesResponse | undefined;
+      .then((page) => {
+        queryClient.setQueryData<WorkspacesResponse>(queryKeys.workspaces.list({ ...NAV_WS_PARAMS, sortBy: orderBy, offset: 0 }), (oldData) => {
           if (!oldData) return page;
           const existingIds = new Set(oldData.workspaces.map(w => w.workspace_id));
           const unique = (page.workspaces || []).filter(w => !existingIds.has(w.workspace_id));

--- a/web/src/pages/ChatAgent/utils/api/workspaces.ts
+++ b/web/src/pages/ChatAgent/utils/api/workspaces.ts
@@ -2,7 +2,7 @@
  * Workspace management endpoints.
  */
 import { api } from '@/api/client';
-import type { ResourceTier, WorkspaceQuota } from '@/types/api';
+import type { ResourceTier, Workspace, WorkspaceQuota, WorkspacesResponse } from '@/types/api';
 import { baseURL, getAuthHeaders } from './transport';
 
 // The shared axios instance sets no global timeout. Workspace-management ops
@@ -13,8 +13,8 @@ const WORKSPACE_MUTATION_TIMEOUT_MS = 120000;
 
 const WORKSPACE_QUERY_TIMEOUT_MS = 15000;
 
-export async function getWorkspaces(limit: number = 20, offset: number = 0, sortBy: string = 'custom', includeFlash: boolean = false) {
-  const { data } = await api.get('/api/v1/workspaces', {
+export async function getWorkspaces(limit: number = 20, offset: number = 0, sortBy: string = 'custom', includeFlash: boolean = false): Promise<WorkspacesResponse> {
+  const { data } = await api.get<WorkspacesResponse>('/api/v1/workspaces', {
     params: { limit, offset, sort_by: sortBy, ...(includeFlash ? { include_flash: true } : {}) },
   });
   return data;
@@ -32,9 +32,9 @@ export async function deleteWorkspace(workspaceId: string) {
   await api.delete(`/api/v1/workspaces/${id}`);
 }
 
-export async function getWorkspace(workspaceId: string) {
+export async function getWorkspace(workspaceId: string): Promise<Workspace> {
   if (!workspaceId) throw new Error('Workspace ID is required');
-  const { data } = await api.get(`/api/v1/workspaces/${workspaceId}`);
+  const { data } = await api.get<Workspace>(`/api/v1/workspaces/${workspaceId}`);
   return data;
 }
 

--- a/web/src/pages/Dashboard/hooks/useChatInput.ts
+++ b/web/src/pages/Dashboard/hooks/useChatInput.ts
@@ -6,7 +6,6 @@ import { attachmentsToContexts, widgetSnapshotsToContexts } from '../../ChatAgen
 import { useWorkspaces } from '../../../hooks/useWorkspaces';
 import { ContextBus } from '@/lib/contextBus';
 import type { WidgetContextSnapshot } from '../widgets/framework/contextSnapshot';
-import type { Workspace } from '@/types/api';
 
 type ChatMode = 'fast' | 'ptc';
 
@@ -50,7 +49,7 @@ export function useChatInput() {
   // dashboard widgets (RecentThreads, ConversationWidget, WorkspacePicker) so all
   // four share a single React Query cache entry instead of four separate ones.
   const { data: wsData } = useWorkspaces({ limit: 100, offset: 0 });
-  const workspaces = ((wsData as { workspaces?: Workspace[] })?.workspaces || []).filter((ws: Workspace) => ws.status !== 'flash');
+  const workspaces = (wsData?.workspaces || []).filter((ws) => ws.status !== 'flash');
 
   // Auto-select first workspace when data arrives
   useEffect(() => {

--- a/web/src/pages/Dashboard/widgets/definitions/ConversationWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/ConversationWidget.tsx
@@ -73,7 +73,7 @@ function ConversationWidget({ instance }: WidgetRenderProps<ConversationConfig>)
   // Fetch 100 to match the shared React Query cache key used by useChatInput,
   // RecentThreadsWidget, and WorkspacePickerWidget (single cache entry serves all).
   const { data: wsData } = useWorkspaces({ limit: 100 });
-  const firstWsId = wsData?.workspaces?.[0]?.workspace_id as string | undefined;
+  const firstWsId = wsData?.workspaces?.[0]?.workspace_id;
 
   const { data: threadsData } = useQuery<ThreadsResponse>({
     queryKey: firstWsId

--- a/web/src/pages/Dashboard/widgets/definitions/RecentThreadsWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/RecentThreadsWidget.tsx
@@ -232,7 +232,7 @@ function RecentThreadsWidget({ instance }: WidgetRenderProps<RecentThreadsConfig
 
   const workspaceMap = useMemo(() => {
     const map = new Map<string, Workspace>();
-    (wsListData?.workspaces ?? []).forEach((ws: Workspace) => {
+    (wsListData?.workspaces ?? []).forEach((ws) => {
       if (ws.workspace_id) map.set(ws.workspace_id, ws);
     });
     return map;

--- a/web/src/pages/Dashboard/widgets/definitions/WorkspacePickerWidget.tsx
+++ b/web/src/pages/Dashboard/widgets/definitions/WorkspacePickerWidget.tsx
@@ -118,7 +118,7 @@ function WorkspacePickerWidget({ instance }: WidgetRenderProps<WorkspacePickerCo
   // slice locally to honor the widget's configured display limit.
   const { data, isLoading } = useWorkspaces({ limit: 100 });
   const displayLimit = instance.config.limit ?? 12;
-  const workspaces: WorkspaceRecord[] = ((data?.workspaces ?? []) as WorkspaceRecord[]).slice(0, displayLimit);
+  const workspaces: WorkspaceRecord[] = (data?.workspaces ?? []).slice(0, displayLimit);
 
   useWidgetContextExport(instance.id, {
     full: () => {

--- a/web/src/pages/MarketView/MarketView.tsx
+++ b/web/src/pages/MarketView/MarketView.tsx
@@ -11,7 +11,8 @@ import MarketChatPanel from './components/MarketChatPanel';
 import MarketSidebarPanel from './components/MarketSidebarPanel';
 import { INTERVALS } from './utils/chartConstants';
 import { useMarketChat } from './hooks/useMarketChat';
-import { getWorkspaces } from '../ChatAgent/utils/api';
+import { useWorkspaces } from '@/hooks/useWorkspaces';
+import type { Workspace } from '@/types/api';
 import { attachmentsToContexts } from '../ChatAgent/utils/fileUpload';
 import { motion, AnimatePresence } from 'framer-motion';
 import CompanyOverviewPanel from './components/CompanyOverviewPanel';
@@ -50,12 +51,10 @@ interface AttachmentItem {
   preview?: string | null;
 }
 
-interface Workspace {
-  workspace_id: string;
-  name?: string;
-  status?: string;
-  [key: string]: unknown;
-}
+// Stable identity for the pre-data render, so the reconcile effect's
+// `workspaces` dependency doesn't change on every render before the fetch
+// lands. React Query's structural sharing covers the loaded case.
+const EMPTY_WORKSPACES: Workspace[] = [];
 
 // TODO: type properly once overview API response shape is formalized
 interface OverviewData {
@@ -147,7 +146,6 @@ function MarketViewInner() {
     const stored = loadPref<string>('mode', 'fast');
     return stored === 'ptc' ? 'ptc' : 'fast';
   });
-  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
     () => loadPref<string | null>('selectedWorkspaceId', null),
   );
@@ -344,28 +342,48 @@ function MarketViewInner() {
     return chartSelections.some((s) => isConfirmedFor(s, sym, tf));
   }, [chartSelections, selectedStock, selectedInterval]);
 
-  // Fetch workspaces for the workspace selector (PTC mode)
+  // Workspaces for the selector (PTC mode). The shared query, not a local
+  // fetch — a rename elsewhere invalidates this key, and a copy in local state
+  // would keep showing the old name until the page remounts. The list is
+  // already PTC-only: this key carries includeFlash=false, and the server
+  // filters flash rows out of that response.
+  // refetchOnMount 'always': the reconcile below only accepts a fetch that
+  // happened during this mount, and the 30s staleTime would otherwise serve a
+  // remount from cache with no request at all, so the check would never run.
+  const { data: workspacesData, isFetchedAfterMount, isSuccess } = useWorkspaces({
+    limit: 50,
+    refetchOnMount: 'always',
+  });
+  const workspaces = workspacesData?.workspaces ?? EMPTY_WORKSPACES;
+
+  // Reconcile the restored selection against the list, once per mount. If the
+  // selected workspace is gone (deleted between visits), drop back to a clean
+  // default state — Flash mode + new chat — instead of silently picking a
+  // different PTC workspace the user didn't ask for. Resolve both decisions
+  // before calling either setter so neither updater runs a side effect on the
+  // other piece of state.
+  //
+  // Gated on a successful fetch that happened during this mount, not merely on
+  // data being present: the query has a 30s staleTime, so a remount inside
+  // that window is served from cache synchronously and a workspace deleted
+  // elsewhere is still in that copy. `isFetchedAfterMount` also flips on an
+  // error update, hence `isSuccess` — a failed list load must not read as
+  // "your workspace is gone" and clear the selection.
+  //
+  // Once per mount, deliberately. Absence from this list does not mean
+  // deleted: it is one page of 50 ordered by recency, so an idle selection
+  // falls off it on its own as other workspaces get activity. Re-running on
+  // every refetch would clear the selection mid-session on a window focus, and
+  // MarketChatPanel reads a workspace change as a scope change the user made
+  // and discards the open thread.
+  const reconciledRef = useRef(false);
   useEffect(() => {
-    let cancelled = false;
-    getWorkspaces(50, 0)
-      .then((data: Record<string, unknown>) => {
-        if (cancelled) return;
-        const list = ((data.workspaces || []) as Workspace[]).filter((ws) => ws.status !== 'flash');
-        setWorkspaces(list);
-        // Reconcile selectedWorkspaceId against the fresh list. If the stored
-        // id is gone (workspace deleted between visits), drop back to a clean
-        // default state — Flash mode + new chat — instead of silently picking
-        // a different PTC workspace the user didn't ask for. Resolve both
-        // decisions before calling either setter so neither updater runs
-        // a side effect on the other piece of state.
-        const storedId = loadPref<string | null>('selectedWorkspaceId', null);
-        const stillValid = storedId && list.some((ws) => ws.workspace_id === storedId);
-        if (storedId && !stillValid) setMode('fast');
-        if (!stillValid) setSelectedWorkspaceId(list[0]?.workspace_id ?? null);
-      })
-      .catch(() => { });
-    return () => { cancelled = true; };
-  }, []);
+    if (reconciledRef.current || !isFetchedAfterMount || !isSuccess) return;
+    reconciledRef.current = true;
+    if (selectedWorkspaceId && workspaces.some((ws) => ws.workspace_id === selectedWorkspaceId)) return;
+    if (selectedWorkspaceId) setMode('fast');
+    setSelectedWorkspaceId(workspaces[0]?.workspace_id ?? null);
+  }, [isFetchedAfterMount, isSuccess, workspaces, selectedWorkspaceId]);
 
   const handleCaptureChart = useCallback(async () => {
     if (!chartRef.current) return;
@@ -641,7 +659,7 @@ function MarketViewInner() {
               isLoading={isLoading}
               mode={mode}
               onModeChange={setMode as any}
-              workspaces={workspaces as any}
+              workspaces={workspaces}
               selectedWorkspaceId={selectedWorkspaceId}
               onWorkspaceChange={setSelectedWorkspaceId}
               onCaptureChart={handleCaptureChartForContext}

--- a/web/src/pages/MarketView/components/MarketChatPanel.tsx
+++ b/web/src/pages/MarketView/components/MarketChatPanel.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../ChatAgent/session/subagents/resolveSubagentTelemetry';
 import type { ToolCallProcessRecord, SubagentInfo } from '../../ChatAgent/components/ToolCallDetailView';
 import type { PreviewData } from '../../ChatAgent/hooks/utils/types';
+import type { Workspace } from '@/types/api';
 import MarketChatHistoryButton from './MarketChatHistoryButton';
 import MarketDetailDialog, { type DialogPayload } from './MarketDetailDialog';
 import { getMarketThreadId, setMarketThreadId, clearMarketThreadId } from '../utils/threadPersistence';
@@ -74,13 +75,6 @@ interface ModelOptionsLike {
   model?: string | null;
   reasoningEffort?: string | null;
   fastMode?: boolean | null;
-}
-
-interface Workspace {
-  workspace_id: string;
-  name?: string;
-  status?: string;
-  [key: string]: unknown;
 }
 
 interface AttachmentItem {
@@ -999,7 +993,7 @@ function ChatBody(props: ChatBodyProps): React.ReactElement {
         mode={mode}
         onModeChange={onModeChange}
         ptcDisabledReason={ptcDisabledReason}
-        workspaces={ptcWorkspaces as never}
+        workspaces={ptcWorkspaces}
         selectedWorkspaceId={selectedWorkspaceId}
         onWorkspaceChange={onWorkspaceChange}
         onCaptureChart={onCaptureChart}

--- a/web/src/pages/MarketView/components/__tests__/MarketChatPanel.test.tsx
+++ b/web/src/pages/MarketView/components/__tests__/MarketChatPanel.test.tsx
@@ -135,7 +135,7 @@ const baseProps: PanelProps = {
   interval: '1day',
   mode: 'ptc',
   onModeChange: vi.fn(),
-  workspaces: [{ workspace_id: 'ws-1' }],
+  workspaces: [{ workspace_id: 'ws-1', name: 'Workspace 1' }],
   selectedWorkspaceId: 'ws-1',
   onWorkspaceChange: vi.fn(),
   chartImage: null,

--- a/web/src/pages/MarketView/utils/api.ts
+++ b/web/src/pages/MarketView/utils/api.ts
@@ -5,6 +5,7 @@
 import { api } from '@/api/client';
 import { getAuthHeaders } from '@/lib/authToken';
 import { normalizeIndexKey } from '@/lib/marketUtils';
+import type { Workspace, WorkspacesResponse } from '@/types/api';
 
 // Legacy full-window bar loader now lives in lib/bars (so lib/ never imports a
 // page); re-exported for page-internal callers that still import it from here.
@@ -488,19 +489,13 @@ export async function deleteMarketThread(threadId: string): Promise<void> {
   }
 }
 
-interface Workspace {
-  workspace_id: string;
-  name: string;
-  [key: string]: unknown;
-}
-
 /**
  * List all workspaces for the user
  * @returns {Promise<Array>} Array of workspace objects
  */
 export async function listWorkspaces(): Promise<Workspace[]> {
   try {
-    const { data } = await api.get('/api/v1/workspaces');
+    const { data } = await api.get<WorkspacesResponse>('/api/v1/workspaces');
     return data?.workspaces || [];
   } catch (error: unknown) {
     console.warn('[MarketView] Failed to list workspaces:', error);

--- a/web/src/pages/Onboarding/OnboardingProvider.tsx
+++ b/web/src/pages/Onboarding/OnboardingProvider.tsx
@@ -343,7 +343,7 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
     enabled: !isLoading && prefs.gettingStartedDismissedAt === null && !workspaceStamped,
   });
   const hasWorkspace =
-    ((workspacesData as { workspaces?: unknown[] } | undefined)?.workspaces?.length ?? 0) > 0;
+    (workspacesData?.workspaces?.length ?? 0) > 0;
   useEffect(() => {
     if (hasWorkspace && !workspaceStamped) markTaskDone('createWorkspace');
   }, [hasWorkspace, workspaceStamped, markTaskDone]);

--- a/web/src/pages/Plugins/hooks/useWorkspaceOptions.ts
+++ b/web/src/pages/Plugins/hooks/useWorkspaceOptions.ts
@@ -6,11 +6,6 @@ import type { ScopeWorkspace } from '../components/ScopeControl';
  * The user's workspaces as the Plugins page consumes them: scope-control
  * options with a display name already resolved, plus the id → name lookup the
  * deck headers read.
- *
- * The workspaces endpoint is untyped, so every list was writing its own
- * `wsData as { workspaces?: … }` assertion — three hand-written shapes that
- * nothing checks against the response. Asserting it once keeps the unchecked
- * part to a single line.
  */
 
 export interface WorkspaceOptions {
@@ -22,9 +17,7 @@ export function useWorkspaceOptions(): WorkspaceOptions {
   const { t } = useTranslation();
   const { data } = useWorkspaces({ limit: 100 });
 
-  const rows =
-    (data as { workspaces?: { workspace_id: string; name?: string }[] } | undefined)
-      ?.workspaces ?? [];
+  const rows = data?.workspaces ?? [];
   const workspaces: ScopeWorkspace[] = rows.map((w) => ({
     id: w.workspace_id,
     name: w.name || t('plugins.scope.unknownWorkspace'),


### PR DESCRIPTION
## Summary

A workspace's name lived in two places that drifted apart: a `---` YAML header inside `agent.md`, which the agent could rewrite, and the `workspaces` row, which the UI shows. The agent read the header, so a rename in the UI never reached it. This branch makes the row the single source of truth and deletes the header parser, then fixes the frontend half where the chat header kept the name it was handed at mount and only picked up a rename on reload.

Four adjacent bugs on the same seam fell out of that work and are fixed in their own commits: an `agent.md` cache that only invalidated for one spelling of the file's path, a cache that swallowed a failed read as an empty notebook, an image-capture path fold that spliced a directory name out of the middle of a path, and a `MarketView` workspace list that shipped a stale copy in local state.

## Overview

| Category | Files | +LOC | -LOC |
|---|---:|---:|---:|
| Modified | 34 | 491 | 422 |
| New | 4 | 268 | 0 |
| Tests (excluded from net) | 8 | 427 | 107 |
| **Net (excl. tests)** | **30** | **332** | **315** |

### `src/ptc_agent/` (net +161/-186)

- `core/paths.py` (+27/-1) new `workspace_relative_path`: folds the spellings of a workspace file (`agent.md`, `/agent.md`, `./agent.md`, `/home/workspace/agent.md`) into one comparable key. `removeprefix`, never `lstrip`, so `.agents/...` keeps the dot that makes it hidden.
- `core/session.py` (+22/-16) `get_agent_md` no longer caches `None` when the read raises. The last known content survives and the entry stays dirty for the next attempt.
- `agent/middleware/workspace_context.py` (+51/-110) the front-matter parser and its fire-and-forget DB write are gone. The middleware now emits a `<workspace>` block built from the row, ahead of `<agentmd>`.
- `agent/graph.py` (+34/-3) reads the name and description inside the `asyncio.gather` that already runs at graph build, so it costs no extra round trip in wall-clock terms.
- `agent/agent.py` (+9/-1) threads `workspace_name` and `workspace_description` to the middleware.
- `agent/middleware/file_operations/sse_middleware.py` (+4/-7) uses the shared fold for its `== "agent.md"` check. Before, only the bare spelling matched, so an edit written as `/agent.md` left the cache holding pre-edit text.
- `agent/middleware/image_capture.py` (+14/-19) drops a hand-rolled fold entirely and hands the raw path to `sandbox.normalize_path`.
- `agent/prompts/templates/components/workspace_context.md.j2` (+2/-0) tells the agent the `<workspace>` block is authoritative and that a `---` header in an older notebook is a stale leftover it may correct.

### `src/server/` (net +52/-41)

- `database/workspace.py` (+29/-0) new `get_workspace_name_and_description`: a narrow `SELECT name, description` with the same `status != 'deleted'` predicate the rest of the module uses.
- `services/workspace_manager.py` (+22/-38) `_seed_agent_md` writes a nameless template. Nothing generates front matter any more.
- `services/persistence/image_capture.py` (+1/-3) follows the middleware in dropping the fold.

### `web/src/` (net +119/-88)

- `pages/ChatAgent/components/ChatView.tsx` (+28/-22) the header reads `useWorkspace(workspaceId).data` instead of a prop captured at mount. The two route-state reads are frozen in a ref on purpose: several `ChatView`s are mounted at once behind `display: none` and share one `useLocation`, so a live read would hand every background view the mode of whichever thread was just opened.
- `hooks/useWorkspace.ts` (+10/-2) seeds `initialData` from any already-cached list, so the header renders the right name on first paint instead of after the detail fetch.
- `pages/MarketView/MarketView.tsx` (+48/-30) the workspace selector reads the shared `useWorkspaces` query rather than a one-shot fetch copied into `useState`, so a rename elsewhere reaches it. The selection reconcile runs once per mount against a forced fresh read.
- `hooks/useWorkspaces.ts` (+5/-1) accepts a `refetchOnMount` passthrough for a consumer that has to decide something against the current list.
- `pages/ChatAgent/utils/api/workspaces.ts` (+5/-5) `getWorkspaces` and `getWorkspace` return typed responses.
- 10 more files (+13/-28) drop the `as any` casts that typing made unnecessary, and a duplicate local `Workspace` interface is replaced by the canonical one.

### Tests (+427/-107, excluded from net)

- `tests/unit/ptc_agent/agent/test_workspace_naming.py` (new, +62) the reader path: row present, NULL description, reader raises, row missing, non-UUID id.
- `tests/unit/middleware/test_agent_md_write_invalidation.py` (new, +64) every spelling of the path invalidates, and a near-miss does not.
- `tests/unit/core/test_session_agent_md_cache.py` (new, +60) a failed read keeps the last value and stays dirty.
- `web/e2e/workspace-rename.spec.js` (new, +82) rename from the sidebar, header flips without a reload.
- `tests/unit/middleware/test_workspace_context.py` (+90/-101) rewritten around the block instead of the parser: escaping, ordering, truncation, and a legacy `---` header surviving as plain text.
- `tests/unit/ptc_agent/agent/middleware/test_image_capture.py` (+52/-1) the fake sandbox now mirrors the real `normalize_path`, including the allowed-roots passthrough that the old fake papered over.

**What this introduces:** renaming a workspace now changes what the agent calls it, on the next turn, on any worker, and the chat header updates the moment the rename lands instead of on the next page load.

## Diff Size

```
Total: 38 files changed, 759 insertions(+), 422 deletions(-)
Net (excl. tests): 30 files changed, 332 insertions(+), 315 deletions(-)
```

## Walkthrough

### The name had two homes

`agent.md` opened with a `---` block carrying `workspace_name:`. The middleware parsed it, injected the name, and fired a background write back to the `workspaces` row when the two disagreed. The agent owns `agent.md`, so it could rewrite that header; the UI owns the row. Whichever wrote last won, and a rename in the UI lost to the next turn that rewrote the notebook.

The row is the only thing the user can see and edit, so it wins. `WorkspaceContextMiddleware` now receives `(name, description)` read at graph build and emits:

```
<workspace>
Name: Q3 Semis Deep Dive
Description: ...
</workspace>
```

as element text with `html.escape(quote=False)`, so an apostrophe in a workspace name survives intact. The parser, the reconcile, and the background write are deleted, and `_seed_agent_md` stops emitting front matter. Existing notebooks keep theirs as ordinary text; the prompt tells the agent it is a stale leftover it may clean up.

### One fold for one concept

Three sites had each hand-rolled the same idea, differently, and each had a bug:

- The `agent.md` cache compared `file_path == "agent.md"`, so a write to `/agent.md` never invalidated it and the rest of the turn read pre-edit content.
- `image_capture` used `path.replace(work_dir, "")`, which strips every occurrence rather than the prefix, so `/home/workspace/mirror/home/workspace/c.png` collapsed to `mirrorc.png`.

`workspace_relative_path` is the shared fold, and `image_capture` turned out not to need a fold at all: `sandbox.normalize_path` already resolves every spelling, and it is the only thing that knows an absolute path may name an allowed root outside the work dir. Folding first re-rooted `/tmp/chart.png` (matplotlib's default savefig target, and `/tmp` is an `allowed_directories` default) to `/home/workspace/tmp/chart.png`, the download missed, and the markdown silently kept a path the browser cannot load. That is now pinned by a test that fails red on the folded version.

### Stale name in the chat header

`ChatView` took the workspace name as a prop resolved at mount. Renaming from the sidebar updated the sidebar and left the header showing the old name until a reload. It now reads the detail query, whose key the rename already invalidates.

`MarketView` had the same shape one level up: a `getWorkspaces` call on mount copied into `useState`, so its selector kept the old name for the life of the page. It now reads the shared query. Its selection reconcile ("is my restored selection still there?") is a mount-time question and stays one: absence from that list is not proof of deletion, since it is one page of 50 ordered by recency and an idle selection falls off it on its own. Re-running it on every background refetch would clear the selection mid-session, and `MarketChatPanel` reads a workspace change as a scope change the user made and discards the open thread.

## Verification

- Backend unit suite: 9736 passed, 0 failed.
- Vitest: 3526 passed, 0 failed.
- `tsc --noEmit` clean. Ruff clean. ESLint 0 errors.
- `web/e2e/workspace-rename.spec.js` passes against the mock server.
- The new DB reader exercised against real Postgres: name plus description, NULL description returns `None` rather than the string `"None"`, a `deleted` row returns nothing, a missing id returns nothing, a non-UUID id returns nothing instead of raising, and an uppercased UUID resolves.
- The `/tmp` image-capture regression reproduced red before the fix (`/home/workspace/tmp/chart.png` vs `/tmp/chart.png`) and green after.

One flaky failure appeared in a single full-suite run and did not reproduce: `test_mcp_client_negotiation.py::test_import_crash_reports_cause_and_isolation_hint`, which spawns a real subprocess under a 1-second `_PROBE_TIMEOUT` and is load-sensitive. The branch touches none of that code.

## Risks

- **Older notebooks still carry a `---` header.** Nothing parses it now, so it renders to the model as ordinary text at the top of `agent.md`. The prompt names it as stale and invites the agent to clean it up, but until a turn does, a model could still read a stale name out of it. The `<workspace>` block is stated as authoritative and appears in the same prompt.
- **Compaction and offload pay a read they do not use.** `/compact` and `/offload` build the full PTC graph to reach `aget_state`/`aupdate_state`, so they now run the extra `SELECT` too, and then discard it: the summarization call goes to `compact_messages` with a bare message list and never renders the system prompt. The read is inside the existing `gather` and is one indexed row, so it adds no serial latency to a path that already does a graph build and two checkpointer round-trips. The clean fix is a flag on `build_ptc_graph_with_session` for callers that only want a checkpointer handle, which is wider than this branch should carry.
- **`MarketView` now forces a fetch on mount.** The reconcile only accepts a fetch that happened during this mount, and the query has a 30s `staleTime`, so without `refetchOnMount: 'always'` a remount inside that window would serve from cache with no request and the check would never run at all. The cost is one list request per `MarketView` mount.
- **No process-local cache holds a workspace name.** On a multi-worker server a rename lands on the next turn regardless of which worker serves it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791185108&installation_model_id=432753&pr_number=397&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F397&signature=0441ced9e2f7b02ab2ce03c86553c50fb4d95e9e2551bdd3e8be3d87388ba2dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspace names and descriptions now appear as authoritative context during agent conversations.
  - Renaming a workspace updates the active chat header immediately.
  - Workspace lists can be refreshed when a page loads.

- **Bug Fixes**
  - Failed reads of workspace notes preserve the last successful content and are retried.
  - Workspace-root file paths and captured images are handled more consistently across absolute and relative paths.
  - Workspace setup notes now use a consistent starter template, with identity details presented separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->