### PR TITLE
fix(llms): scope the raw-reasoning rescue to DashScope streams

### DIFF
--- a/src/llms/extension/dashscope.py
+++ b/src/llms/extension/dashscope.py
@@ -6,8 +6,19 @@ converter has no branch for, so both fall through its final ``else`` and vanish:
 ``response.failed`` carries the reason a stream died. The bridge below rescues
 both, which is the difference between a Qwen turn that shows its reasoning and
 names its own failures, and one that silently returns nothing.
+
+The two halves reach different distances, because the evidence for them does.
+``response.failed`` is rescued for every Responses backend: the event type is
+self-describing, no provider means anything else by it, and letting it through
+returns a half-finished stream as a success. The raw-reasoning rewrite is scoped
+to this client, because it guesses how one provider numbers its thought sections
+and a backend emitting both reasoning families would collide on
+``summary_index``. Scope is carried by a ContextVar the streaming overrides set
+while upstream's body runs; widening it to another provider later is one more
+read in ``_patched``.
 """
 
+import contextvars
 import logging
 
 from langchain_openai import ChatOpenAI
@@ -18,6 +29,12 @@ logger = logging.getLogger(__name__)
 # a user can see, so a newline in it would forge a second log entry.
 _MAX_PROVIDER_TEXT = 500
 
+# True only while this client's own Responses stream is being advanced, which is
+# exactly the window in which upstream calls the converter the bridge replaces.
+_in_dashscope_stream: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "in_dashscope_stream", default=False
+)
+
 
 def _one_line(value) -> str | None:
     if value is None:
@@ -26,16 +43,66 @@ def _one_line(value) -> str | None:
 
 
 class ChatDashScope(ChatOpenAI):
-    """ChatOpenAI under a DashScope name, carrying no request-side behavior.
+    """ChatOpenAI under a DashScope name, marking its own stream while it runs.
 
-    DashScope accepts the standard Responses payload, and replaying a prior
-    turn's reasoning item back to it round-trips, so there is nothing to
-    override yet. The subclass earns its place by giving the route a name: the
-    manifest's ``sdk`` says DashScope, the factory hands back a class that says
-    DashScope, and anything provider-specific that shows up later has a home
-    that is not an ``if`` in the shared OpenAI path. It does not scope the
-    bridge below, which is process-wide.
+    DashScope accepts the standard Responses payload and replaying a prior
+    turn's reasoning item back to it round-trips, so nothing about the request
+    is overridden. The two overrides exist only to raise a flag while upstream's
+    body runs: the converter the bridge replaces is a module global taking no
+    provider argument, so this is the only handle it has for telling a Qwen
+    stream apart from any other Responses stream in the process.
+
+    They hook ``_stream``/``_astream`` and not the ``*_responses`` pair those
+    dispatch to, which would read as the tighter choice and is in fact dead
+    code: ``ChatOpenAI._stream`` reaches the Responses body through ``super()``,
+    so an override of it on a subclass is never consulted. Nothing reports that,
+    the flag simply never rises, which is why a test drives a real stream and
+    asserts the converter sees the flag rather than calling the overrides here.
     """
+
+    def _stream(self, *args, **kwargs):
+        stream = iter(super()._stream(*args, **kwargs))
+        try:
+            while True:
+                # Set around the resume and never held across the ``yield``: a
+                # generator body runs in its caller's context, so a flag still
+                # set at the yield would stay set for the caller, and the next
+                # plain OpenAI stream opened in that same context would be read
+                # as a Qwen one.
+                token = _in_dashscope_stream.set(True)
+                try:
+                    chunk = next(stream)
+                except StopIteration:
+                    return
+                finally:
+                    _in_dashscope_stream.reset(token)
+                yield chunk
+        finally:
+            # Reached on an abandoned stream too, where it is what propagates
+            # the close into upstream's ``with`` and releases the response. Looked
+            # up rather than called, because upstream returns this as an
+            # ``Iterator``, and only the generator it happens to be has a close.
+            close = getattr(stream, "close", None)
+            if close is not None:
+                close()
+
+    async def _astream(self, *args, **kwargs):
+        stream = super()._astream(*args, **kwargs).__aiter__()
+        try:
+            while True:
+                # Same window as the sync twin above, and for the same reason.
+                token = _in_dashscope_stream.set(True)
+                try:
+                    chunk = await stream.__anext__()
+                except StopAsyncIteration:
+                    return
+                finally:
+                    _in_dashscope_stream.reset(token)
+                yield chunk
+        finally:
+            aclose = getattr(stream, "aclose", None)
+            if aclose is not None:
+                await aclose()
 
 
 class ResponsesStreamFailedError(RuntimeError):
@@ -72,13 +139,18 @@ class ResponsesStreamFailedError(RuntimeError):
 _TERMINAL_SERVER_ERROR_TOKENS = ("DataInspectionFailed",)
 
 
-def _status_for(code: str | None, message: str) -> int | None:
-    """What a DashScope failure code means, as an HTTP status, or None if unknown.
+def _status_for_failure_code(code: str | None, message: str) -> int | None:
+    """What a failed stream's error code means as an HTTP status, or None if unknown.
 
-    Neither field decides this alone: the code says ``server_error`` for a
-    permanent content block, and the message carries no status at all for an
-    unsupported model. Returning None leaves the older message-regex guess in
-    place, so an unrecognised code behaves exactly as it did before.
+    The codes are the ones observed from DashScope, but this decides for every
+    Responses backend, because the failure it feeds is not scoped to one. That
+    holds up rather than merely not having broken yet: ``InvalidParameter`` is
+    DashScope's own spelling and is not in the OpenAI SDK's error vocabulary at
+    all, ``server_error`` turns permanent only on prose no other provider
+    writes, and ``rate_limit_exceeded`` means 429 wherever it appears.
+
+    Anything unrecognised returns None, which leaves the older message-regex
+    guess in ``src.llms.error_classification`` exactly as it was.
     """
     if code == "InvalidParameter":
         return 400
@@ -96,12 +168,11 @@ def _status_for(code: str | None, message: str) -> int | None:
 def _install_responses_stream_bridge() -> None:
     """Rescue the two event families langchain-openai's Responses converter drops.
 
-    The hook is a module global, so this is process-wide and keyed on event
-    type rather than on provider: any Responses backend that emits these two
-    frames gets the same treatment, which is what makes it a fix to the
-    converter's blind spot rather than a DashScope special case. One installer
-    wrapping it once, not two, since a second would stack in import order and
-    collide on the idempotence flag.
+    The hook is a module global taking no provider argument, so the wrapper is
+    process-wide and each half picks its own reach inside it: ``response.failed``
+    for every backend, the raw-reasoning rewrite only for a stream
+    ``ChatDashScope`` has marked. One installer wrapping it once, not two, since
+    a second would stack in import order and collide on the idempotence flag.
     """
     try:
         import langchain_openai.chat_models.base as base
@@ -114,7 +185,8 @@ def _install_responses_stream_bridge() -> None:
         logger.warning(
             "Responses stream bridge not installed: "
             "langchain_openai._convert_responses_chunk_to_generation_chunk is gone; "
-            "Qwen turns will stream without reasoning and fail without a reason"
+            "Qwen turns will stream without reasoning, and every Responses stream "
+            "will report a killed stream as a truncated success"
         )
         return
 
@@ -122,6 +194,7 @@ def _install_responses_stream_bridge() -> None:
         return
 
     _warned_unbridgeable = False
+    _warned_off_scope = False
 
     def _as_summary_delta(chunk):
         """Rewrite a raw-reasoning delta as the summary event upstream understands.
@@ -130,8 +203,10 @@ def _install_responses_stream_bridge() -> None:
         rotting: block shape, index bookkeeping and the v0 downgrade all stay
         upstream's. ``content_index`` becomes ``summary_index`` because both
         number the thought section, which the SSE layer reads to space sections
-        apart. The ``done`` event is deliberately still dropped, since the
-        deltas already aggregate to the same text.
+        apart. Reusing that number is also why the caller scopes this to one
+        provider: a backend emitting both reasoning families would have the two
+        share a section. The ``done`` event is deliberately still dropped, since
+        the deltas already aggregate to the same text.
         """
         try:
             return ResponseReasoningSummaryTextDeltaEvent(
@@ -171,13 +246,37 @@ def _install_responses_stream_bridge() -> None:
         raise ResponsesStreamFailedError(
             f"Responses stream failed ({code}): {message}",
             code=code,
-            status_code=_status_for(code, message),
+            status_code=_status_for_failure_code(code, message),
+        )
+
+    def _note_off_scope_reasoning() -> None:
+        """Say once that a backend outside the scope emits raw reasoning we drop.
+
+        The scope above is a claim about which providers emit this family, and
+        upstream drops what it does not recognise in silence, so the day the
+        claim is wrong the only symptom is a model that stopped showing its
+        thinking. Every backend we have measured outside the scope emits the
+        summary family and never this one, so the line is silent on known
+        ground and firing at all is the claim being wrong. One per process,
+        since this is reached once per reasoning token.
+        """
+        nonlocal _warned_off_scope
+        if _warned_off_scope:
+            return
+        _warned_off_scope = True
+        logger.warning(
+            "Dropping raw reasoning from a Responses backend outside the bridge's "
+            "scope. If this model should show its thinking, its client has to mark "
+            "its own stream the way ChatDashScope does."
         )
 
     def _patched(chunk, *args, **kwargs):
         chunk_type = getattr(chunk, "type", None)
         if chunk_type == "response.reasoning_text.delta":
-            chunk = _as_summary_delta(chunk)
+            if _in_dashscope_stream.get():
+                chunk = _as_summary_delta(chunk)
+            else:
+                _note_off_scope_reasoning()
         elif chunk_type == "response.failed":
             _raise_if_failed(chunk)
 

--- a/src/server/services/llm/clients.py
+++ b/src/server/services/llm/clients.py
@@ -143,11 +143,13 @@ async def _walk_byok_candidates(
     return None, None
 
 
-# SDKs that speak the OpenAI wire shape, so the ``"openai"`` a custom provider
-# derives by default already reaches them. A parent on this list is skipped by
-# ``_inherit_custom_provider_sdk`` below; anything added here must be routable
-# by a plain ``ChatOpenAI`` against a third-party gateway.
-_OPENAI_SHAPED_SDKS = (None, "openai", "dashscope")
+# Parents with no dialect of their own. ``openai`` is the base shape a great
+# many services implement rather than a vendor whose behaviour you would want
+# copied, and a provider declaring ``sdk: "openai"`` is saying exactly that
+# about itself. A parent on this list is skipped by
+# ``_inherit_custom_provider_sdk`` below, so its OpenAI-specific request
+# shaping (``use_response_api``, ``prompt_cache_key``) stays opt-in.
+_OPENAI_SHAPED_SDKS = (None, "openai")
 
 
 def _inherit_custom_provider_sdk(custom_config, parent_provider, provider_def, mc):
@@ -159,17 +161,34 @@ def _inherit_custom_provider_sdk(custom_config, parent_provider, provider_def, m
     (``/chat/completions`` vs ``/v1/messages``). Rewriting ``provider`` to the
     manifest parent fixes the SDK and ``default_headers``.
 
-    Skip the rewrite for OpenAI-shaped parents: the default already reaches
-    them, and inheriting the manifest entry would force ``use_response_api`` /
-    ``prompt_cache_key`` onto OpenAI-compatible gateways (vLLM/LiteLLM/
-    OpenRouter) that only speak ``/chat/completions``. The custom provider's own
-    ``use_response_api`` opt-in is honoured either way.
+    Naming a parent is how a custom provider says what it is, so it gets that
+    parent's dialect: SDK, ``default_headers``, and the request shaping the
+    manifest entry declares. ``openai`` is the exception, because it is the base
+    shape a great many unrelated services implement rather than a vendor whose
+    behaviour a gateway means to copy. Declaring it says "my API is OpenAI
+    shaped", not "treat me as OpenAI", so its ``use_response_api`` and
+    ``prompt_cache_key`` stay opt-in and a gateway that only speaks
+    ``/chat/completions`` is left alone. Providers that declare ``sdk:
+    "openai"`` themselves (vLLM, Groq, DeepInfra, LM Studio) are saying the same
+    thing about themselves and are covered by the same entry.
+
+    A parent with its own SDK is a real dialect, so declaring it matches
+    everything. DashScope is the case that makes this concrete: it has its own
+    client because its raw reasoning is rescued by a bridge scoped to
+    ``ChatDashScope``, and a gateway left on a plain ``ChatOpenAI`` would stream
+    every Qwen turn with the thinking silently dropped.
     """
     updates: dict = {}
     if mc.get_provider_info(parent_provider).get("sdk") not in _OPENAI_SHAPED_SDKS:
         updates["provider"] = parent_provider
-    if provider_def.get("use_response_api"):
-        updates["_use_response_api"] = True
+    # Tri-state, not a truthiness check: ``users.py`` validates this field as a
+    # boolean and so accepts an explicit ``false``, which is a gateway saying it
+    # speaks only ``/chat/completions``. Collapsing that into "absent" hands it
+    # the parent's manifest default instead, and for a parent that defaults the
+    # Responses API on, every call would go to ``/responses`` and fail.
+    declared_response_api = provider_def.get("use_response_api")
+    if declared_response_api is not None:
+        updates["_use_response_api"] = bool(declared_response_api)
     return {**custom_config, **updates} if updates else custom_config
 
 

--- a/tests/unit/llms/test_error_classification.py
+++ b/tests/unit/llms/test_error_classification.py
@@ -115,12 +115,12 @@ class TestDashScopeFailureStatus:
 
     @staticmethod
     def _error(code, message):
-        from src.llms.extension.dashscope import ResponsesStreamFailedError, _status_for
+        from src.llms.extension.dashscope import ResponsesStreamFailedError, _status_for_failure_code
 
         return ResponsesStreamFailedError(
             f"Responses stream failed ({code}): {message}",
             code=code,
-            status_code=_status_for(code, message),
+            status_code=_status_for_failure_code(code, message),
         )
 
     @pytest.mark.parametrize("code,message", LIVE_TERMINAL)

--- a/tests/unit/llms/test_responses_stream_bridge.py
+++ b/tests/unit/llms/test_responses_stream_bridge.py
@@ -1,0 +1,370 @@
+"""The Responses converter bridge: what it rescues, and for whom.
+
+Every test drives ``stream``/``astream``, the entry point production uses, over
+a stubbed SDK client. Reaching in at ``_stream_responses`` instead would pass
+just as happily while the scoping was dead: ``ChatOpenAI._stream`` dispatches to
+the Responses body through ``super()``, so a subclass override of that method is
+never consulted, and only a test that starts where callers start can tell.
+"""
+
+import asyncio
+import typing
+
+import pytest
+from langchain_core.messages import HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_openai.chat_models import base
+from openai.types.responses import (
+    ResponseFailedEvent,
+    ResponseReasoningTextDeltaEvent,
+    ResponseTextDeltaEvent,
+)
+from openai.types.responses.response import Response
+from openai.types.responses.response_error import ResponseError
+
+import src.llms  # noqa: F401  installs the bridge
+from src.llms.extension.dashscope import (
+    ChatDashScope,
+    ResponsesStreamFailedError,
+    _in_dashscope_stream,
+    _status_for_failure_code,
+)
+
+
+def _reasoning_delta(text="thinking out loud", *, sequence_number=1):
+    return ResponseReasoningTextDeltaEvent(
+        type="response.reasoning_text.delta",
+        delta=text,
+        item_id="rs_1",
+        output_index=0,
+        content_index=0,
+        sequence_number=sequence_number,
+    )
+
+
+def _text_delta(text="ok"):
+    return ResponseTextDeltaEvent(
+        type="response.output_text.delta",
+        delta=text,
+        item_id="msg_1",
+        output_index=1,
+        content_index=0,
+        sequence_number=99,
+        logprobs=[],
+    )
+
+
+def _failed(code=None, message=None):
+    response = Response(
+        id="resp_1",
+        created_at=0,
+        model="test-model",
+        object="response",
+        output=[],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        status="failed",
+        error={"code": code, "message": message} if code else None,
+    )
+    return ResponseFailedEvent(
+        type="response.failed", response=response, sequence_number=1
+    )
+
+
+class _FakeStream:
+    """Stands in for the SDK's streaming context manager, sync and async."""
+
+    def __init__(self, events):
+        self._events = events
+        self.exited = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.exited = True
+        return False
+
+    def __iter__(self):
+        return iter(self._events)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.exited = True
+        return False
+
+    def __aiter__(self):
+        return self._aiter()
+
+    async def _aiter(self):
+        for event in self._events:
+            yield event
+
+
+def _client(cls, events, *, is_async=False):
+    """A client of ``cls`` whose SDK stream replays ``events``.
+
+    A text delta is appended to every stream because langchain-core raises on a
+    run that yields no chunk at all, and a plain client is supposed to drop the
+    reasoning event that is often the only other one here.
+    """
+    stream = _FakeStream([*events, _text_delta()])
+
+    class _Responses:
+        def create(self, **kwargs):
+            return stream
+
+    class _AsyncResponses:
+        async def create(self, **kwargs):
+            return stream
+
+    class _Root:
+        responses = _AsyncResponses() if is_async else _Responses()
+
+    llm = cls(
+        model="test-model",
+        api_key="fake",
+        use_responses_api=True,
+        output_version="responses/v1",
+    )
+    object.__setattr__(llm, "root_async_client" if is_async else "root_client", _Root())
+    return llm, stream
+
+
+def _drain(llm):
+    return list(llm.stream([HumanMessage(content="hi")]))
+
+
+async def _adrain(llm):
+    return [c async for c in llm.astream([HumanMessage(content="hi")])]
+
+
+def _reasoning_text(chunks):
+    out = []
+    for chunk in chunks:
+        content = chunk.content if hasattr(chunk, "content") else []
+        for block in content if isinstance(content, list) else []:
+            if isinstance(block, dict) and block.get("type") == "reasoning":
+                out += [s["text"] for s in block.get("summary", [])]
+    return "".join(out)
+
+
+def _openai_error_codes():
+    """The SDK's declared `response.failed` codes, unwrapped from their Literal.
+
+    Read through ``get_args`` rather than off ``.__args__`` so an SDK that wraps
+    the annotation fails one parametrized case instead of the module import,
+    which would take the scope tests down with it.
+    """
+    annotation = ResponseError.model_fields["code"].annotation
+    args = typing.get_args(annotation)
+    while args and not all(isinstance(a, str) for a in args):
+        args = tuple(x for a in args for x in (typing.get_args(a) or ()))
+    return sorted(a for a in args if isinstance(a, str))
+
+
+@pytest.fixture(autouse=True)
+def _no_tracing(monkeypatch):
+    """Keep the tracer out of a hermetic suite.
+
+    These are the only unit tests that drive a real ``stream``/``astream``, so
+    they are the only ones that wake LangSmith if the developer's ``.env`` has
+    it on. It then posts these fake-model runs to a real tenant from a
+    background flush, after the socket block is lifted at teardown.
+    """
+    for flag in ("LANGCHAIN_TRACING_V2", "LANGSMITH_TRACING", "LANGCHAIN_TRACING"):
+        monkeypatch.setenv(flag, "false")
+    for key in ("LANGCHAIN_API_KEY", "LANGSMITH_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def converter_spy(monkeypatch):
+    """Records the scope flag as each raw event reaches the patched converter."""
+    installed = base._convert_responses_chunk_to_generation_chunk
+    seen = {}
+
+    def _spy(chunk, *args, **kwargs):
+        event = getattr(chunk, "type", None)
+        seen.setdefault(event, set()).add(_in_dashscope_stream.get())
+        return installed(chunk, *args, **kwargs)
+
+    monkeypatch.setattr(base, "_convert_responses_chunk_to_generation_chunk", _spy)
+    return seen
+
+
+class TestScopeReachesTheConverter:
+    """The flag has to be raised at the one moment the bridge reads it.
+
+    This is the regression guard for the attachment point. Hook the wrong
+    method and everything else still behaves: the client constructs, the stream
+    runs, the events arrive. Only the flag stays down, and only here does that
+    show up as a failure.
+    """
+
+    def test_dashscope_stream_raises_the_flag_at_the_converter(self, converter_spy):
+        llm, _ = _client(ChatDashScope, [_reasoning_delta()])
+        _drain(llm)
+        assert converter_spy["response.reasoning_text.delta"] == {True}
+
+    def test_plain_openai_stream_leaves_it_down(self, converter_spy):
+        llm, _ = _client(ChatOpenAI, [_reasoning_delta()])
+        _drain(llm)
+        assert converter_spy["response.reasoning_text.delta"] == {False}
+
+    @pytest.mark.asyncio
+    async def test_async_dashscope_stream_raises_the_flag(self, converter_spy):
+        llm, _ = _client(ChatDashScope, [_reasoning_delta()], is_async=True)
+        await _adrain(llm)
+        assert converter_spy["response.reasoning_text.delta"] == {True}
+
+
+class TestReasoningScope:
+    """The rewrite reaches a DashScope stream and nothing else."""
+
+    def test_dashscope_stream_surfaces_reasoning(self):
+        llm, _ = _client(ChatDashScope, [_reasoning_delta("thinking out loud")])
+        assert _reasoning_text(_drain(llm)) == "thinking out loud"
+
+    def test_plain_openai_stream_still_drops_it(self):
+        # Upstream's own behavior, deliberately left alone: this event family is
+        # not one OpenAI emits, so rewriting it there would only risk the
+        # summary_index collision for a frame that never arrives.
+        llm, _ = _client(ChatOpenAI, [_reasoning_delta()])
+        assert _reasoning_text(_drain(llm)) == ""
+
+    @pytest.mark.asyncio
+    async def test_async_dashscope_stream_surfaces_reasoning(self):
+        llm, _ = _client(ChatDashScope, [_reasoning_delta("async thought")], is_async=True)
+        assert _reasoning_text(await _adrain(llm)) == "async thought"
+
+    @pytest.mark.asyncio
+    async def test_async_plain_openai_stream_still_drops_it(self):
+        llm, _ = _client(ChatOpenAI, [_reasoning_delta()], is_async=True)
+        assert _reasoning_text(await _adrain(llm)) == ""
+
+
+class TestScopeDoesNotLeak:
+    """The flag is held around the resume only, never across the yield.
+
+    Setting it once for the life of the generator would be the obvious way to
+    write this and would be wrong: a generator body runs in its caller's
+    context, so the flag would still be raised in the consumer, and the next
+    plain stream opened there would be read as a DashScope one.
+    """
+
+    def test_caller_never_observes_the_flag(self):
+        llm, _ = _client(ChatDashScope, [_reasoning_delta() for _ in range(3)])
+        seen = [_in_dashscope_stream.get() for _ in llm.stream([HumanMessage(content="hi")])]
+        assert seen and set(seen) == {False}
+
+    def test_a_plain_stream_interleaved_with_a_live_one_stays_unscoped(self, converter_spy):
+        qwen, _ = _client(ChatDashScope, [_reasoning_delta() for _ in range(3)])
+        live = qwen.stream([HumanMessage(content="hi")])
+        next(live)  # left open, mid-flight
+
+        plain, _ = _client(ChatOpenAI, [_reasoning_delta()])
+        plain_chunks = _drain(plain)
+        assert converter_spy["response.reasoning_text.delta"] == {True, False}
+        assert _reasoning_text(plain_chunks) == ""
+
+        live.close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_tasks_do_not_share_scope(self):
+        qwen, _ = _client(ChatDashScope, [_reasoning_delta("qwen")], is_async=True)
+        plain, _ = _client(ChatOpenAI, [_reasoning_delta("openai")], is_async=True)
+
+        qwen_chunks, plain_chunks = await asyncio.gather(_adrain(qwen), _adrain(plain))
+        assert _reasoning_text(qwen_chunks) == "qwen"
+        assert _reasoning_text(plain_chunks) == ""
+
+    def test_abandoning_the_stream_closes_the_response(self):
+        llm, stream = _client(ChatDashScope, [_reasoning_delta() for _ in range(3)])
+        live = llm.stream([HumanMessage(content="hi")])
+        next(live)
+        assert stream.exited is False
+        live.close()
+        assert stream.exited is True
+
+
+class TestFailureIsRescuedEverywhere:
+    """``response.failed`` is not scoped, and the OpenAI path is the reason to check.
+
+    The event type is self-describing and every Responses backend can send it,
+    so a plain client raises on it too. Left unrescued it is worse than silent:
+    upstream discards the frame and the turn returns whatever the killed stream
+    had already accumulated, which for an agent turn can be a half-formed tool
+    call that then executes.
+    """
+
+    def test_openai_shaped_failure_raises_on_a_plain_client(self):
+        llm, _ = _client(ChatOpenAI, [_failed("rate_limit_exceeded", "slow down")])
+        with pytest.raises(ResponsesStreamFailedError) as exc_info:
+            _drain(llm)
+        assert exc_info.value.code == "rate_limit_exceeded"
+        assert exc_info.value.status_code == 429
+        assert "slow down" in str(exc_info.value)
+
+    def test_an_openai_code_we_do_not_map_defers_to_the_message(self):
+        llm, _ = _client(ChatOpenAI, [_failed("invalid_prompt", "rejected by policy")])
+        with pytest.raises(ResponsesStreamFailedError) as exc_info:
+            _drain(llm)
+        assert exc_info.value.status_code is None
+
+    @pytest.mark.asyncio
+    async def test_async_plain_client_raises_too(self):
+        llm, _ = _client(ChatOpenAI, [_failed("server_error", "boom")], is_async=True)
+        with pytest.raises(ResponsesStreamFailedError):
+            await _adrain(llm)
+
+    def test_failure_without_an_error_payload_still_raises(self):
+        llm, _ = _client(ChatDashScope, [_failed()])
+        with pytest.raises(ResponsesStreamFailedError) as exc_info:
+            _drain(llm)
+        assert exc_info.value.code is None
+        assert "no reason given" in str(exc_info.value)
+
+    def test_partial_output_is_not_returned_as_success(self):
+        llm, _ = _client(
+            ChatDashScope,
+            [_reasoning_delta("half a thought"), _failed("server_error", "killed")],
+        )
+        with pytest.raises(ResponsesStreamFailedError):
+            _drain(llm)
+
+
+class TestStatusMappingAssertsNothingItCannotKnow:
+    """The mapper runs process-wide, so it is pinned against OpenAI's own codes.
+
+    Every code the SDK declares must come back either unmapped, which restores
+    the older message-regex guess, or with the status that code means anywhere.
+    Unmapped is the honest answer for a code this provider never emits, not a
+    safe one: an unknown status reads as retryable, so an OpenAI policy verdict
+    arriving as ``response.failed`` spends the retry ladder before falling back.
+    That is the behaviour these codes already had, and giving them a status is a
+    change to the OpenAI route rather than to this one.
+    """
+
+    OPENAI_CODES = _openai_error_codes()
+
+    @pytest.mark.parametrize("code", OPENAI_CODES)
+    def test_no_openai_code_gets_a_wrong_status(self, code):
+        expected = 429 if code == "rate_limit_exceeded" else None
+        assert _status_for_failure_code(code, "an ordinary failure message") == expected
+
+    def test_dashscopes_own_code_is_absent_from_that_vocabulary(self):
+        # Which is why mapping it to 400 process-wide cannot mislead OpenAI.
+        assert "InvalidParameter" not in self.OPENAI_CODES
+
+    def test_the_permanent_server_error_turns_on_prose_not_on_the_code(self):
+        assert _status_for_failure_code("server_error", "upstream unavailable") is None
+        assert (
+            _status_for_failure_code(
+                "server_error", "<400> InternalError.Algo.DataInspectionFailed: blocked"
+            )
+            == 400
+        )

--- a/tests/unit/server/handlers/chat/test_custom_provider_sdk_inheritance.py
+++ b/tests/unit/server/handlers/chat/test_custom_provider_sdk_inheritance.py
@@ -97,14 +97,14 @@ async def test_openai_parent_does_not_rewrite_or_force_response_api():
 
 
 @pytest.mark.asyncio
-async def test_dashscope_parent_does_not_rewrite_or_force_response_api():
-    """A DashScope parent is OpenAI-shaped, so it gets the gateway treatment too.
+async def test_dashscope_parent_is_matched_in_full():
+    """A parent with its own SDK is a dialect, so naming it inherits all of it.
 
-    DashScope's manifest entry declares ``sdk: "dashscope"`` to route built-in
-    Qwen models at their own client, but a custom provider under that parent is
-    still someone's own endpoint. Rewriting it would inherit the manifest's
-    ``use_response_api`` and session-cache header, putting a gateway that only
-    speaks ``/chat/completions`` onto ``/responses`` with no way to opt out.
+    DashScope declares ``sdk: "dashscope"`` because it has a client of its own,
+    which is also what rescues its raw reasoning. A gateway that names it as a
+    parent is saying it is that thing, so it gets the client, the headers and
+    the manifest's ``use_response_api`` without opting in separately. Contrast
+    the ``openai`` parent above, which is a wire shape rather than a vendor.
     """
     provider_def = {"name": "my-qwen-gw", "parent_provider": "vendor-parent"}
     custom_model = {"name": "eval-model", "model_id": "some-model", "provider": "my-qwen-gw"}
@@ -114,8 +114,7 @@ async def test_dashscope_parent_does_not_rewrite_or_force_response_api():
     with p1, p2, p3:
         byok, base_url, out = await _resolve_custom_model_byok("u", "eval-model", dict(custom_model), mc)
 
-    assert out["provider"] == "my-qwen-gw"
-    assert "_use_response_api" not in out
+    assert out["provider"] == "vendor-parent"
 
 
 @pytest.mark.asyncio
@@ -133,3 +132,86 @@ async def test_custom_provider_explicit_use_response_api_opt_in_preserved():
         byok, base_url, out = await _resolve_custom_model_byok("u", "eval-model", dict(custom_model), mc)
 
     assert out.get("_use_response_api") is True
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_responses_opt_out_survives_the_inheritance():
+    """Inheriting a parent's default is not the same as ignoring what the child said.
+
+    ``users.py`` validates this field as a boolean, so ``false`` is a value a
+    gateway can actually store, and it means it speaks only
+    ``/chat/completions``. A truthiness check here forwards only ``true`` and
+    leaves ``false`` indistinguishable from absent, which hands the gateway the
+    parent's manifest default and points every call at ``/responses``.
+    """
+    provider_def = {
+        "name": "my-qwen-gw",
+        "parent_provider": "vendor-parent",
+        "use_response_api": False,
+    }
+    custom_model = {"name": "eval-model", "model_id": "some-model", "provider": "my-qwen-gw"}
+    mc = _mock_mc("dashscope", parent_extra={"use_response_api": True})
+
+    p1, p2, p3 = _patches(provider_def)
+    with p1, p2, p3:
+        byok, base_url, out = await _resolve_custom_model_byok("u", "eval-model", dict(custom_model), mc)
+
+    # Still the parent's dialect: the opt-out is about the route, not the client.
+    assert out["provider"] == "vendor-parent"
+    assert out["_use_response_api"] is False
+
+
+def test_an_explicit_opt_out_reaches_the_client_as_chat_completions():
+    """The opt-out has to survive to the built client, not just the config.
+
+    ``False`` and absent take different paths through ``ModelSpec`` only if the
+    key is present, so this is the assertion that a truthiness check breaks.
+    """
+    from src.llms.extension import ChatDashScope
+    from src.llms.llm import LLM
+
+    def build(**extra):
+        return LLM.from_custom_config(
+            {"name": "eval-model", "model_id": "qwen3.8-max", "provider": "dashscope", **extra},
+            api_key="sk-test",
+            base_url_override="https://gw.example.com/v1",
+        )
+
+    opted_out = build(_use_response_api=False)
+    assert isinstance(opted_out, ChatDashScope)  # the bridge still applies
+    assert opted_out.output_version != "responses/v1"
+
+    # Absent still inherits the parent's default, which is the rule above.
+    assert build().output_version == "responses/v1"
+
+
+def test_an_inherited_dashscope_provider_actually_builds_the_bridged_client():
+    """The rewrite above is only worth anything if it changes the client class.
+
+    Asserting on the config alone would keep passing if the factory stopped
+    honouring ``provider``, which is the failure the rewrite exists to prevent.
+    """
+    from langchain_openai import ChatOpenAI
+
+    from src.llms.extension import ChatDashScope
+    from src.llms.llm import LLM
+
+    # No ``_use_response_api``: the inherited parent is what supplies it, which
+    # is the half of "matched in full" a config assertion cannot see.
+    def build(provider):
+        return LLM.from_custom_config(
+            {"name": "eval-model", "model_id": "qwen3.8-max", "provider": provider},
+            api_key="sk-test",
+            base_url_override="https://gw.example.com/v1",
+        )
+
+    not_inherited = build("my-qwen-gw")
+    assert isinstance(not_inherited, ChatOpenAI)
+    assert not isinstance(not_inherited, ChatDashScope)
+
+    inherited = build("dashscope")
+    assert isinstance(inherited, ChatDashScope)
+    # The Responses opt-in rides as ``output_version``; see llm.py:698.
+    assert inherited.output_version == "responses/v1"
+    # The gateway's own endpoint outranks the manifest's, both ways.
+    assert inherited.openai_api_base == "https://gw.example.com/v1"


### PR DESCRIPTION
## Summary

The Responses stream bridge rescues two event families langchain-openai's converter drops on the floor: `response.reasoning_text.delta`, which carries raw thinking tokens, and `response.failed`, which carries the reason a stream died. It installs by rewriting a module global, so both halves ran for every Responses backend in the process.

Only one of them has the evidence to justify that reach. This narrows the raw-reasoning rewrite to the client that provoked it and leaves the failure rescue where it was.

## Overview

**What this introduces**

- The raw-reasoning rewrite now follows `ChatDashScope` instead of every Responses stream in the process. It guesses how one provider numbers its thought sections, and a backend emitting both reasoning families would have had the two collide on `summary_index`.
- `response.failed` still raises for every Responses backend. The event type is self-describing, no provider means anything else by it, and letting it through returns a killed stream as a truncated success.
- `dashscope` comes off `_OPENAI_SHAPED_SDKS`, so a custom provider naming it as a parent inherits its client, headers and `use_response_api` like any other parent with an SDK of its own. That list is for `openai`, the base wire shape a great many unrelated services implement, where declaring the parent means "my API is shaped like this" rather than "treat me as this vendor". Providers that declare `sdk: "openai"` themselves (vLLM, Groq, DeepInfra, LM Studio) are saying the same thing and keep their opt-in unchanged.
- A gateway that explicitly sets `use_response_api: false` keeps that opt-out. It still inherits the parent's client, so the reasoning bridge still applies; only the route stays on `/chat/completions`.
- A backend that emits raw reasoning from outside the scope now warns once per process, instead of having it dropped in silence. Every backend measured outside the scope emits the summary family and never this one, so the line is silent on known ground and firing at all is the scope's claim being wrong.

**Totals**

| | files | + | - |
|---|---|---|---|
| All | 5 | 620 | 50 |
| Net (excl. tests) | 2 | 156 | 38 |
| Tests | 3 | 464 | 12 |

**By module**

*Backend, LLM layer*
- `src/llms/extension/dashscope.py` (+125/-26): the `_in_dashscope_stream` ContextVar, the `_stream`/`_astream` overrides that raise it, the off-scope diagnostic, and `_status_for` renamed to `_status_for_failure_code`.
- `src/server/services/llm/clients.py` (+31/-12): `dashscope` removed from `_OPENAI_SHAPED_SDKS`, which is now documented as the list of parents with no dialect of their own, and `use_response_api` forwarded as the tri-state `users.py` already validates so an explicit opt-out is not read as absent.

*Tests*
- `tests/unit/llms/test_responses_stream_bridge.py` (new, +370): scope, leak, failure-rescue and status-mapping coverage.
- `tests/unit/server/handlers/chat/test_custom_provider_sdk_inheritance.py` (+92/-10): the overturned dashscope case and the explicit Responses opt-out, each asserted at the config and at the client class.
- `tests/unit/llms/test_error_classification.py` (+2/-2): the rename, kept in the same commit as the rename so bisect stays green.

## Why this way

**The two halves reach different distances because the evidence for them does.** `InvalidParameter` is DashScope's own spelling and is absent from the OpenAI SDK's error vocabulary; `server_error` turns permanent only on prose no other provider writes; `rate_limit_exceeded` means 429 wherever it appears. So the failure mapper decides safely process-wide. The reasoning rewrite has no equivalent argument: it reuses `content_index` as `summary_index`, which is a guess about one provider's numbering.

**Scope is a ContextVar, set around each resume and never held across the `yield`.** A generator body runs in its caller's context, so a flag still set at the yield would stay set for the consumer, and the next plain OpenAI stream opened in that context would be read as a Qwen one. Setting it around `next()` / `__anext__()` and resetting in a `finally` before the yield is leak-free, and separate asyncio tasks copy context at creation, so they are isolated without further work.

**The overrides hook `_stream`/`_astream`, not the `*_responses` pair those dispatch to.** Hooking the tighter-looking pair is dead code: `ChatOpenAI._stream` reaches the Responses body through `super()`, so a subclass override of `_stream_responses` is never consulted. Nothing reports this. The flag simply never rises. That is why the tests drive `stream()` / `astream()` and assert the flag *at the converter*, rather than calling the overrides directly, which is a path production never takes.

**A parent with its own SDK is a dialect; `openai` is a shape.** `_OPENAI_SHAPED_SDKS` skips the SDK inheritance for parents a plain `ChatOpenAI` already reaches, so their OpenAI-specific request shaping (`use_response_api`, `prompt_cache_key`) stays opt-in and a gateway that only speaks `/chat/completions` is left alone. That is right for `openai` and for every provider that declares `sdk: "openai"` about itself. `dashscope` was on the list too, and it was the one entry there whose SDK has its own client class, so naming it as a parent quietly did not give you that class. Harmless while the bridge was process-wide, since a plain `ChatOpenAI` got the reasoning anyway; consequential the moment scope moved onto the client. Removing it makes the list mean exactly one thing, and leaves the `openai` opt-in untouched.

## Verification

- **Live, both providers, instrumented at the converter.** `qwen3.8-max` emitted 24 `response.reasoning_text.delta` events, all seen with the flag up, 105 characters of reasoning recovered. `gpt-5.6-sol` emitted 101 `response.reasoning_summary_text.delta` and **zero** raw events, flag down, 389 characters, unchanged. That measures rather than argues the claim that the narrowing is inert for OpenAI.
- **The codex backend was probed directly** for the same question: `gpt-5.6-sol` emits only `reasoning_summary_*`, and `gpt-5.3-codex-spark` emits no reasoning family at all. That route loses nothing.
- **The custom-provider path was exercised through the real factory**, not just the resolver: a config naming `dashscope` builds `ChatDashScope` with `output_version: responses/v1` and the session-cache header, while the un-inherited slug builds a plain `ChatOpenAI`. The gateway's own `base_url` survives both ways.
- **Five ablations confirm the tests discriminate.** Hooking the `*_responses` pair fails 6; dropping the guard fails 3; a naive set-once fails 6; removing the overrides fails 6; removing `dashscope` from the shape-only list fails 1.
- **Backend suite:** 9785 passed, 23 skipped, 594 deselected by the project's default scope. `ruff check src/` clean, and the touched test files are clean too. The one xfail-marked test, `test_delta_channel_ordering.py::test_fan_out_reconstruction_preserves_live_order`, xpassed on this run and xfailed on the previous two, matching its own reason describing it as roughly 50/50 nondeterministic. It is untouched by this branch.
- Frontend is untouched by this branch and was not re-run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DashScope streaming responses now surface reasoning updates correctly in synchronous and asynchronous usage.
  * Custom providers using DashScope configurations now inherit the expected connection settings and response behavior.
  * Explicitly disabling the Responses API is now respected for inherited provider configurations.
* **Bug Fixes**
  * Stream failures now consistently produce clear errors with appropriate status details.
  * Reasoning content from non-DashScope streams is no longer incorrectly rewritten.
  * Stream cleanup and concurrent streaming behavior are more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->