### PR TITLE
fix(web): focus ring, transcript spacing and a named settings control

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,6 +25,7 @@ be declared there (enforced by `web/src/styles/__tests__/tokenRefs.test.ts`).
 | Cards | `hsl(var(--card))` ~#202020 | white + `#E8E8E6` hairline |
 | Elevated (menus, tooltips) | `#2A2B2E` | `#F7F7F6` |
 | Primary text | `#E6E6E4` | `#1F1F1E` |
+| Focus ring | = primary text | = primary text |
 | Accent (annotation) | `#E9954A` | `#D07D33` |
 | Primary button | `#ECECEA` bg / `#1A1B1D` text | `#1F1D1A` bg / `#FAF9F7` text |
 | Profit / loss | `#3FB950` / `#F85149` | `#1A7F37` / `#CF222E` |
@@ -66,9 +67,8 @@ brand by hand, which is how that panel spent a rebrand still showing the old one
 
 **The sign-in page is the one product surface that is exempt**, and the reason
 is that the rule has nothing to bite on there. It carries no chrome, no
-navigation and no data, so there is nothing for the accent to annotate, and the
-neutral focus ring would paint in a color the page uses nowhere else. Amber is
-its whole interaction vocabulary instead: the submit button has always taken the
+navigation and no data, so there is nothing for the accent to annotate. Amber
+is its whole interaction vocabulary instead: the submit button has always taken the
 fill on hover, and keyboard focus takes the same fill rather than inventing a
 second language for the same "about to act" state. Focus is not left to hue
 alone, since hue is what a color deficiency flattens: an underline by default, a

--- a/web/e2e/auth-surface.focus.spec.js
+++ b/web/e2e/auth-surface.focus.spec.js
@@ -151,6 +151,24 @@ test.describe('a field on the auth surface', () => {
     expect(tabbed.shadow).not.toBe(clicked.shadow);
     expect(clicked.shadow).not.toBe('none');
   });
+
+  test('keeps the muted halo while the user is typing into it', async ({ page }) => {
+    // This rule reads the *absence* of the recorded device, and typing is a
+    // keydown. lib/inputModality.ts refreshes that record on a keydown so a
+    // clicked <select> rings once the keyboard takes over, and the guard that
+    // stops the refresh reaching a text field is what keeps the ember off an
+    // address someone is halfway through. The outline assertions above cannot
+    // see this one: the ember is a border and a shadow, not an outline.
+    await emailView(page);
+    await page.locator(EMAIL).click();
+    const clicked = await paintOn(page, EMAIL);
+
+    await page.keyboard.type('someone@example.com');
+    const typed = await paintOn(page, EMAIL);
+    expect(typed.focused).toBe(true);
+    expect(typed.border).toBe(clicked.border);
+    expect(typed.shadow).toBe(clicked.shadow);
+  });
 });
 
 test.describe('a button or link on the auth surface', () => {

--- a/web/e2e/focus-ring.spec.js
+++ b/web/e2e/focus-ring.spec.js
@@ -515,6 +515,12 @@ test.describe('a native select', () => {
     const clicked = await outlineOn(page, SELECT);
     expect(unpainted(clicked.style, clicked.color)).toBe(true);
 
+    // The click left the option list up, and while it is the browser widget
+    // owns the keyboard: on the Linux runner the arrow below never reaches the
+    // page, on this machine it does. Escape hands the keys back either way,
+    // and it is itself a keystroke on the same element, so whichever of the
+    // two lands on the page is the one that does the refresh.
+    await page.keyboard.press('Escape');
     // The gesture the refresh exists for: same element, same focus, keyboard
     // from here on.
     await page.keyboard.press('ArrowDown');

--- a/web/e2e/focus-ring.spec.js
+++ b/web/e2e/focus-ring.spec.js
@@ -459,3 +459,67 @@ test.describe('a field left focused while the user is in another app', () => {
     expect(ring.style === 'solid' || ring.shadow !== 'none').toBe(true);
   });
 });
+
+/**
+ * A <select> matches :focus-visible on a click the way a text field does, so a
+ * click used to leave the app's ring sitting on it while the same click on a
+ * button left nothing, on every native select in the app.
+ *
+ * Holding the ring off under the pointer is only half of it. Focus does not
+ * move when someone clicks a select and then arrows it to a new option, so no
+ * focusin fires, the record still says the mouse placed the focus, and the
+ * control stays dark for a user who is now on the keyboard. What makes the
+ * rule safe is the keydown refresh in lib/inputModality.ts, and the third test
+ * here is the only place that difference exists -- the first two pass either
+ * way.
+ */
+test.describe('a native select', () => {
+  // The timezone field, the one select on this tab carrying grouped options.
+  // Named rather than taken positionally so the helpers below stay strict: a
+  // selector matching two controls should fail loudly, not silently pick one.
+  const SELECT = 'select:has(optgroup)';
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/settings');
+    await expect(page.locator(SELECT)).toBeVisible();
+  });
+
+  /**
+   * Click the box itself. Playwright's `.click()` on a select opens the native
+   * popup, an OS surface no assertion here can see past.
+   */
+  async function clickSelect(page) {
+    const box = await page.locator(SELECT).boundingBox();
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  }
+
+  test('wears no ring when the mouse focused it', async ({ page }) => {
+    await clickSelect(page);
+    const clicked = await outlineOn(page, SELECT);
+    expect(clicked.focused).toBe(true);
+    expect(unpainted(clicked.style, clicked.color)).toBe(true);
+    // Transparent rather than none, for the forced-colors reason the fields
+    // above are: the substitution needs an outline box to repaint.
+    expect(clicked.style).toBe('solid');
+  });
+
+  test('rings when the keyboard focused it', async ({ page }) => {
+    await keyboardFocus(page, SELECT);
+    const tabbed = await outlineOn(page, SELECT);
+    expect(tabbed.focused).toBe(true);
+    expect(unpainted(tabbed.style, tabbed.color)).toBe(false);
+  });
+
+  test('rings again on the first key after a click, without focus moving', async ({ page }) => {
+    await clickSelect(page);
+    const clicked = await outlineOn(page, SELECT);
+    expect(unpainted(clicked.style, clicked.color)).toBe(true);
+
+    // The gesture the refresh exists for: same element, same focus, keyboard
+    // from here on.
+    await page.keyboard.press('ArrowDown');
+    const arrowed = await outlineOn(page, SELECT);
+    expect(arrowed.focused).toBe(true);
+    expect(unpainted(arrowed.style, arrowed.color)).toBe(false);
+  });
+});

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -34,7 +34,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button
         className={cn(
-          "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+          "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50",
           variants[variant],
           sizes[size],
           className

--- a/web/src/components/ui/context-menu.tsx
+++ b/web/src/components/ui/context-menu.tsx
@@ -41,7 +41,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-3 py-2 text-sm outline-none transition-colors",
+      "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-3 py-2 text-sm transition-colors",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       itemVariants[variant],
       className

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -142,7 +142,7 @@ const DialogContent = React.forwardRef<
         {...props}>
         {children}
         <DialogPrimitive.Close
-          className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
           <X className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -72,7 +72,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-2.5 py-1.5 text-sm outline-none transition-colors",
+      "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-2.5 py-1.5 text-sm transition-colors",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       itemVariants[variant],
       className
@@ -117,7 +117,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-2.5 py-1.5 text-sm outline-none data-[state=open]:bg-accent/15",
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2.5 py-1.5 text-sm data-[state=open]:bg-accent/15",
       ITEM_HIGHLIGHT,
       variant === "setting" && SETTING_ROW,
       className

--- a/web/src/components/ui/field.tsx
+++ b/web/src/components/ui/field.tsx
@@ -51,8 +51,8 @@ const fieldGroupVariants = cva("", {
     variant: {
       default: [
         "relative flex h-10 w-full items-center overflow-hidden rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background",
-        /* Focus Within */
-        "data-[focus-within]:outline-none data-[focus-within]:ring-2 data-[focus-within]:ring-ring data-[focus-within]:ring-offset-2",
+        /* Keyboard focus within: data-focus-within also fires on a click, and the group has no pointer exemption of its own */
+        "data-[focus-visible]:outline-none data-[focus-visible]:ring-2 data-[focus-visible]:ring-ring data-[focus-visible]:ring-offset-2",
         /* Disabled */
         "data-[disabled]:opacity-50",
       ],

--- a/web/src/components/ui/list-box.tsx
+++ b/web/src/components/ui/list-box.tsx
@@ -49,7 +49,7 @@ const ListBoxItem = <T extends object>({
       }
       className={composeRenderProps(className, (className) =>
         cn(
-          "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+          "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm",
           /* Disabled */
           "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
           /* Focused */

--- a/web/src/components/ui/segmented-control.tsx
+++ b/web/src/components/ui/segmented-control.tsx
@@ -9,8 +9,8 @@ interface SegmentedControlProps<T extends string> {
   value: T;
   onChange: (value: T) => void;
   options: ReadonlyArray<SegmentedOption<T>>;
-  /** Accessible name for the group; the row label beside it is not associated. */
-  ariaLabel: string;
+  /** id of the visible row label, so the group is named by the text a sighted reader sees. */
+  labelledBy: string;
 }
 
 /**
@@ -19,9 +19,9 @@ interface SegmentedControlProps<T extends string> {
  * ToggleGroup: it keeps the markup and theme-var styling the rows already
  * shipped, and the pressed state is read by screen readers as a toggle.
  */
-export function SegmentedControl<T extends string>({ value, onChange, options, ariaLabel }: SegmentedControlProps<T>): React.ReactElement {
+export function SegmentedControl<T extends string>({ value, onChange, options, labelledBy }: SegmentedControlProps<T>): React.ReactElement {
   return (
-    <div role="group" aria-label={ariaLabel} className="inline-flex rounded-lg overflow-hidden clips-focus-ring" style={{ border: '1px solid var(--color-border-muted)' }}>
+    <div role="group" aria-labelledby={labelledBy} className="inline-flex rounded-lg overflow-hidden clips-focus-ring" style={{ border: '1px solid var(--color-border-muted)' }}>
       {options.map((option) => {
         const selected = option.value === value;
         return (
@@ -33,7 +33,9 @@ export function SegmentedControl<T extends string>({ value, onChange, options, a
             className="flex items-center gap-1.5 px-2.5 py-1 text-[0.8125rem] font-medium transition-colors"
             style={{
               backgroundColor: selected ? 'var(--color-accent-soft)' : 'transparent',
-              color: selected ? 'var(--color-accent-primary)' : 'var(--color-text-tertiary)',
+              // Secondary, not tertiary: the tertiary grey reads under 2.5:1
+              // on the light surface, below AA for 13 px text.
+              color: selected ? 'var(--color-accent-primary)' : 'var(--color-text-secondary)',
             }}
           >
             {option.label}

--- a/web/src/lib/inputModality.ts
+++ b/web/src/lib/inputModality.ts
@@ -13,16 +13,55 @@
 const MODIFIERS = new Set(['Meta', 'Control', 'Alt', 'Shift']);
 
 /**
- * Set on the document element while the focus the page currently holds arrived
- * by pointer. `tokens.css` reads it to keep the ring off a text field the mouse
- * focused -- the one control `:focus-visible` matches for either device, so a
- * selector alone cannot tell a click from a Tab. One element holds focus at a
- * time, so a single record says everything a mark on each element would, and
- * leaves nothing behind on every field the mouse has ever touched.
+ * Input types that take a printable key as *content*. ``el.type`` reports "text"
+ * for a missing or unrecognized attribute, so a bare `<input>` is covered
+ * without being listed.
+ *
+ * The stepper types are here on purpose, though their arrow keys command the
+ * control rather than write into it: someone who clicked a number or a date
+ * field and then arrows it keeps no ring. That is the trade this whole module
+ * is built around -- a ring nobody asked for is the one users notice, and the
+ * field has its own affordance anyway.
+ */
+const TEXT_ENTRY_TYPES = new Set([
+  'text', 'email', 'password', 'search', 'tel', 'url',
+  'number', 'date', 'datetime-local', 'month', 'time', 'week',
+]);
+
+/** Would the next printable key land in this control as text the user is writing? */
+function acceptsTextEntry(el: Element | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  if (el.isContentEditable) return true;
+  if (el instanceof HTMLTextAreaElement) return true;
+  return el instanceof HTMLInputElement && TEXT_ENTRY_TYPES.has(el.type);
+}
+
+/**
+ * Set on the document element while the focus the page currently holds was not
+ * placed by the keyboard: a click, a hover, script on its own. `tokens.css`
+ * reads it to hold the focus ring off, since `:focus-visible` alone cannot
+ * tell a click from a Tab on a text field or a `<select>`, nor a control
+ * focused by script after a click from one focused by script after a key. One
+ * element holds focus at a time, so a single record says everything a mark on
+ * each element would, and leaves nothing behind on every field the mouse has
+ * ever touched.
  */
 const POINTER_FOCUS = 'data-pointer-focus';
 
+/** A press since the last key: what the overlay autofocus guards ask. */
 let pointer = false;
+
+/**
+ * Whether a key was the last thing the user touched. This is what the ring
+ * asks, and it is false until the first key: focus the page places on its own
+ * -- a composer autofocused on load, a field focused once its data arrives --
+ * was asked for by nobody and draws no ring. A mouse move clears it as a press
+ * does, since a menu focuses the item under the mouse as it passes (Radix does
+ * it from pointermove) and nothing is pressed for that. Kept apart from
+ * `pointer` because a move says nothing about what opened or dismissed an
+ * overlay, and the guards read presses only.
+ */
+let keyboard = false;
 
 /**
  * What held focus when the browser window last lost it.
@@ -43,12 +82,46 @@ let parked: EventTarget | null = null;
 if (typeof window !== 'undefined') {
   // Capture phase: a handler that stops propagation must not be able to hide
   // the interaction from this.
-  window.addEventListener('pointerdown', () => { pointer = true; parked = null; }, true);
+  window.addEventListener(
+    'pointerdown',
+    () => {
+      pointer = true;
+      keyboard = false;
+      parked = null;
+      // Focus does not move when the press lands on the control that already
+      // holds it, so no focusin follows to re-decide the record -- and a field
+      // reached by Tab a moment ago would wear its ring through the click that
+      // took it over. Stamped here rather than left to the focusin below,
+      // which is a no-op when the record already says pointer.
+      document.documentElement.toggleAttribute(POINTER_FOCUS, true);
+    },
+    true,
+  );
+  window.addEventListener('pointermove', () => { keyboard = false; }, true);
   window.addEventListener(
     'keydown',
     (event) => {
-      if (!MODIFIERS.has(event.key)) pointer = false;
+      // Any key, modifier included, is a real keystroke: a parked focus that
+      // sees one was not restored by a window trip.
       parked = null;
+      if (MODIFIERS.has(event.key)) return;
+      pointer = false;
+      keyboard = true;
+      // Focus does not move when someone clicks a control and then drives it
+      // from the keyboard, so no focusin fires and the record below would keep
+      // saying pointer for the rest of that interaction. Refresh it here for a
+      // control that cannot be typed into: someone arrowing a <select> to a new
+      // option is navigating by keyboard and has to be ringed like one.
+      //
+      // The text-entry guard is the entire reason this is a refresh and not an
+      // unstamp. Typing is a keydown, and both readers key off a text field --
+      // tokens.css suppresses the baseline ring on one the mouse focused, and
+      // LoginPage.css paints its ember on the record's *absence*. Clearing it
+      // under a printable key lights both mid-sentence, which is the regression
+      // the record was introduced to fix.
+      if (!acceptsTextEntry(document.activeElement)) {
+        document.documentElement.toggleAttribute(POINTER_FOCUS, false);
+      }
     },
     true,
   );
@@ -59,15 +132,16 @@ if (typeof window !== 'undefined') {
   window.addEventListener('blur', () => { parked = document.activeElement; });
   // Written when focus moves rather than read at paint: typing into a field is
   // a keydown, so a rule consulting the live flag would light a ring under the
-  // user mid-sentence. Freezing it here answers what the ring actually asks,
-  // which is how the control holding focus was reached.
+  // user mid-sentence. Writing it here answers what the ring actually asks,
+  // which is how the control holding focus was reached -- amended above only
+  // where a later keystroke cannot be that user typing.
   window.addEventListener(
     'focusin',
     (event) => {
       const restored = event.target === parked;
       parked = null;
       if (restored) return;
-      document.documentElement.toggleAttribute(POINTER_FOCUS, pointer);
+      document.documentElement.toggleAttribute(POINTER_FOCUS, !keyboard);
     },
     true,
   );

--- a/web/src/lib/inputModality.ts
+++ b/web/src/lib/inputModality.ts
@@ -104,7 +104,12 @@ if (typeof window !== 'undefined') {
       // Any key, modifier included, is a real keystroke: a parked focus that
       // sees one was not restored by a window trip.
       parked = null;
-      if (MODIFIERS.has(event.key)) return;
+      // A held modifier makes the keystroke a shortcut rather than a move.
+      // Cmd-C sends a second keydown whose `key` is the letter with `metaKey`
+      // still set, and reading that as navigation rings the <select> the user
+      // clicked a moment ago, for as long as the focus stays there. Shift is
+      // not one of these: Shift-Tab is how a keyboard user walks backwards.
+      if (MODIFIERS.has(event.key) || event.metaKey || event.ctrlKey || event.altKey) return;
       pointer = false;
       keyboard = true;
       // Focus does not move when someone clicks a control and then drives it

--- a/web/src/lib/inputModality.ts
+++ b/web/src/lib/inputModality.ts
@@ -9,6 +9,8 @@
  * restore when no keyboard was involved.
  */
 
+import { registerAuthReset } from '@/lib/authResets';
+
 /** Held alone, a modifier is someone reaching for Cmd-Tab, not navigating. */
 const MODIFIERS = new Set(['Meta', 'Control', 'Alt', 'Shift']);
 
@@ -150,6 +152,17 @@ if (typeof window !== 'undefined') {
     },
     true,
   );
+  // Sign-out and account switch clear the record with the session. Nothing
+  // here is user-scoped, and the next press or keystroke would overwrite it
+  // anyway, but a `keyboard` left true carries one account's keystroke into
+  // the first focus the next one is handed, and focus the page places on its
+  // own is exactly what this module holds the ring off for.
+  registerAuthReset(() => {
+    pointer = false;
+    keyboard = false;
+    parked = null;
+    document.documentElement.toggleAttribute(POINTER_FOCUS, false);
+  });
 }
 
 export function lastInputWasPointer(): boolean {

--- a/web/src/pages/ChatAgent/components/ActivityBlock.tsx
+++ b/web/src/pages/ChatAgent/components/ActivityBlock.tsx
@@ -101,6 +101,8 @@ interface ActivityBlockProps {
   items: ActivityItem[];
   preparingToolCall?: PreparingToolCallData | null;
   isStreaming: boolean;
+  /** First block of the message: the accordion sits against the bubble's top padding. */
+  isFirst: boolean;
   onToolCallClick?: (item: ActivityItem) => void;
   onOpenFile?: (path: string, workspaceId?: string) => void;
 }
@@ -112,7 +114,7 @@ interface ActivityBlockProps {
  * eliminating the visible gap that separate components caused between
  * fade-out and reappear across render cycles.
  */
-const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, isStreaming, onToolCallClick, onOpenFile }: ActivityBlockProps): React.ReactElement | null {
+const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, isStreaming, isFirst, onToolCallClick, onOpenFile }: ActivityBlockProps): React.ReactElement | null {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   const reduceMotion = useReducedMotion();
@@ -317,9 +319,11 @@ const ActivityBlock = memo(function ActivityBlock({ items, preparingToolCall, is
             className="clips-focus-ring"
             /* The pull-up against the bubble's top padding rides the same
                keyframes as the height: applied as a class it lands whole on
-               the frame the zone mounts at height 0, an 8 px hop. */
+               the frame the zone mounts at height 0, an 8 px hop. It is
+               only owed at the top of the bubble: lower down, or under an
+               inline card, it would eat the gap to whatever sits above. */
             initial={{ opacity: 0, height: 0, marginTop: 0 }}
-            animate={{ opacity: 1, height: 'auto', marginTop: '-0.5rem' }}
+            animate={{ opacity: 1, height: 'auto', marginTop: isFirst && !hasInlineCharts ? '-0.5rem' : 0 }}
             transition={SPRING_FOLD}
             style={{ overflow: 'hidden' }}
           >

--- a/web/src/pages/ChatAgent/components/CreateWorkspaceModal.css
+++ b/web/src/pages/ChatAgent/components/CreateWorkspaceModal.css
@@ -99,7 +99,6 @@
   background-color: var(--color-bg-card);
   border: 1px solid var(--color-border-muted);
   color: var(--color-text-primary);
-  outline: none;
   font-family: inherit;
   transition: border-color 0.15s;
 }

--- a/web/src/pages/ChatAgent/components/Markdown.tsx
+++ b/web/src/pages/ChatAgent/components/Markdown.tsx
@@ -221,16 +221,16 @@ const chatP = ({ node: _node, ...props }: MarkdownComponentProps) => (
   <p className="my-[1px] py-[3px] whitespace-pre-wrap break-words first:mt-0 last:mb-0" style={{ color: 'var(--color-text-primary)' }} {...props} />
 );
 const chatH1 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h1 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.75em', fontWeight: 700, lineHeight: '1.3', marginTop: '1.5em', marginBottom: '0.5em' }} {...props} />
+  <h1 className="mt-[1.5em] mb-[0.5em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.75em', fontWeight: 700, lineHeight: '1.3' }} {...props} />
 );
 const chatH2 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h2 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.4em', fontWeight: 700, lineHeight: '1.3', marginTop: '1.4em', marginBottom: '0.4em' }} {...props} />
+  <h2 className="mt-[1.4em] mb-[0.4em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.4em', fontWeight: 700, lineHeight: '1.3' }} {...props} />
 );
 const chatH3 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h3 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.2em', fontWeight: 600, lineHeight: '1.3', marginTop: '1.2em', marginBottom: '0.3em' }} {...props} />
+  <h3 className="mt-[1.2em] mb-[0.3em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.2em', fontWeight: 600, lineHeight: '1.3' }} {...props} />
 );
 const chatH4 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h4 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.05em', fontWeight: 600, lineHeight: '1.4', marginTop: '1em', marginBottom: '0.25em' }} {...props} />
+  <h4 className="mt-[1em] mb-[0.25em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.05em', fontWeight: 600, lineHeight: '1.4' }} {...props} />
 );
 const chatCode = ({ node: _node, className, children, ...props }: MarkdownComponentProps) => {
   const isBlock = /language-/.test(className || '');
@@ -309,16 +309,16 @@ const panelP = ({ node: _node, ...props }: MarkdownComponentProps) => (
   <p className="my-1 whitespace-pre-wrap break-words" style={{ color: 'var(--color-text-primary)' }} {...props} />
 );
 const panelH1 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h1 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.5em', fontWeight: 700, lineHeight: '1.3', marginTop: '1.2em', marginBottom: '0.4em' }} {...props} />
+  <h1 className="mt-[1.2em] mb-[0.4em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.5em', fontWeight: 700, lineHeight: '1.3' }} {...props} />
 );
 const panelH2 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h2 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.25em', fontWeight: 700, lineHeight: '1.3', marginTop: '1.1em', marginBottom: '0.35em' }} {...props} />
+  <h2 className="mt-[1.1em] mb-[0.35em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.25em', fontWeight: 700, lineHeight: '1.3' }} {...props} />
 );
 const panelH3 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h3 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.1em', fontWeight: 600, lineHeight: '1.3', marginTop: '1em', marginBottom: '0.3em' }} {...props} />
+  <h3 className="mt-[1em] mb-[0.3em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.1em', fontWeight: 600, lineHeight: '1.3' }} {...props} />
 );
 const panelH4 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h4 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1em', fontWeight: 600, lineHeight: '1.4', marginTop: '0.8em', marginBottom: '0.2em' }} {...props} />
+  <h4 className="mt-[0.8em] mb-[0.2em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1em', fontWeight: 600, lineHeight: '1.4' }} {...props} />
 );
 const panelCode = ({ node: _node, className, children, ...props }: MarkdownComponentProps) => {
   const isBlock = /language-/.test(className || '');
@@ -369,13 +369,13 @@ const compactP = ({ node: _node, ...props }: MarkdownComponentProps) => (
   <p className="my-[1px] py-[3px] whitespace-pre-wrap break-words first:mt-0 last:mb-0" style={{ color: 'var(--color-text-primary)' }} {...props} />
 );
 const compactH1 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h1 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.25em', fontWeight: 700, lineHeight: '1.3', marginTop: '0.8em', marginBottom: '0.2em' }} {...props} />
+  <h1 className="mt-[0.8em] mb-[0.2em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.25em', fontWeight: 700, lineHeight: '1.3' }} {...props} />
 );
 const compactH2 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h2 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.15em', fontWeight: 700, lineHeight: '1.3', marginTop: '0.7em', marginBottom: '0.15em' }} {...props} />
+  <h2 className="mt-[0.7em] mb-[0.15em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.15em', fontWeight: 700, lineHeight: '1.3' }} {...props} />
 );
 const compactH3 = ({ node: _node, ...props }: MarkdownComponentProps) => (
-  <h3 className="first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.05em', fontWeight: 600, lineHeight: '1.3', marginTop: '0.6em', marginBottom: '0.1em' }} {...props} />
+  <h3 className="mt-[0.6em] mb-[0.1em] first:mt-0" style={{ color: 'var(--color-text-primary)', fontSize: '1.05em', fontWeight: 600, lineHeight: '1.3' }} {...props} />
 );
 const compactCode = ({ node: _node, className, children, ...props }: MarkdownComponentProps) => {
   const isBlock = /language-/.test(className || '');

--- a/web/src/pages/ChatAgent/components/__tests__/ActivityBlock.failed.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/ActivityBlock.failed.test.tsx
@@ -105,7 +105,7 @@ describe('ActivityBlock — failed tool calls', () => {
       }),
     ];
 
-    render(<ActivityBlock items={items} isStreaming={false} />);
+    render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
 
     // Folded summary intentionally omits the failed count — failure
     // visibility lives on the per-row badge instead.
@@ -122,7 +122,7 @@ describe('ActivityBlock — failed tool calls', () => {
       }),
     ];
 
-    const { container } = render(<ActivityBlock items={items} isStreaming={false} />);
+    const { container } = render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
 
     // Expand the accordion.
     fireEvent.click(screen.getByRole('button', { name: SUMMARY_BUTTON_RE }));
@@ -151,7 +151,7 @@ describe('ActivityBlock — failed tool calls', () => {
       }),
     ];
 
-    const { container } = render(<ActivityBlock items={items} isStreaming={false} />);
+    const { container } = render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
     fireEvent.click(screen.getByRole('button', { name: SUMMARY_BUTTON_RE }));
 
     const failedRow = container.querySelector('.titem.failed');
@@ -170,7 +170,7 @@ describe('ActivityBlock — failed tool calls', () => {
       }),
     ];
 
-    render(<ActivityBlock items={items} isStreaming={false} />);
+    render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
     const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
     // Three reads in the fileRead bucket (failures don't split the count).
     expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.fileRead/i);
@@ -186,7 +186,7 @@ describe('ActivityBlock — failed tool calls', () => {
       }),
     ];
 
-    const { container } = render(<ActivityBlock items={items} isStreaming={false} />);
+    const { container } = render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
     fireEvent.click(screen.getByRole('button', { name: SUMMARY_BUTTON_RE }));
     expect(container.querySelector('.titem.failed')).toBeNull();
     expect(container.querySelector('.nrow-badge')).toBeNull();
@@ -206,7 +206,7 @@ describe('ActivityBlock — memo write/edit fragment', () => {
       }),
     ];
 
-    render(<ActivityBlock items={items} isStreaming={false} />);
+    render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
     const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
     expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.memoWrite/i);
     // It must NOT show as a memo read.
@@ -221,7 +221,7 @@ describe('ActivityBlock — memo write/edit fragment', () => {
       }),
     ];
 
-    render(<ActivityBlock items={items} isStreaming={false} />);
+    render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
     const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
     expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.memo/i);
     expect(summary).not.toHaveTextContent(/toolArtifact\.categoryCount.memoWrite/i);
@@ -247,7 +247,7 @@ describe('ActivityBlock — priority fragments survive the cap', () => {
       completedTool('Read', { id: 'r-1', toolCall: { args: { file_path: 'work/scratch.md' } } }),
     ];
 
-    render(<ActivityBlock items={items} isStreaming={false} />);
+    render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
     const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
     // memoryUpdated must be in the visible 3 even with overflow.
     expect(summary).toHaveTextContent(/toolArtifact\.categoryCount.memoryUpdated/i);
@@ -266,7 +266,7 @@ describe('ActivityBlock — accordion a11y', () => {
       completedTool('Read', { id: 'r-1', toolCall: { args: { file_path: 'work/scratch.md' } } }),
     ];
 
-    render(<ActivityBlock items={items} isStreaming={false} />);
+    render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
     const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
     expect(summary).toHaveAttribute('aria-expanded', 'false');
 
@@ -279,7 +279,7 @@ describe('ActivityBlock — accordion a11y', () => {
       completedTool('Read', { id: 'r-1', toolCall: { args: { file_path: 'work/scratch.md' } } }),
     ];
 
-    const { container } = render(<ActivityBlock items={items} isStreaming={false} />);
+    const { container } = render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
     const summary = screen.getByRole('button', { name: SUMMARY_BUTTON_RE });
     fireEvent.click(summary);
 

--- a/web/src/pages/ChatAgent/components/__tests__/ActivityBlock.lifecycle.test.tsx
+++ b/web/src/pages/ChatAgent/components/__tests__/ActivityBlock.lifecycle.test.tsx
@@ -93,7 +93,7 @@ const SUMMARY_BUTTON_RE = /toolArtifact/i;
 describe('ActivityBlock — live-row lifecycle states', () => {
   it('renders an active tool row with the state-active left-rule hook and no badge', () => {
     const items = [toolItem('active', { isComplete: false })];
-    const { container } = render(<ActivityBlock items={items} isStreaming={true} />);
+    const { container } = render(<ActivityBlock items={items} isStreaming={true} isFirst={false} />);
 
     const row = container.querySelector('.nrow.state-active');
     expect(row).not.toBeNull();
@@ -104,7 +104,7 @@ describe('ActivityBlock — live-row lifecycle states', () => {
 
   it('renders a completing tool row without the active rule and without a badge', () => {
     const items = [toolItem('completing', { isComplete: true, _recentlyCompleted: true })];
-    const { container } = render(<ActivityBlock items={items} isStreaming={true} />);
+    const { container } = render(<ActivityBlock items={items} isStreaming={true} isFirst={false} />);
 
     const row = container.querySelector('.nrow');
     expect(row).not.toBeNull();
@@ -114,7 +114,7 @@ describe('ActivityBlock — live-row lifecycle states', () => {
 
   it('renders the failed ✕ badge on a live failed row with the a11y label', () => {
     const items = [toolItem('failed', { isComplete: true, isFailed: true, _recentlyCompleted: true })];
-    const { container } = render(<ActivityBlock items={items} isStreaming={true} />);
+    const { container } = render(<ActivityBlock items={items} isStreaming={true} isFirst={false} />);
 
     const badge = container.querySelector('.nrow .nrow-badge');
     expect(badge).not.toBeNull();
@@ -134,7 +134,7 @@ describe('ActivityBlock — replay parity', () => {
       toolItem('completed', { id: 'tc-1', isComplete: true }),
       toolItem('completed', { id: 'tc-2', isComplete: true }),
     ];
-    const { container } = render(<ActivityBlock items={items} isStreaming={false} />);
+    const { container } = render(<ActivityBlock items={items} isStreaming={false} isFirst={false} />);
 
     fireEvent.click(screen.getByRole('button', { name: SUMMARY_BUTTON_RE }));
 
@@ -148,7 +148,7 @@ describe('ActivityBlock — replay parity', () => {
 
   it('renders newly completed rows WITH the entrance wrapper while streaming (contrast case)', () => {
     const items = [toolItem('completed', { id: 'tc-1', isComplete: true })];
-    const { container } = render(<ActivityBlock items={items} isStreaming={true} />);
+    const { container } = render(<ActivityBlock items={items} isStreaming={true} isFirst={false} />);
 
     fireEvent.click(screen.getByRole('button', { name: SUMMARY_BUTTON_RE }));
 

--- a/web/src/pages/ChatAgent/components/messageList/MessageContentSegments.tsx
+++ b/web/src/pages/ChatAgent/components/messageList/MessageContentSegments.tsx
@@ -249,6 +249,7 @@ export const MessageContentSegments = memo(function MessageContentSegments({ seg
               items={(block as ActivityRenderBlock).items as any} // TODO: type properly — ActivityItem[] not exported
               preparingToolCall={blockIdx === lastActivityBlockIdx ? preparingToolCall : null}
               isStreaming={isStreaming ?? false}
+              isFirst={blockIdx === 0}
               onToolCallClick={onToolCallDetailClick as any} // TODO: type properly
               onOpenFile={onOpenFile}
             />
@@ -431,6 +432,7 @@ export const MessageContentSegments = memo(function MessageContentSegments({ seg
           items={[]}
           preparingToolCall={preparingToolCall}
           isStreaming={isStreaming ?? false}
+          isFirst={renderBlocks.length === 0}
           onToolCallClick={onToolCallDetailClick as any} // TODO: type properly
           onOpenFile={onOpenFile}
         />

--- a/web/src/pages/ChatAgent/components/sandbox/PackagesTab.tsx
+++ b/web/src/pages/ChatAgent/components/sandbox/PackagesTab.tsx
@@ -64,7 +64,7 @@ export function PackagesTab({ workspaceId, packages, defaultPackages, onInstalle
           value={pkgSearch}
           onChange={e => setPkgSearch(e.target.value)}
           placeholder="Filter packages..."
-          className="w-full pl-9 pr-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+          className="w-full pl-9 pr-3 py-2 text-sm rounded-md bg-transparent"
           style={{
             color: 'var(--color-text-primary)',
             border: '1px solid var(--color-border-muted)',
@@ -124,7 +124,7 @@ export function PackagesTab({ workspaceId, packages, defaultPackages, onInstalle
             onChange={e => setInstallInput(e.target.value)}
             placeholder="Package names (e.g. torch transformers>=4.0)"
             onKeyDown={e => e.key === 'Enter' && !installing && handleInstall()}
-            className="flex-1 px-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+            className="flex-1 px-3 py-2 text-sm rounded-md bg-transparent"
             style={{
               color: 'var(--color-text-primary)',
               border: '1px solid var(--color-border-muted)',

--- a/web/src/pages/ChatAgent/components/vault/SecretEditor.tsx
+++ b/web/src/pages/ChatAgent/components/vault/SecretEditor.tsx
@@ -29,7 +29,7 @@ export const EMPTY_DRAFT: SecretDraft = {
 type DraftPatch = (patch: Partial<SecretDraft>) => void;
 
 const inputClass =
-  'w-full px-3 py-2 text-sm rounded-md bg-transparent outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring';
+  'w-full px-3 py-2 text-sm rounded-md bg-transparent';
 const inputStyle: React.CSSProperties = {
   color: 'var(--color-text-primary)',
   border: '1px solid var(--color-border-muted)',

--- a/web/src/pages/Settings/panels/UserInfoTab.tsx
+++ b/web/src/pages/Settings/panels/UserInfoTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { User, LogOut, Sun, Moon, Monitor } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
@@ -44,6 +44,9 @@ export function UserInfoTab() {
   const queryClient = useQueryClient();
   const { theme: _theme, preference, setTheme: setThemePref } = useTheme();
   const [fontScale, setFontScaleState] = useState(getFontScale);
+  const themeLabelId = useId();
+  const fontSizeLabelId = useId();
+  const turnEndLabelId = useId();
   const { t, i18n } = useTranslation();
 
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
@@ -318,10 +321,10 @@ export function UserInfoTab() {
       {/* Theme Toggle */}
       <div className="settings-row">
         <div className="space-y-0.5">
-          <label className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.theme')}</label>
+          <label id={themeLabelId} className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.theme')}</label>
         </div>
         <SegmentedControl
-          ariaLabel={t('settings.theme')}
+          labelledBy={themeLabelId}
           value={preference}
           onChange={setThemePref}
           options={[
@@ -335,10 +338,10 @@ export function UserInfoTab() {
       {/* Font size — multiplies the browser's own font-size preference */}
       <div className="settings-row">
         <div className="space-y-0.5">
-          <label className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.fontSize', 'Font size')}</label>
+          <label id={fontSizeLabelId} className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.fontSize', 'Font size')}</label>
         </div>
         <SegmentedControl
-          ariaLabel={t('settings.fontSize', 'Font size')}
+          labelledBy={fontSizeLabelId}
           value={String(fontScale)}
           onChange={(v) => { const next = Number(v) as FontScale; setFontScale(next); setFontScaleState(next); }}
           options={FONT_SCALES.map((scale) => ({ value: String(scale), label: `${Math.round(scale * 100)}%` }))}
@@ -361,11 +364,11 @@ export function UserInfoTab() {
       {/* Where the transcript lands when a reply finishes */}
       <div className="settings-row">
         <div className="space-y-0.5">
-          <label className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.turnEndScroll')}</label>
+          <label id={turnEndLabelId} className="text-[0.8125rem] font-medium" style={{ color: 'var(--color-text-primary)' }}>{t('settings.turnEndScroll')}</label>
           <p className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>{t('settings.turnEndScrollDesc')}</p>
         </div>
         <SegmentedControl
-          ariaLabel={t('settings.turnEndScroll')}
+          labelledBy={turnEndLabelId}
           value={turnEndScroll}
           onChange={(v) => { void handleTurnEndScrollChange(v); }}
           options={[

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -422,56 +422,34 @@ html {
     padding: 0;
   }
 
-  /* The ring every control gets unless it draws its own. Without a baseline the
-     fallback is Chromium's -- `outline: auto` in a blue this product uses
-     nowhere -- and that was the ring on four out of five controls, the chat
-     transcript included. Lives in the base layer, so a component that does draw
-     its own still wins: a Tailwind `focus-visible:` utility by layer order, a
-     hand-written `.class:focus-visible` by specificity. */
+  /* Tailwind's preflight carries `:-moz-focusring { outline: auto }`, and it
+     lands here unlayered, so in Firefox it would beat the whole focus layer
+     below: its own ring on a keyboard focus, and one on a clicked field the
+     layer means to keep quiet. Same specificity and later in source, so this
+     wins, and revert-layer hands the decision back to the layer. */
+  :-moz-focusring {
+    outline: revert-layer;
+  }
+}
+
+/* Focus rings.
+
+   Everything in here is a default: the ring a control gets unless something
+   draws its own. It sits in a cascade layer of its own so that "its own"
+   means any rule outside this layer, whatever its specificity -- a Tailwind
+   `focus-visible:` utility, a hand-written `.class:focus-visible`, a
+   box-shadow ring on a sidebar row. Unlayered styles beat layered ones
+   outright, so a component never has to out-specify this block. (Tailwind's
+   `@layer base` above is not a cascade layer: the plugin unwraps it into plain
+   unlayered CSS, where a rule here and a component's would be settled by
+   specificity and source order instead.) */
+@layer focus-defaults {
+  /* Without a baseline the fallback is Chromium's -- `outline: auto` in a blue
+     this product uses nowhere -- and that was the ring on four out of five
+     controls, the chat transcript included. */
   :focus-visible {
     outline: 2px solid var(--color-focus-ring);
     outline-offset: 2px;
-  }
-
-  /* A text field is the one control the browser matches :focus-visible on for
-     either device. The heuristic is deliberate -- a field about to receive
-     typing has to look focused -- but it means the rule above rings a field
-     the mouse just clicked, where the same click on a button rings nothing.
-     No selector separates the two, so lib/inputModality.ts records how focus
-     arrived and this reads it back. A field the mouse focused keeps the caret
-     and its own border change; a Tab still brings the ring.
-
-     Spelled out type by type because the exemption has to be the narrow set
-     where every key is typing. A checkbox, a range, a number spinner and a
-     date field all take keys that are *commands*, and Chromium starts matching
-     :focus-visible the moment one arrives -- while this record still says
-     pointer, because focus never moved and no focusin fired. Written as
-     `input` those controls go dark under the user's own first keystroke.
-     Anything left off this list keeps a ring on a click, which is the mild
-     half of the trade. `contenteditable` is qualified for the same reason the
-     inputs are: the bare attribute selector also matches
-     `contenteditable="false"`, which is not a field and does not take typing.
-
-     Transparent rather than `none`, which is not a stylistic choice: forced
-     colors repaints every outline in the system palette but cannot paint one
-     that was never drawn, and it drops the box-shadow and normalizes the
-     border a field would otherwise be distinguished by. `none` here leaves a
-     high-contrast user with a clicked field marked by nothing but the caret.
-     A transparent outline is invisible everywhere else and becomes the
-     system's own focus color there -- the same reason Tailwind's
-     `outline-none` compiles to this and not to `outline: none`. */
-  :root[data-pointer-focus] :is(
-    textarea,
-    [contenteditable]:not([contenteditable="false"]),
-    input:not([type]),
-    input[type="text"],
-    input[type="email"],
-    input[type="password"],
-    input[type="search"],
-    input[type="tel"],
-    input[type="url"]
-  ):focus-visible {
-    outline: 2px solid transparent;
   }
 
   /* A field that fills a bordered container has nowhere to put a ring of its
@@ -482,9 +460,9 @@ html {
 
      Scoped to a direct-child input so a button sharing the container -- a clear
      affordance, a chip's remove -- still rings itself instead of lighting the
-     whole box. Gated like the rule above and for the same reason: the field
-     inside matches :focus-visible for either device, so ungated this would
-     light the container on a click.
+     whole box. Held off under the pointer like everything else here, and for
+     the same reason: the field inside matches :focus-visible for either
+     device, so ungated this would light the container on a click.
 
      All three sit behind @supports because only the first of them survives a
      parser without :has(): taking the ring off the field is a plain selector,
@@ -501,9 +479,9 @@ html {
       outline-offset: 2px;
     }
 
-    /* Transparent for the reason the field rule above is. */
+    /* Transparent for the reason the rule at the end of this layer is. */
     :root[data-pointer-focus] .rings-within:has(> input:focus-visible) {
-      outline: 2px solid transparent;
+      outline-color: transparent;
     }
   }
 
@@ -536,6 +514,33 @@ html {
      so without this the ring draws around an entire dialog. */
   [tabindex="-1"]:focus-visible {
     outline: none;
+  }
+
+  /* The browser matches :focus-visible on a mouse click for any control that
+     might take a keystroke next -- text fields, <select>, the number and date
+     widgets -- and Chromium carries it across a programmatic focus move on top
+     of that: the first control a dialog focuses after a click, the trigger a
+     menu hands focus back to, the item under the mouse as it crosses a menu.
+     No selector tells any of those from a Tab, so lib/inputModality.ts records
+     whether a key placed the focus the page holds, and while it says no the
+     ring this sheet draws is held off. A keystroke lifts the record, so the
+     same control rings the moment the keyboard takes over. It out-specifies
+     both the baseline and the item rule above, so it reaches every ring in
+     this layer. Only the color, so a rule that already set `outline: none`
+     stays at none -- and a component painting a ring of its own outside this
+     layer keeps it, which is why one that can light under a pointer reads the
+     same record itself (`:root:not([data-pointer-focus])`, LoginPage.css).
+
+     Transparent rather than `none`, which is not a stylistic choice: forced
+     colors repaints every outline in the system palette but cannot paint one
+     that was never drawn, and it drops the box-shadow and normalizes the
+     border a field would otherwise be distinguished by. `none` here leaves a
+     high-contrast user with a clicked field marked by nothing but the caret.
+     A transparent outline is invisible everywhere else and becomes the
+     system's own focus color there -- the same reason Tailwind's
+     `outline-none` compiles to this and not to `outline: none`. */
+  :root[data-pointer-focus] :focus-visible {
+    outline-color: transparent;
   }
 }
 

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -516,6 +516,36 @@ html {
     outline: none;
   }
 
+  /* Menu and listbox items are tabindex="-1" as well (roving focus), but they
+     are the one landing spot the user drives through: someone arrowing down a
+     menu needs the ring to travel with them. Inward, because the menu clips at
+     its own padding. currentColor rather than the ink token: a highlighted
+     item swaps its text to the accent foreground, and a ring in the page ink
+     drawn inside that fill reads at under 2:1 against it.
+
+     The ring below it is transparent rather than absent, and it is on every
+     item rather than the focused one: forced colors drops the highlight tint
+     that marks the current row everywhere else, and what it repaints instead
+     is an outline that was already drawn. A row with no outline at all is a
+     row the OS has nothing to paint, which under a mouse is every row in the
+     menu. This is the `outline-none` the items used to carry as a utility
+     class, kept where the rest of the rule lives. */
+  [role="menuitem"],
+  [role="menuitemcheckbox"],
+  [role="menuitemradio"],
+  [role="option"] {
+    outline: 2px solid transparent;
+    outline-offset: -2px;
+  }
+
+  [role="menuitem"]:focus-visible,
+  [role="menuitemcheckbox"]:focus-visible,
+  [role="menuitemradio"]:focus-visible,
+  [role="option"]:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: -2px;
+  }
+
   /* The browser matches :focus-visible on a mouse click for any control that
      might take a keystroke next -- text fields, <select>, the number and date
      widgets -- and Chromium carries it across a programmatic focus move on top

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -203,15 +203,17 @@ html {
   --destructive-foreground: 0 0% 98%;
   --border: 0 0% 100% / 0.08;
   --input: 220 4% 14.5%;
-  /* Focus ring is the navy this product carried before the amber. Amber is the
+  /* Focus ring is the primary text color, carrying no hue at all. Amber is the
      active/selected language here, so a ring painted in it reads as "selected"
-     rather than "focused" — which is the whole reason the ring is not the brand
-     color (DESIGN.md). Lightness is set by the *lightest* surface a ring can
-     land on, not the page: at 52% it cleared 3:1 (WCAG 1.4.11) against the
-     sidebar and the cards but came to 2.98:1 on --color-bg-elevated, the menus
-     and tooltips. 55% lands at 3.35:1 there and higher everywhere else. Opaque
-     rather than a wash, so that margin does not move with the backdrop. */
-  --ring: 221 43% 55%;
+     rather than "focused", and any other hue would be a color the product uses
+     nowhere else (DESIGN.md). Ink is what the eye already reads as "this one":
+     a control gains the same edge its label has. It also clears WCAG 1.4.11 by
+     a wide margin on every surface, 11:1 on --color-bg-elevated, the menus and
+     tooltips, where the previous navy was tuned to reach 3.35:1. Kept as an
+     HSL triplet, and derived rather than repeated, because Tailwind composes
+     `ring-ring` as `hsl(var(--ring) / <alpha>)` and DESIGN.md publishes the
+     equality with the text ink as a contract. */
+  --ring: var(--foreground);
   --radius: 0.5rem;
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.35), 0 4px 16px rgba(0, 0, 0, 0.25);
 
@@ -374,8 +376,8 @@ html {
   --destructive-foreground: 0 0% 100%;
   --border: 60 2% 12% / 0.09;
   --input: 60 4% 96.5%;
-  /* Same navy as dark, one step down: on paper the lighter face washes out. */
-  --ring: 221 43% 45%;
+  /* The light theme's text ink, for the same reason. */
+  --ring: var(--foreground);
   /* Kept tight rather than dropped: floating overlays (AgentEventOverlay,
      SelectionCommentOverlay, JumpToLatestPill) rely on this to separate from
      a now-pure-white page — the workspace cards carry their own border. */


### PR DESCRIPTION
## Overview

**What this introduces.** Three fixes to controls a keyboard or a mouse touches directly.

The largest is a focus ring that appears only when a key placed the focus. Clicking a text field,
hovering a menu row, opening a dialog with the mouse, coming back from another app, or landing on a
control the page focused by itself all leave the control unringed. Tabbing to the same control rings
it. The mechanism is one record of how the current focus arrived, read by one set of defaults in a
cascade layer, replacing the per-control `outline: none` patches that had accumulated across the app.

Alongside it, the activity accordion in the transcript pulls up against the message bubble only when
it leads, where it used to pull up everywhere and eat the gap to whatever sat above it, and Markdown
heading margins move from inline styles to classes. In settings, each segmented control is named by
the visible row label beside it rather than a duplicated string, and its unselected options move to
an ink that reads at AA.

| | Files | + | - |
|---|---|---|---|
| Modified | 21 | 356 | 129 |
| New | 0 | 0 | 0 |
| Net excluding tests | 17 | 253 | 114 |

**By module**

| Module | Change | What |
|---|---|---|
| `web/src/lib/inputModality.ts` | +103/-11 | The record. Tracks whether a key was the last input, whether a press was, and what held focus when the window lost it. Stamps `data-pointer-focus` on the document element when focus was not placed by a key, and clears itself on sign-out. |
| `web/src/styles/tokens.css` | +99/-62 | A native `@layer focus-defaults` holding the baseline ring, the inward variants for clipping containers, the menu and listbox item ring, and the rule that holds the color off while the record says pointer. `--ring` now derives from `--foreground` in both themes. |
| `web/src/components/ui/` (7 files) | +15/-13 | `button`, `dialog`, `dropdown-menu`, `context-menu`, `list-box`, `field`, `segmented-control`. Each drops a hand-written ring or `outline-none` and falls through to the layer; `segmented-control` takes `labelledBy` instead of `ariaLabel`. |
| `web/src/pages/ChatAgent/` (6 files) | +23/-18 | The accordion's pull-up and the `isFirst` that gates it, Markdown heading margins as classes, and three controls that drew their own ring: `CreateWorkspaceModal`, `PackagesTab`, `SecretEditor`. |
| `web/src/pages/Settings/panels/UserInfoTab.tsx` | +10/-7 | Gives each row label an id and points its control at it. |
| `DESIGN.md` | +3/-3 | The focus ring's palette row, and the sign-in exemption clause that argued from the old navy. |
| Tests (4 files) | +103/-15 | 2 Playwright specs and 2 `ActivityBlock` unit tests. |

## Summary

Nine commits, each one shippable on its own.

The transcript and the settings row:

1. **Heading sits under the accordion, accordion clears the card above it.** Markdown heading margins move from inline styles to classes; the activity block pulls up against the bubble only when it leads and nothing inline sits above it.
2. **SegmentedControl is named by its row label and reads at AA.** `aria-labelledby` pointing at the visible label, and the unselected options raised from tertiary to secondary ink, which the tertiary grey missed at under 2.5:1 on the light surface.

The ring:

3. **The focus ring is held off unless a key placed the focus.** The record plus the layer.
4. **Six controls that rang on a click, never rang, or drew their own.** They all fall through to the layer now.
5. **Menu items ring under the keyboard, not under the mouse.** Roving focus lands on the row under the cursor; that is not a keyboard visit.
6. **The focus ring is the text ink, not a navy.** One less hue in a product whose only accent is amber.

Landed during review:

7. **A held modifier is a shortcut, not a keyboard move.** Cmd-C sends a second keydown whose key is the letter with the modifier still down, which rang a select the mouse had focused.
8. **The select refresh test survives a native option list.** The browser widget owns the keyboard while the list is up, so the arrow never reached the page on a Linux runner.
9. **The modality record clears with the session.** It is a module singleton that outlives React, which `web/AGENTS.md` requires be reset on sign-out.

## Why this shape

`:focus-visible` cannot answer the question the ring is actually asking. Chromium matches it on a
plain click for anything that might take a keystroke next, which is every text field, every
`<select>`, and the number and date widgets. It also carries the state across a programmatic focus
move, so the first control a dialog focuses after a click inherits it, as does a trigger a menu
hands focus back to, and the menu row the mouse passes over.

The patches this replaces were per-control: an `outline: none` here, a `:focus` override there. Each
one fixed the surface in front of it and left the next one to be found by a user. One record and one
layer put the decision in a single place, and the failure mode of a missing record is a missing
ring, not a ring nobody asked for.

## How it works

`inputModality.ts` keeps a boolean for whether a key was the last thing the user touched. It starts
false, so focus the page places on its own draws nothing. A press or a mouse move clears it, since a
menu focuses the row under the cursor from `pointermove` with nothing pressed. On `focusin` the
module stamps `data-pointer-focus` on the document element when the answer is no, and `tokens.css`
reads that attribute to hold the ring's color at transparent.

Three details carry the rest:

- **The record is written when focus moves, not read at paint.** Typing is a keydown, so a rule
  reading the live flag would light a ring under the user mid-sentence. A keystroke does refresh the
  record, but only for a control that cannot be typed into, and only when no modifier is held, which
  is how arrowing a `<select>` rings it while typing a password or copying does not.
- **A window trip is not a focus move.** Leaving the app fires a `focusout`/`focusin` pair around
  the round trip without moving focus. The module remembers what was parked and passes the restoring
  event over, so clicking the composer, typing, switching apps and coming back does not ring it.
- **Transparent rather than `none`.** Forced colors repaints an outline that was drawn and cannot
  repaint one that never was, so the suppressed ring stays a transparent box. Menu rows keep that
  box unconditionally, since the highlight tint that marks the current row is the first thing forced
  colors drops.

## Risk

- **Tab into the page from browser chrome draws no ring on the first stop.** No keydown reaches the
  document for that Tab, so the record still says pointer. The alternative is a ring on every
  page-placed focus at load, which is the case this branch exists to remove.
- **A component that paints its own ring outside the layer is not covered by the gate.** Audited
  across the app: the ones that can light under a pointer are the sign-in field, which reads the same
  record itself, and border-only field emphasis on the composer and the search box. The comment in
  `tokens.css` names the pattern for the next one.
- **Number and date fields keep the ring suppressed while their arrow keys step the value.** Those
  keys command the control rather than write into it, so the refresh skips them along with typing.
  Deliberate, and the field's own affordance is the indicator.
- **Firefox is not verified here.** Tailwind's preflight sets `:-moz-focusring { outline: auto }`
  unlayered, which would beat the layer, so the branch neutralizes it with `outline: revert-layer`.
  No Firefox on this machine to confirm it.
- **The pointer gate is a universal descendant selector.** Toggling the root attribute invalidates
  style for the document. Measured on synthetic pages at roughly 5ms for an 18k-node DOM. It only
  runs on an actual modality switch, since `toggleAttribute` is a no-op when the state already
  matches, but it is worth knowing before the transcript grows further.

## Follow-ups

- The model menu's quiet rows paint their label in tertiary ink at 2.39:1, which fails text contrast
  on its own and drags the item's ring down with it, since that ring is drawn in the row's own color.
- `FieldGroup` in `field.tsx` gates its ring on react-aria's own modality flag and paints a
  box-shadow the pointer rule cannot suppress. It has no call sites today.

## Test plan

| Suite | Result |
|---|---|
| `pnpm test` (Vitest) | 3533 passed, 326 files |
| `pnpm typecheck` | clean |
| Playwright `focus-ring`, `auth-surface.focus`, `model-menu.focus` | 42 passed |
| Backend `pytest tests/unit` | 10043 passed, 1 xfailed |

Verified live in Chrome over the debug protocol on the running stack, in both themes: click a field,
hover a menu row, open and dismiss a dialog with the mouse, Tab through the same controls, leave the
window and come back, and reload onto a page that autofocuses the composer.
