### PR TITLE
feat(manifest): move DeepSeek to V4.1 Flash and retire the V4 keys

### DIFF
--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -12,7 +12,7 @@ llm:
   compaction: "" # blank → same model as flash
   fetch: ""         # blank → same model as flash
   fallback:
-    - "deepseek-v4-pro"
+    - "deepseek-flash"
     - "glm-5.2"
 
 sandbox:

--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -623,72 +623,13 @@
       "write": "parameters.reasoning_effort"
     }
   },
-  "deepseek-v4-pro": {
-    "model_id": "deepseek-v4-pro",
+  "deepseek-flash": {
+    "model_id": "deepseek-flash",
     "provider": "deepseek",
-    "visible": true,
-    "speed": 2,
-    "intelligence": 4,
-    "context": 1000000,
-    "input_modalities": [
-      "text"
-    ],
-    "parameters": {
-      "max_tokens": 384000
-    },
-    "reasoning": {
-      "efforts": [
-        "none",
-        "low",
-        "high",
-        "max"
-      ],
-      "default": "high",
-      "write": "parameters.output_config.effort",
-      "on": {
-        "parameters.thinking.type": "enabled"
-      },
-      "off": {
-        "parameters.thinking.type": "disabled"
-      }
-    }
-  },
-  "deepseek-v4-flash": {
-    "model_id": "deepseek-v4-flash",
-    "provider": "deepseek",
+    "display_name": "DeepSeek-V4.1-Flash",
     "visible": true,
     "speed": 4,
-    "intelligence": 4,
-    "context": 1000000,
-    "input_modalities": [
-      "text"
-    ],
-    "parameters": {
-      "max_tokens": 384000
-    },
-    "reasoning": {
-      "efforts": [
-        "none",
-        "low",
-        "high",
-        "max"
-      ],
-      "default": "high",
-      "write": "parameters.output_config.effort",
-      "on": {
-        "parameters.thinking.type": "enabled"
-      },
-      "off": {
-        "parameters.thinking.type": "disabled"
-      }
-    }
-  },
-  "deepseek-v4-flash-vision-exp": {
-    "model_id": "deepseek-v4-flash-vision-exp",
-    "provider": "deepseek",
-    "visible": true,
-    "speed": 4,
-    "intelligence": 4,
+    "intelligence": 5,
     "context": 1000000,
     "input_modalities": [
       "text",

--- a/src/llms/manifest/providers.json
+++ b/src/llms/manifest/providers.json
@@ -388,16 +388,20 @@
     "openrouter": [],
     "deepseek": [
       {
-        "id": "deepseek-v4-pro",
-        "name": "DeepSeek V4 Pro",
+        "id": "deepseek-flash",
+        "name": "DeepSeek-V4.1-Flash",
         "is_reasoning": true,
-        "description": "DeepSeek's V4 Pro model with extended thinking and 1M context",
+        "description": "DeepSeek's V4.1 Flash model with extended thinking, image input and 1M context",
+        "alias": [
+          "deepseek-v4-flash",
+          "deepseek-v4-flash-vision-exp"
+        ],
         "context_window": 1000000,
         "max_output": 384000,
         "pricing": {
-          "input": 1.32,
-          "cached_input": 0.044,
-          "output": 3.96,
+          "input": 0.3,
+          "cached_input": 0.006,
+          "output": 1.2,
           "unit": "per_1m_tokens",
           "peak_utc": [
             [
@@ -418,83 +422,9 @@
           ],
           "peak_days_utc_offset": 8,
           "off_peak": {
-            "input": 0.66,
-            "cached_input": 0.022,
-            "output": 1.98
-          }
-        }
-      },
-      {
-        "id": "deepseek-v4-flash",
-        "name": "DeepSeek V4 Flash",
-        "is_reasoning": true,
-        "description": "DeepSeek's V4 Flash model with extended thinking and 1M context",
-        "context_window": 1000000,
-        "max_output": 384000,
-        "pricing": {
-          "input": 0.44,
-          "cached_input": 0.014,
-          "output": 1.32,
-          "unit": "per_1m_tokens",
-          "peak_utc": [
-            [
-              1,
-              4
-            ],
-            [
-              6,
-              10
-            ]
-          ],
-          "peak_days": [
-            1,
-            2,
-            3,
-            4,
-            5
-          ],
-          "peak_days_utc_offset": 8,
-          "off_peak": {
-            "input": 0.22,
-            "cached_input": 0.007,
-            "output": 0.66
-          }
-        }
-      },
-      {
-        "id": "deepseek-v4-flash-vision-exp",
-        "name": "DeepSeek V4 Flash Vision (Exp)",
-        "is_reasoning": true,
-        "description": "DeepSeek's V4 Flash with image input, priced identically to the text model; experimental, and the vendor may change or withdraw it",
-        "context_window": 1000000,
-        "max_output": 384000,
-        "pricing": {
-          "input": 0.44,
-          "cached_input": 0.014,
-          "output": 1.32,
-          "unit": "per_1m_tokens",
-          "peak_utc": [
-            [
-              1,
-              4
-            ],
-            [
-              6,
-              10
-            ]
-          ],
-          "peak_days": [
-            1,
-            2,
-            3,
-            4,
-            5
-          ],
-          "peak_days_utc_offset": 8,
-          "off_peak": {
-            "input": 0.22,
-            "cached_input": 0.007,
-            "output": 0.66
+            "input": 0.15,
+            "cached_input": 0.003,
+            "output": 0.6
           }
         }
       }

--- a/tests/unit/llms/test_chunk_multiplier.py
+++ b/tests/unit/llms/test_chunk_multiplier.py
@@ -18,7 +18,7 @@ from src.llms.pricing_utils import (
 
 # DeepSeek's card is the one with hours on it: peak is 01-04 and 06-10 UTC on
 # weekdays, so these two stamps straddle a boundary the manifest defines.
-_SCHEDULED = "deepseek-v4-pro"
+_SCHEDULED = "deepseek-flash"
 _PEAK = datetime(2026, 8, 27, 2, 0, tzinfo=timezone.utc)  # a Thursday
 _OFF_PEAK = datetime(2026, 8, 27, 12, 0, tzinfo=timezone.utc)
 
@@ -59,7 +59,7 @@ def test_the_mix_weights_reads_far_above_input():
     assert card["cached_input"] < rate < card["input"]
 
 
-@pytest.mark.parametrize("model", ["claude-opus-5", "deepseek-v4-pro", "gpt-5.6-sol"])
+@pytest.mark.parametrize("model", ["claude-opus-5", "deepseek-flash", "gpt-5.6-sol"])
 def test_a_multiplier_is_a_coarse_figure(model):
     """Snapped, because a budget is read by people. Anything below the baseline
     lands on a tenth, anything above on a half — a rate that drifts by a cent

--- a/tests/unit/llms/test_input_modalities.py
+++ b/tests/unit/llms/test_input_modalities.py
@@ -28,9 +28,10 @@ class TestGetInputModalities:
         assert "image" in result
         assert "pdf" in result
 
-    def test_deepseek_text_only(self, model_config):
-        result = model_config.get_input_modalities("deepseek-v4-flash")
-        assert result == ["text"]
+    def test_deepseek_flash_supports_image(self, model_config):
+        result = model_config.get_input_modalities("deepseek-flash")
+        assert "text" in result
+        assert "image" in result
 
     def test_glm_text_only(self, model_config):
         result = model_config.get_input_modalities("glm-5.2")

--- a/tests/unit/ptc_agent/middleware/test_multimodal_strip.py
+++ b/tests/unit/ptc_agent/middleware/test_multimodal_strip.py
@@ -236,13 +236,13 @@ class TestResolveModalities:
         mw = MultimodalStripMiddleware(model_name="gpt-5.5")
         # Configured for a vision model, but resilience substituted a text-only
         # client; judging on the configured name would replay image blocks at it.
-        assert mw._resolve_target(_request("deepseek-v4-pro"))[1] == ["text"]
+        assert mw._resolve_target(_request("glm-5.2"))[1] == ["text"]
 
     def test_custom_modalities_apply_only_to_the_configured_model(self):
         mw = MultimodalStripMiddleware(model_name="my-custom-vlm", custom_modalities=["text", "image"])
         assert mw._resolve_target(_request("my-custom-vlm"))[1] == ["text", "image"]
         # A fallback is a different model — the override must not follow it over.
-        assert mw._resolve_target(_request("deepseek-v4-pro"))[1] == ["text"]
+        assert mw._resolve_target(_request("glm-5.2"))[1] == ["text"]
 
     def test_an_unstamped_client_is_text_only_even_under_a_vision_parent(self):
         """Regression: a bare-string subagent resolves via ``init_chat_model`` and
@@ -321,7 +321,7 @@ class TestAwrapModelCall:
             return "ok"
 
         history = self._image_history()
-        request = _ModelCallRequest("deepseek-v4-pro", history)
+        request = _ModelCallRequest("glm-5.2", history)
         await MultimodalStripMiddleware().awrap_model_call(request, handler)
 
         forwarded = seen["request"]
@@ -339,7 +339,7 @@ class TestAwrapModelCall:
             seen["request"] = request
             return "ok"
 
-        request = _ModelCallRequest("deepseek-v4-pro", [HumanMessage(content="plain text")])
+        request = _ModelCallRequest("glm-5.2", [HumanMessage(content="plain text")])
         await MultimodalStripMiddleware().awrap_model_call(request, handler)
         assert seen["request"] is request
 
@@ -355,7 +355,7 @@ class TestManifestModelStampRoundTrip:
 
         # Configured for a text-only model, handed a vision client: the stamp is
         # what must win, which only works if both sides name the same key.
-        mw = MultimodalStripMiddleware(model_name="deepseek-v4-pro")
+        mw = MultimodalStripMiddleware(model_name="glm-5.2")
         _, modalities = mw._resolve_target(types.SimpleNamespace(model=client))
         assert "image" in modalities
 
@@ -380,7 +380,7 @@ class TestTheNoteReachesTheModelThatCannotSee:
             seen["request"] = request
             return "ok"
 
-        request = _ModelCallRequest("deepseek-v4-pro", [
+        request = _ModelCallRequest("glm-5.2", [
             HumanMessage(content=[
                 {"type": "text", "text": "Look at this"},
                 {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},


### PR DESCRIPTION
## Overview

| | Files | + | − |
|---|---|---|---|
| Manifest (`models.json`, `providers.json`) | 2 | 20 | 143 |
| Config (`agent_config.yaml`) | 1 | 1 | 1 |
| Tests | 3 | 9 | 14 |
| **Total** | **6** | **30** | **158** |

- **`src/llms/manifest/models.json`**: `deepseek-flash` replaces `deepseek-v4-pro`, `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp`.
- **`src/llms/manifest/providers.json`**: one pricing card replaces three. The legacy Flash ids stay on it as `alias`.
- **`agent_config.yaml`**: the `llm.fallback` entry moves from `deepseek-v4-pro` to `deepseek-flash`.
- **Tests**: tests that looked up a retired key now use `deepseek-flash`. Tests that needed a text-only model now use `glm-5.2`, because `deepseek-flash` reads images.

## Summary

DeepSeek released V4.1 Flash under the API id `deepseek-flash`. It now handles every DeepSeek Flash request, including those sent with the legacy ids. From 12:00 Beijing time on 2026-09-14, it will also handle `deepseek-v4-pro` requests, billed at the Flash price. This PR updates the manifest to match:

- **One entry.** `deepseek-flash` replaces all three DeepSeek entries and appears in the UI as **DeepSeek-V4.1-Flash** (`display_name`). It accepts text and image input. Intelligence is 5, context is 1M, and `max_tokens` is 384K.
- **New prices.** DeepSeek's published USD rates are $0.30 input, $0.006 cached and $1.20 output per 1M tokens at peak. Off-peak is half, and the peak windows are unchanged.
- **Unchanged reasoning ladder** (`none`, `low`, `high`, `max`).

## Why this way

- **Retire rather than keep the old keys.** DeepSeek already serves both legacy Flash ids as `deepseek-flash`. After 2026-09-14, `deepseek-v4-pro` becomes a copy of Flash too. Keeping any of the three would leave duplicate models in the picker, and Pro would be priced at the old Pro rate. There is no key-remap mechanism, and earlier retirements shipped without one: the stored-preference cleanup is what takes care of users.
- **Aliases only on the pricing card.** DeepSeek still accepts the legacy ids and bills them at Flash rates. Pricing a leftover usage row under an old id at Flash rates therefore matches the invoice.
- **No new reasoning levels.** The Anthropic-format endpoint now accepts `low, medium, high, xhigh, ultra, max`. DeepSeek documents `medium` and `xhigh` as aliases of `high`, and `ultra` as an alias of `max`. Three samples per level on the same prompt agreed: the spread within a level was larger than the spread between levels. Offering them would add buttons that all do the same thing.

## Risk

- **Users with a retired key saved.** A saved preference makes the first turn fail with `model_removed`, and the cleanup then clears it. An automation pinned to a retired key is disabled after its usual 3 failures. A reopened thread whose last model was a retired key keeps failing until the user picks another model.
- **Pro removed early.** Pro disappears from the picker a few days before DeepSeek itself redirects it.

## Test plan

- [x] Unit tests: `tests/unit/llms/`, `tests/unit/middleware/`, `tests/unit/ptc_agent/middleware/model_compat/`, `test_multimodal_strip.py` (1617 passed, 0 failed)
- [x] Resolution checks: `deepseek-flash` has the expected display name, modalities and pricing, including off-peak. The legacy Flash ids resolve through the alias, and the retired keys return `None`.
- [x] Live checks against `api.deepseek.com/anthropic` with `deepseek-flash`:
  - `max_tokens: 384000` is accepted.
  - Every rung returns 200, and `thinking.type: disabled` returns no thinking block.
  - Image input works and the colors are read back correctly.
  - The endpoint still rejects a tool-calling turn that has no thinking block while thinking is on. The empty placeholder block the existing replay code injects returns 200, so no code change is needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ginlix-ai/codesmith/LangAlpha/pr/404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791614932&installation_model_id=432753&pr_number=404&repository=ginlix-ai%2FLangAlpha&return_to=https%3A%2F%2Fgithub.com%2Fginlix-ai%2FLangAlpha%2Fpull%2F404&signature=3edd4c7b2a70f2d24b55a5d6e3ddd6e4c4871102024327f1d02219f9954035ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `deepseek-flash` model, supporting both text and image inputs with updated performance and pricing details.
  - Added compatibility aliases for existing DeepSeek model identifiers.

- **Changes**
  - Consolidated the previous DeepSeek V4 Pro, V4 Flash, and experimental vision entries into the unified `deepseek-flash` model.
  - Updated the default fallback configuration to use `deepseek-flash` as the first fallback model.
  - Reduced off-peak pricing for the DeepSeek model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->